### PR TITLE
Fix rustc attr wrapper crate name

### DIFF
--- a/crates/rustc_attr_data_structures/src/lib.rs
+++ b/crates/rustc_attr_data_structures/src/lib.rs
@@ -1,11 +1,11 @@
 #![feature(rustc_private)]
 
-//! Re-exports the nightly `rustc_attr_data_structures` crate for lint scaffolding.
+//! Re-exports the nightly `rustc_data_structures` crate for lint scaffolding.
 //!
 //! This proxy crate exposes the upstream compiler crate so lint templates and
 //! scaffolding code can integrate with the compiler without each generated
 //! project reaching into unstable internals directly.
 
-extern crate rustc_attr_data_structures as upstream;
+extern crate rustc_data_structures as upstream;
 
 pub use upstream::*;


### PR DESCRIPTION
## Summary
- point the rustc_attr_data_structures shim at the real rustc_data_structures compiler crate to unblock docs and clippy

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_69035df5283083229526d3e0ac40564a

## Summary by Sourcery

Bug Fixes:
- Update re-export from rustc_attr_data_structures to rustc_data_structures