### PR TITLE
Address review feedback on shared utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-test:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     permissions:
       contents: read
     env:
@@ -38,7 +41,6 @@ jobs:
         run: make check-fmt
 
       - name: Install Mermaid CLI
-        shell: bash
         run: |
           set -euxo pipefail
           bun install --no-progress --global @mermaid-js/mermaid-cli@11.9.0
@@ -54,7 +56,6 @@ jobs:
         run: uv tool install --from git+https://github.com/leynos/nixie nixie
 
       - name: Nixie
-        shell: bash
         run: make nixie
 
       - name: Markdown lint
@@ -63,7 +64,6 @@ jobs:
           globs: '**/*.md'
 
       - name: Lint
-        shell: bash
         run: make lint
 
       - name: Test and Measure Coverage (with features)

--- a/common/src/attributes/attribute.rs
+++ b/common/src/attributes/attribute.rs
@@ -40,20 +40,20 @@ impl Attribute {
     /// let attribute = Attribute::with_arguments(
     ///     AttributePath::from("allow"),
     ///     AttributeKind::Outer,
-    ///     vec!["clippy::needless_bool".to_string()],
+    ///     ["clippy::needless_bool"],
     /// );
     /// assert_eq!(attribute.arguments(), &["clippy::needless_bool"]);
     /// ```
     #[must_use]
-    pub fn with_arguments(
-        path: AttributePath,
-        kind: AttributeKind,
-        arguments: Vec<String>,
-    ) -> Self {
+    pub fn with_arguments<I, S>(path: AttributePath, kind: AttributeKind, arguments: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
         Self {
             path,
             kind,
-            arguments,
+            arguments: arguments.into_iter().map(Into::into).collect(),
         }
     }
 
@@ -73,12 +73,7 @@ impl Attribute {
     /// ```
     #[must_use]
     pub fn with_str_arguments(path: AttributePath, kind: AttributeKind, args: &[&str]) -> Self {
-        let arguments = args.iter().map(|segment| segment.to_string()).collect();
-        Self {
-            path,
-            kind,
-            arguments,
-        }
+        Self::with_arguments(path, kind, args.iter().copied())
     }
 
     /// Returns the underlying attribute path.

--- a/common/src/attributes/attribute.rs
+++ b/common/src/attributes/attribute.rs
@@ -40,20 +40,44 @@ impl Attribute {
     /// let attribute = Attribute::with_arguments(
     ///     AttributePath::from("allow"),
     ///     AttributeKind::Outer,
-    ///     ["clippy::needless_bool"],
+    ///     vec!["clippy::needless_bool".to_string()],
     /// );
     /// assert_eq!(attribute.arguments(), &["clippy::needless_bool"]);
     /// ```
     #[must_use]
-    pub fn with_arguments<I, S>(path: AttributePath, kind: AttributeKind, arguments: I) -> Self
-    where
-        I: IntoIterator<Item = S>,
-        S: Into<String>,
-    {
+    pub fn with_arguments(
+        path: AttributePath,
+        kind: AttributeKind,
+        arguments: Vec<String>,
+    ) -> Self {
         Self {
             path,
             kind,
-            arguments: arguments.into_iter().map(Into::into).collect(),
+            arguments,
+        }
+    }
+
+    /// Creates an attribute with borrowed string arguments.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use common::attributes::{Attribute, AttributeKind, AttributePath};
+    ///
+    /// let attribute = Attribute::with_str_arguments(
+    ///     AttributePath::from("allow"),
+    ///     AttributeKind::Outer,
+    ///     &["clippy::needless_bool"],
+    /// );
+    /// assert_eq!(attribute.arguments(), &["clippy::needless_bool"]);
+    /// ```
+    #[must_use]
+    pub fn with_str_arguments(path: AttributePath, kind: AttributeKind, args: &[&str]) -> Self {
+        let arguments = args.iter().map(|segment| segment.to_string()).collect();
+        Self {
+            path,
+            kind,
+            arguments,
         }
     }
 
@@ -94,10 +118,10 @@ impl Attribute {
     /// ```
     /// use common::attributes::{Attribute, AttributeKind, AttributePath};
     ///
-    /// let attribute = Attribute::with_arguments(
+    /// let attribute = Attribute::with_str_arguments(
     ///     AttributePath::from("allow"),
     ///     AttributeKind::Outer,
-    ///     ["dead_code"],
+    ///     &["dead_code"],
     /// );
     /// assert_eq!(attribute.arguments(), &["dead_code"]);
     /// ```

--- a/common/src/attributes/path.rs
+++ b/common/src/attributes/path.rs
@@ -1,9 +1,9 @@
 //! Attribute-specific conveniences built atop the shared path helper.
 
-use crate::path::Path;
+use crate::path::SimplePath;
 
 /// Structured representation of an attribute path such as `tokio::test`.
-pub type AttributePath = Path<String>;
+pub type AttributePath = SimplePath;
 
 #[cfg(test)]
 mod tests {

--- a/common/src/attributes/tests.rs
+++ b/common/src/attributes/tests.rs
@@ -4,6 +4,39 @@ use super::*;
 use rstest::rstest;
 
 #[rstest]
+#[case::empty(Vec::<String>::new())]
+#[case::single(vec!["dead_code".to_string()])]
+#[case::complex(vec!["cfg(feature = \"test\")".to_string(), "path(\"std::io\")".to_string()])]
+fn attribute_with_arguments_preserves_inputs(#[case] arguments: Vec<String>) {
+    let attribute = Attribute::with_arguments(
+        AttributePath::from("allow"),
+        AttributeKind::Outer,
+        arguments.clone(),
+    );
+
+    assert_eq!(attribute.arguments(), arguments);
+}
+
+#[rstest]
+fn attribute_with_str_arguments_converts() {
+    let attribute = Attribute::with_str_arguments(
+        AttributePath::from("allow"),
+        AttributeKind::Outer,
+        &["dead_code", "unused_variables"],
+    );
+
+    assert_eq!(attribute.arguments(), &["dead_code", "unused_variables"]);
+}
+
+#[rstest]
+fn attribute_with_str_arguments_handles_empty() {
+    let attribute =
+        Attribute::with_str_arguments(AttributePath::from("allow"), AttributeKind::Outer, &[]);
+
+    assert!(attribute.arguments().is_empty());
+}
+
+#[rstest]
 #[case::outer(AttributeKind::Outer, true)]
 #[case::inner(AttributeKind::Inner, false)]
 fn attribute_kind_is_outer(#[case] kind: AttributeKind, #[case] expected: bool) {

--- a/common/src/diagnostics.rs
+++ b/common/src/diagnostics.rs
@@ -38,12 +38,12 @@ impl Suggestion {
     #[must_use]
     pub fn new(
         message: impl Into<String>,
-        replacement: String,
+        replacement: impl Into<String>,
         applicability: Applicability,
     ) -> Self {
         Self {
             message: message.into(),
-            replacement,
+            replacement: replacement.into(),
             applicability,
         }
     }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,5 +15,5 @@ pub use attributes::{
 pub use context::{ContextEntry, ContextKind, in_test_like_context, is_in_main_fn, is_test_fn};
 pub use diagnostics::{Applicability, Diagnostic, DiagnosticBuilder, Suggestion, span_lint};
 pub use expr::{Expr, def_id_of_expr_callee, is_path_to, recv_is_option_or_result};
-pub use path::{Path, SimplePath};
-pub use span::{SourceLocation, SourceSpan, SpanError, module_line_count, span_to_lines};
+pub use path::SimplePath;
+pub use span::{SourceLocation, SourceSpan, SpanError, span_line_count, span_to_lines};

--- a/common/src/path.rs
+++ b/common/src/path.rs
@@ -113,4 +113,43 @@ mod tests {
         assert!(path.matches(["crate", "module", "Item"]));
         assert!(!path.matches(["crate", "module", "Other"]));
     }
+
+    #[rstest]
+    fn last_returns_final_segment() {
+        let populated = SimplePath::from("crate::module::Item");
+        assert_eq!(populated.last(), Some("Item"));
+
+        let empty = SimplePath::new(Vec::<String>::new());
+        assert_eq!(empty.last(), None);
+    }
+
+    #[rstest]
+    fn is_doc_identifies_doc_segments() {
+        assert!(SimplePath::from("doc").is_doc());
+        assert!(!SimplePath::from("allow").is_doc());
+    }
+
+    #[rstest]
+    fn display_formats_with_separators() {
+        let path = SimplePath::from("crate::module::Item");
+        assert_eq!(path.to_string(), "crate::module::Item");
+    }
+
+    #[rstest]
+    fn from_string_parses_owned_values() {
+        let owned = String::from("test::path");
+        let path = SimplePath::from(owned);
+        assert_eq!(path.segments(), &["test", "path"]);
+    }
+
+    #[rstest]
+    fn new_accepts_varied_iterators() {
+        let from_vec = SimplePath::new(vec!["a", "b"]);
+        let from_array = SimplePath::new(["a", "b"]);
+        let from_owned = SimplePath::new(vec![String::from("a"), String::from("b")]);
+
+        assert_eq!(from_vec.segments(), &["a", "b"]);
+        assert_eq!(from_array.segments(), &["a", "b"]);
+        assert_eq!(from_owned.segments(), &["a", "b"]);
+    }
 }

--- a/common/src/path.rs
+++ b/common/src/path.rs
@@ -52,15 +52,13 @@ impl SimplePath {
 
     /// Returns the path segments as a slice.
     #[must_use]
-    pub fn segments(&self) -> &[String] {
-        &self.segments
-    }
+    #[rustfmt::skip]
+    pub fn segments(&self) -> &[String] { &self.segments }
 
     /// Returns the final path segment when present.
     #[must_use]
-    pub fn last(&self) -> Option<&str> {
-        self.segments.last().map(String::as_str)
-    }
+    #[rustfmt::skip]
+    pub fn last(&self) -> Option<&str> { self.segments.last().map(String::as_str) }
 
     /// Returns `true` when this path matches the provided sequence exactly.
     #[must_use]
@@ -76,9 +74,8 @@ impl SimplePath {
 
     /// Returns `true` when the path denotes a doc comment (`doc`).
     #[must_use]
-    pub fn is_doc(&self) -> bool {
-        self.matches(["doc"])
-    }
+    #[rustfmt::skip]
+    pub fn is_doc(&self) -> bool { self.matches(["doc"]) }
 }
 
 impl From<&str> for SimplePath {

--- a/common/src/path.rs
+++ b/common/src/path.rs
@@ -100,11 +100,12 @@ impl fmt::Display for SimplePath {
 mod tests {
     use super::*;
     use rstest::rstest;
+    use std::collections::VecDeque;
 
     #[rstest]
     fn filters_empty_segments() {
         let path = SimplePath::from("::crate::::Item::");
-        assert_eq!(path.segments(), &["crate", "Item"]);
+        assert!(path.matches(["crate", "Item"]));
     }
 
     #[rstest]
@@ -139,7 +140,7 @@ mod tests {
     fn from_string_parses_owned_values() {
         let owned = String::from("test::path");
         let path = SimplePath::from(owned);
-        assert_eq!(path.segments(), &["test", "path"]);
+        assert!(path.matches(["test", "path"]));
     }
 
     #[rstest]
@@ -148,8 +149,17 @@ mod tests {
         let from_array = SimplePath::new(["a", "b"]);
         let from_owned = SimplePath::new(vec![String::from("a"), String::from("b")]);
 
-        assert_eq!(from_vec.segments(), &["a", "b"]);
-        assert_eq!(from_array.segments(), &["a", "b"]);
-        assert_eq!(from_owned.segments(), &["a", "b"]);
+        assert!(from_vec.matches(["a", "b"]));
+        assert!(from_array.matches(["a", "b"]));
+        assert!(from_owned.matches(["a", "b"]));
+    }
+
+    #[rstest]
+    fn new_accepts_iterator_inputs_beyond_vectors() {
+        let deque_path = SimplePath::new(VecDeque::from(["module", "Item"]));
+        assert!(deque_path.matches(["module", "Item"]));
+
+        let once_path = SimplePath::new(std::iter::once("solo"));
+        assert!(once_path.matches(["solo"]));
     }
 }

--- a/common/src/path.rs
+++ b/common/src/path.rs
@@ -42,11 +42,11 @@ impl SimplePath {
     ///
     /// let parsed = SimplePath::from("tokio::test");
     /// assert_eq!(parsed.segments(), &["tokio", "test"]);
-    /// let compact = SimplePath::from("::test::");
+    /// let compact = SimplePath::parse("::test::");
     /// assert_eq!(compact.segments(), &["test"]);
     /// ```
     #[must_use]
-    pub fn from(path: &str) -> Self {
+    pub fn parse(path: &str) -> Self {
         Self::new(path.split("::").filter(|segment| !segment.is_empty()))
     }
 
@@ -78,6 +78,18 @@ impl SimplePath {
     #[must_use]
     pub fn is_doc(&self) -> bool {
         self.matches(["doc"])
+    }
+}
+
+impl From<&str> for SimplePath {
+    fn from(path: &str) -> Self {
+        Self::parse(path)
+    }
+}
+
+impl From<String> for SimplePath {
+    fn from(path: String) -> Self {
+        Self::parse(&path)
     }
 }
 

--- a/common/src/span.rs
+++ b/common/src/span.rs
@@ -112,13 +112,13 @@ pub fn span_to_lines(span: SourceSpan) -> RangeInclusive<usize> {
 /// # Examples
 ///
 /// ```
-/// use common::span::{SourceLocation, SourceSpan, module_line_count};
+/// use common::span::{SourceLocation, SourceSpan, span_line_count};
 ///
 /// let span = SourceSpan::new(SourceLocation::new(2, 0), SourceLocation::new(5, 1)).expect("valid span for example");
-/// assert_eq!(module_line_count(span), 4);
+/// assert_eq!(span_line_count(span), 4);
 /// ```
 #[must_use]
-pub fn module_line_count(span: SourceSpan) -> usize {
+pub fn span_line_count(span: SourceSpan) -> usize {
     span.end.line() - span.start.line() + 1
 }
 
@@ -138,6 +138,6 @@ mod tests {
         let span = SourceSpan::new(SourceLocation::new(5, 0), SourceLocation::new(7, 3))
             .expect("valid span for line range test");
         assert_eq!(span_to_lines(span), 5..=7);
-        assert_eq!(module_line_count(span), 3);
+        assert_eq!(span_line_count(span), 3);
     }
 }

--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -75,7 +75,7 @@ Utilities shared by lints:
   attributes (`test`, `tokio::test`, `rstest`).
 - **Context:** `in_test_like_context`, `is_test_fn`, `is_in_main_fn`.
 - **Types:** `recv_is_option_or_result`.
-- **Spans:** `span_to_lines`, `module_line_count`, `def_id_of_expr_callee`,
+- **Spans:** `span_to_lines`, `span_line_count`, `def_id_of_expr_callee`,
   `is_path_to`.
 - **Visibility:** effective export check via `cx.tcx`/`effective_visibilities`.
 - **Diagnostics:** `span_lint`, formatting helpers, suggestion utilities.


### PR DESCRIPTION
## Summary
- align `Suggestion::new` and span utilities naming with the requested API tweaks
- simplify attribute argument handling, add a helper for borrowed inputs, and extend tests around edge cases
- replace the generic `Path<T>` with a concrete `SimplePath` type and DRY the workflow shell configuration
- refresh documentation to reference the new helper names

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68de627edd0c83229aae025401c72185

## Summary by Sourcery

Align shared utilities with recent API changes by replacing the generic Path<T> with SimplePath, renaming span helpers, simplifying attribute and suggestion constructors, updating CI shell configuration, and refreshing documentation.

New Features:
- Add with_str_arguments helper to create attributes from borrowed string slices

Enhancements:
- Replace generic Path<T> with concrete SimplePath type and update AttributePath alias accordingly
- Rename module_line_count to span_line_count and update all references
- Simplify Attribute::with_arguments signature to take Vec<String>
- Update Suggestion::new to accept Into<String> for the replacement parameter

CI:
- DRY CI workflow by moving shell: bash declaration under defaults and removing redundant per-step shell entries

Documentation:
- Refresh documentation to reference new helper names such as SimplePath and span_line_count

Tests:
- Extend attribute argument tests to cover empty, single, and complex cases for both with_arguments and with_str_arguments