### PR TITLE
Inline fixture reset and reuse meta attribute check

### DIFF
--- a/common/tests/context_behaviour.rs
+++ b/common/tests/context_behaviour.rs
@@ -37,10 +37,6 @@ impl FunctionFixture {
         if let Some(entry) = self.context.borrow_mut().last_mut() {
             entry.attributes_mut().clear();
         }
-        self.reset_additional();
-    }
-
-    fn reset_additional(&self) {
         self.additional.borrow_mut().clear();
     }
 

--- a/crates/no_expect_outside_tests/src/context.rs
+++ b/crates/no_expect_outside_tests/src/context.rs
@@ -252,8 +252,7 @@ mod tests {
 
 fn is_cfg_test_attribute(attr: &hir::Attribute) -> bool {
     attr.meta()
-        .map(|meta| meta_contains_test_cfg(&meta))
-        .unwrap_or(false)
+        .is_some_and(|meta| meta_contains_test_cfg(&meta))
 }
 
 fn meta_item_inner_contains_test(item: MetaItemInner) -> bool {


### PR DESCRIPTION
## Summary
- inline the additional attribute reset in the context behaviour fixture to remove indirection
- delegate cfg test attribute detection to the shared meta helper via `Option::is_some_and`

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68f631cb49fc832282c6d7065bd584ac

## Summary by Sourcery

Simplify the context fixture reset logic and streamline cfg test attribute detection

Enhancements:
- Inline the additional attribute reset into the context behaviour fixture’s reset method and remove the reset_additional helper function
- Refactor is_cfg_test_attribute to use Option::is_some_and and reuse the shared meta helper for cfg test attribute detection