### PR TITLE
Simplify shared configuration loading

### DIFF
--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -101,12 +101,13 @@ Utilities shared by lints:
   structure mirrors `rustc` concepts but keeps the surface area simple for unit
   and behaviour tests.
 - Shared configuration lives in `whitaker::config::SharedConfig`. The
-  `load_for` helper accepts the caller's crate name so individual lint crates
-  read their matching tables in `dylint.toml`, while `load()` remains a
-  convenience alias for Whitaker itself. `serde` defaults keep fields optional
-  so teams can override only the `module_max_400_lines.max_lines` threshold
-  (default 400) without rewriting the table. Unknown fields are rejected via
-  `deny_unknown_fields` so configuration typos fail fast during deserialisation.
+  `load()` helper uses the Dylint loader for Whitaker itself, while
+  `load_with()` accepts the caller's crate name plus an injectable loader so
+  individual lint crates can read their matching tables in `dylint.toml` or
+  tests can stub the source. `serde` defaults keep fields optional so teams can
+  override only the `module_max_400_lines.max_lines` threshold (default 400)
+  without rewriting the table. Unknown fields are rejected via
+  `deny_unknown_fields` so configuration typos fail fast during deserialization.
 - Unit and behaviour coverage lean on `rstest` fixtures and `rstest-bdd`
   scenarios (v0.1.0-alpha4) to exercise happy, unhappy, and edge cases without
   duplicating setup logic.


### PR DESCRIPTION
## Summary
- collapse the shared configuration loader onto `SharedConfig::load`, eliminating the extra `load_for` helper
- clarify how `load_with` injects crate-specific loaders in the suite design documentation and fix spelling to en-oxendic norms

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e6b04ea2688322a569655556f023c8

## Summary by Sourcery

Simplify SharedConfig loading by consolidating the configuration loader into load(), deprecating load_for, and aligning documentation and tests with the revised API

Enhancements:
- Collapse the shared configuration loader into SharedConfig::load by removing the load_for helper and default_loader
- Make load() conditionally use the Dylint loader under the feature flag or panic when testing without injection via load_with

Documentation:
- Update the suite design documentation to explain the new load() and load_with() API and fix spelling to en-oxendic norms

Tests:
- Rename the load_for test to load_with_passes_through_the_requested_crate and update the stub loader accordingly