### PR TITLE
Rename module_max_400_lines references to module_max_lines

### DIFF
--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -29,7 +29,7 @@ lint crate, a feasibility study for a **Bumpy Road** detector, and a phased
 │  ├─ module_must_have_inner_docs/
 │  ├─ conditional_max_two_branches/   # revised: complex conditional detection
 │  ├─ test_must_not_have_example/
-│  ├─ module_max_400_lines/
+│  ├─ module_max_lines/
 │  └─ no_unwrap_or_else_panic/        # separate crate
 ├─ suite/                         # aggregated dylint library (optional)
 ├─ installer/                     # optional convenience binary
@@ -140,7 +140,7 @@ Utilities shared by lints:
   `load_with()` accepts the caller's crate name plus an injectable loader so
   individual lint crates can read their matching tables in `dylint.toml` or
   tests can stub the source. `serde` defaults keep fields optional so teams can
-  override only the `module_max_400_lines.max_lines` threshold (default 400)
+  override only the `module_max_lines.max_lines` threshold (default 400)
   without rewriting the table. Unknown fields are rejected via
   `deny_unknown_fields` so configuration typos fail fast during deserialization.
 - Unit and behaviour coverage lean on `rstest` fixtures and `rstest-bdd`
@@ -207,7 +207,7 @@ Utilities shared by lints:
 | `public_fn_must_have_docs`    | pedantic        | Publicly exported functions require at least one outer doc comment.                                                     | warn  |
 | `module_must_have_inner_docs` | pedantic        | Every module must open with a `//!` inner doc comment.                                                                  | warn  |
 | `test_must_not_have_example`  | style           | Test functions (e.g. `#[test]`, `#[tokio::test]`) must not ship example blocks or `# Examples` headings in docs.        | warn  |
-| `module_max_400_lines`        | maintainability | Flag modules whose span exceeds 400 lines; encourage decomposition or submodules.                                       | warn  |
+| `module_max_lines`            | maintainability | Flag modules whose span exceeds 400 lines; encourage decomposition or submodules.                                       | warn  |
 
 ### Per-lint crate scaffolding
 
@@ -553,7 +553,7 @@ Forbid examples or fenced code blocks in `#[test]` docs.
 Heuristic: detect Markdown `# Examples` heading or fenced code (``` / ```rust)
 in collected doc text.
 
-### 3.7 `module_max_400_lines` (maintainability, warn)
+### 3.7 `module_max_lines` (maintainability, warn)
 
 Lint when module span exceeds 400 lines. Configurable via `max_lines`.
 
@@ -800,7 +800,7 @@ no_expect_outside_tests = { path = "../crates/no_expect_outside_tests", features
 public_fn_must_have_docs = { path = "../crates/public_fn_must_have_docs", features = ["constituent"] }
 module_must_have_inner_docs = { path = "../crates/module_must_have_inner_docs", features = ["constituent"] }
 test_must_not_have_example = { path = "../crates/test_must_not_have_example", features = ["constituent"] }
-module_max_400_lines = { path = "../crates/module_max_400_lines", features = ["constituent"] }
+module_max_lines = { path = "../crates/module_max_lines", features = ["constituent"] }
 ```
 
 ```rust
@@ -816,7 +816,7 @@ declare_combined_late_lint_pass!(CombinedPass => [
     public_fn_must_have_docs::Pass,
     module_must_have_inner_docs::Pass,
     test_must_not_have_example::Pass,
-    module_max_400_lines::Pass,
+    module_max_lines::Pass,
 ]);
 
 #[no_mangle]
@@ -828,7 +828,7 @@ pub fn register_lints(sess: &Session, store: &mut LintStore) {
         public_fn_must_have_docs::PUBLIC_FN_MUST_HAVE_DOCS,
         module_must_have_inner_docs::MODULE_MUST_HAVE_INNER_DOCS,
         test_must_not_have_example::TEST_MUST_NOT_HAVE_EXAMPLE,
-        module_max_400_lines::MODULE_MAX_400_LINES,
+        module_max_lines::MODULE_MAX_LINES,
     ]);
     store.register_late_pass(|_| Box::new(CombinedPass));
 }
@@ -880,7 +880,7 @@ VS Code rust-analyser integration uses `cargo dylint` as the check command.
 
 ## 10) Configuration knobs (examples)
 
-- `module_max_400_lines.max_lines = 400`
+- `module_max_lines.max_lines = 400`
 - `conditional_max_two_branches.max_atoms = 1`
 - `no_expect_outside_tests` allowlist of modules (regex)
 - `no_unwrap_or_else_panic.allow_in_main = false`
@@ -1106,7 +1106,7 @@ function and can ship as an experimental Dylint rule guarded by a feature flag.
   - Count predicate atoms; config `max_atoms`; examples in diagnostics; UI
     tests for `if`/`while`/guards.
 - `test_must_not_have_example` (doc text scan + UI tests)
-- `module_max_400_lines` (line counting + config + UI tests)
+- `module_max_lines` (line counting + config + UI tests)
 
 ### Phase 3 — Additional restriction lint (separate crate)
 

--- a/locales/cy/module_max_lines.ftl
+++ b/locales/cy/module_max_lines.ftl
@@ -1,5 +1,5 @@
 ## Canllaw hyd modiwl.
 
-module_max_400_lines = Mae modiwl { $module } yn ymestyn i { $lines } o linellau ac yn torri’r terfyn o { $limit }.
+module_max_lines = Mae modiwl { $module } yn ymestyn i { $lines } o linellau ac yn torri’r terfyn o { $limit }.
     .note = Mae modiwlau mawr yn anoddach i’w hadolygu.
     .help = Rhannwch { $module } neu leihau’r cyfaint cyfrifoldebau.

--- a/locales/en-GB/module_max_lines.ftl
+++ b/locales/en-GB/module_max_lines.ftl
@@ -1,5 +1,5 @@
 ## Module length guidance.
 
-module_max_400_lines = Module { $module } spans { $lines } lines which exceeds the { $limit } line limit.
+module_max_lines = Module { $module } spans { $lines } lines which exceeds the { $limit } line limit.
     .note = Large modules are harder to navigate and review.
     .help = Split { $module } into smaller modules or reduce its responsibilities.

--- a/locales/gd/module_max_lines.ftl
+++ b/locales/gd/module_max_lines.ftl
@@ -1,5 +1,5 @@
 ## Riaghailt air faid mòideil.
 
-module_max_400_lines = Tha mòideal { $module } a’ leudachadh gu { $lines } loidhnichean agus a’ briseadh an crìoch { $limit }.
+module_max_lines = Tha mòideal { $module } a’ leudachadh gu { $lines } loidhnichean agus a’ briseadh an crìoch { $limit }.
     .note = Tha mòidealan mòra nas duilghe an ath-sgrùdadh.
     .help = Roinn { $module } no lughdaich an luchd dleastanais.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod config;
 pub mod lints;
 pub mod testing;
 
-pub use config::{ModuleMax400LinesConfig, SharedConfig};
+pub use config::{ModuleMaxLinesConfig, SharedConfig};
 pub use lints::{LintCrateTemplate, TemplateError, TemplateFiles};
 
 /// Returns a greeting for the library.

--- a/src/lints/template/mod.rs
+++ b/src/lints/template/mod.rs
@@ -237,8 +237,7 @@ mod tests {
 
     #[test]
     fn template_rejects_absolute_ui_directory() {
-        let Err(error) =
-            LintCrateTemplate::with_ui_tests_directory("module_max_400_lines", "/tmp/ui")
+        let Err(error) = LintCrateTemplate::with_ui_tests_directory("module_max_lines", "/tmp/ui")
         else {
             panic!("absolute UI directories should be rejected");
         };
@@ -253,7 +252,7 @@ mod tests {
     #[test]
     fn template_rejects_parent_directory_in_ui_directory() {
         let Err(error) =
-            LintCrateTemplate::with_ui_tests_directory("module_max_400_lines", "ui/../secrets")
+            LintCrateTemplate::with_ui_tests_directory("module_max_lines", "ui/../secrets")
         else {
             panic!("parent directory traversal should be rejected");
         };

--- a/src/lints/template/validation.rs
+++ b/src/lints/template/validation.rs
@@ -147,14 +147,14 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case("module_max_400_lines", "MODULE_MAX_400_LINES")]
+    #[case("module_max_lines", "MODULE_MAX_LINES")]
     #[case("no-expect-outside-tests", "NO_EXPECT_OUTSIDE_TESTS")]
     fn constant_from_crate_name(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(lint_constant(input), expected);
     }
 
     #[rstest]
-    #[case("module_max_400_lines", "ModuleMax400Lines")]
+    #[case("module_max_lines", "ModuleMaxLines")]
     #[case("no-expect-outside-tests", "NoExpectOutsideTests")]
     fn pass_struct_from_crate_name(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(pass_struct_name(input), expected);

--- a/tests/config_loading.rs
+++ b/tests/config_loading.rs
@@ -75,13 +75,13 @@ fn no_overrides(config_source: &RefCell<Option<String>>) {
 fn override_max_lines(config_source: &RefCell<Option<String>>, value: usize) {
     config_source
         .borrow_mut()
-        .replace(format!("[module_max_400_lines]\nmax_lines = {value}\n"));
+        .replace(format!("[module_max_lines]\nmax_lines = {value}\n"));
 }
 
 #[given("the workspace config sets the module max line limit to an invalid value")]
 fn invalid_override(config_source: &RefCell<Option<String>>) {
     config_source.borrow_mut().replace(String::from(
-        "[module_max_400_lines]\nmax_lines = \"invalid\"\n",
+        "[module_max_lines]\nmax_lines = \"invalid\"\n",
     ));
 }
 
@@ -90,7 +90,7 @@ fn unknown_fields(config_source: &RefCell<Option<String>>) {
     config_source.borrow_mut().replace(
         concat!(
             "unexpected = true\n",
-            "[module_max_400_lines]\n",
+            "[module_max_lines]\n",
             "max_lines = 120\n",
         )
         .to_owned(),
@@ -108,8 +108,8 @@ fn load_config(
 ) {
     let maybe_source = config_source.borrow().clone();
     let outcome = catch_unwind(AssertUnwindSafe(|| {
-        SharedConfig::load_with("module_max_400_lines", |crate_name| {
-            assert_eq!(crate_name, "module_max_400_lines");
+        SharedConfig::load_with("module_max_lines", |crate_name| {
+            assert_eq!(crate_name, "module_max_lines");
             maybe_source
                 .as_ref()
                 .map_or_else(SharedConfig::default, |input| {
@@ -133,7 +133,7 @@ fn assert_max_lines(load_result: &RefCell<Option<Result<SharedConfig, String>>>,
         None => panic!("configuration should be loaded"),
     };
 
-    assert_eq!(config.module_max_400_lines.max_lines, expected);
+    assert_eq!(config.module_max_lines.max_lines, expected);
 }
 
 #[then("a configuration error is reported")]

--- a/tests/features/lint_template.feature
+++ b/tests/features/lint_template.feature
@@ -41,13 +41,13 @@ Feature: Lint crate template
     Then template creation fails due to a trailing separator -
 
   Scenario: Rejecting absolute UI directories
-    Given the lint crate name is module_max_400_lines
+    Given the lint crate name is module_max_lines
     And the UI tests directory is /tmp/ui
     When I render the lint crate template
     Then template creation fails with an absolute UI directory error pointing to /tmp/ui
 
   Scenario: Rejecting absolute Windows UI directories
-    Given the lint crate name is module_max_400_lines
+    Given the lint crate name is module_max_lines
     And the UI tests directory is C:\\temp\\ui
     When I render the lint crate template
     Then template creation fails with an absolute UI directory error pointing to C:\\temp\\ui
@@ -59,13 +59,13 @@ Feature: Lint crate template
     Then template creation fails with an absolute UI directory error pointing to //server/share/ui
 
   Scenario: Rejecting drive-relative Windows UI directories
-    Given the lint crate name is module_max_400_lines
+    Given the lint crate name is module_max_lines
     And the UI tests directory is C:ui
     When I render the lint crate template
     Then template creation fails with an absolute UI directory error pointing to C:ui
 
   Scenario: Rejecting parent directory segments in the UI directory
-    Given the lint crate name is module_max_400_lines
+    Given the lint crate name is module_max_lines
     And the UI tests directory is ui/../secrets
     When I render the lint crate template
     Then template creation fails because the UI directory traverses upwards
@@ -76,7 +76,7 @@ Feature: Lint crate template
     Then template creation fails with an invalid crate name character U
 
   Scenario: Rejecting blank UI test directories
-    Given the lint crate name is module_max_400_lines
+    Given the lint crate name is module_max_lines
     And the UI tests directory is blank
     When I render the lint crate template
     Then template creation fails with an empty UI directory error


### PR DESCRIPTION
## Summary
- rename the shared configuration field and type to module_max_lines and update call sites
- refresh documentation, templates, and feature specs to reference module_max_lines
- rename the locale resource files to module_max_lines

## Testing
- make check-fmt
- make lint *(fails: can't find crate `rustc_attr_data_structures` in the nightly toolchain)*
- make test

------
https://chatgpt.com/codex/tasks/task_e_690337862a4c832295ca32e4155d15f7

## Summary by Sourcery

Rename the module_max_400_lines lint and configuration field to module_max_lines across code, documentation, tests, and localization to ensure consistent naming.

Enhancements:
- Rename SharedConfig.module_max_400_lines and ModuleMax400LinesConfig to module_max_lines and ModuleMaxLinesConfig in code and public API

Documentation:
- Update documentation, design docs, and crate templates to reference module_max_lines
- Rename locale resource files and FTL keys from module_max_400_lines to module_max_lines

Tests:
- Adjust Rust unit tests and feature specs to expect module_max_lines