### PR TITLE
Rename module_max_400_lines references to module_max_lines

### DIFF
--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -29,7 +29,7 @@ lint crate, a feasibility study for a **Bumpy Road** detector, and a phased
 │  ├─ module_must_have_inner_docs/
 │  ├─ conditional_max_two_branches/   # revised: complex conditional detection
 │  ├─ test_must_not_have_example/
-│  ├─ module_max_400_lines/
+│  ├─ module_max_lines/
 │  └─ no_unwrap_or_else_panic/        # separate crate
 ├─ suite/                         # aggregated dylint library (optional)
 ├─ installer/                     # optional convenience binary
@@ -140,7 +140,7 @@ Utilities shared by lints:
   `load_with()` accepts the caller's crate name plus an injectable loader so
   individual lint crates can read their matching tables in `dylint.toml` or
   tests can stub the source. `serde` defaults keep fields optional so teams can
-  override only the `module_max_400_lines.max_lines` threshold (default 400)
+  override only the `module_max_lines.max_lines` threshold (default 400)
   without rewriting the table. Unknown fields are rejected via
   `deny_unknown_fields` so configuration typos fail fast during deserialization.
 - Unit and behaviour coverage lean on `rstest` fixtures and `rstest-bdd`
@@ -207,7 +207,7 @@ Utilities shared by lints:
 | `public_fn_must_have_docs`    | pedantic        | Publicly exported functions require at least one outer doc comment.                                                     | warn  |
 | `module_must_have_inner_docs` | pedantic        | Every module must open with a `//!` inner doc comment.                                                                  | warn  |
 | `test_must_not_have_example`  | style           | Test functions (e.g. `#[test]`, `#[tokio::test]`) must not ship example blocks or `# Examples` headings in docs.        | warn  |
-| `module_max_400_lines`        | maintainability | Flag modules whose span exceeds 400 lines; encourage decomposition or submodules.                                       | warn  |
+| `module_max_lines`            | maintainability | Flag modules whose span exceeds 400 lines; encourage decomposition or submodules.                                       | warn  |
 
 ### Per-lint crate scaffolding
 
@@ -553,7 +553,7 @@ Forbid examples or fenced code blocks in `#[test]` docs.
 Heuristic: detect Markdown `# Examples` heading or fenced code (``` / ```rust)
 in collected doc text.
 
-### 3.7 `module_max_400_lines` (maintainability, warn)
+### 3.7 `module_max_lines` (maintainability, warn)
 
 Lint when module span exceeds 400 lines. Configurable via `max_lines`.
 
@@ -800,7 +800,7 @@ no_expect_outside_tests = { path = "../crates/no_expect_outside_tests", features
 public_fn_must_have_docs = { path = "../crates/public_fn_must_have_docs", features = ["constituent"] }
 module_must_have_inner_docs = { path = "../crates/module_must_have_inner_docs", features = ["constituent"] }
 test_must_not_have_example = { path = "../crates/test_must_not_have_example", features = ["constituent"] }
-module_max_400_lines = { path = "../crates/module_max_400_lines", features = ["constituent"] }
+module_max_lines = { path = "../crates/module_max_lines", features = ["constituent"] }
 ```
 
 ```rust
@@ -816,7 +816,7 @@ declare_combined_late_lint_pass!(CombinedPass => [
     public_fn_must_have_docs::Pass,
     module_must_have_inner_docs::Pass,
     test_must_not_have_example::Pass,
-    module_max_400_lines::Pass,
+    module_max_lines::Pass,
 ]);
 
 #[no_mangle]
@@ -828,7 +828,7 @@ pub fn register_lints(sess: &Session, store: &mut LintStore) {
         public_fn_must_have_docs::PUBLIC_FN_MUST_HAVE_DOCS,
         module_must_have_inner_docs::MODULE_MUST_HAVE_INNER_DOCS,
         test_must_not_have_example::TEST_MUST_NOT_HAVE_EXAMPLE,
-        module_max_400_lines::MODULE_MAX_400_LINES,
+        module_max_lines::MODULE_MAX_LINES,
     ]);
     store.register_late_pass(|_| Box::new(CombinedPass));
 }
@@ -880,7 +880,7 @@ VS Code rust-analyser integration uses `cargo dylint` as the check command.
 
 ## 10) Configuration knobs (examples)
 
-- `module_max_400_lines.max_lines = 400`
+- `module_max_lines.max_lines = 400`
 - `conditional_max_two_branches.max_atoms = 1`
 - `no_expect_outside_tests` allowlist of modules (regex)
 - `no_unwrap_or_else_panic.allow_in_main = false`
@@ -1106,7 +1106,7 @@ function and can ship as an experimental Dylint rule guarded by a feature flag.
   - Count predicate atoms; config `max_atoms`; examples in diagnostics; UI
     tests for `if`/`while`/guards.
 - `test_must_not_have_example` (doc text scan + UI tests)
-- `module_max_400_lines` (line counting + config + UI tests)
+- `module_max_lines` (line counting + config + UI tests)
 
 ### Phase 3 — Additional restriction lint (separate crate)
 

--- a/locales/cy/module_max_lines.ftl
+++ b/locales/cy/module_max_lines.ftl
@@ -1,5 +1,5 @@
 ## Canllaw hyd modiwl.
 
-module_max_400_lines = Mae modiwl { $module } yn ymestyn i { $lines } o linellau ac yn torri’r terfyn o { $limit }.
+module_max_lines = Mae modiwl { $module } yn ymestyn i { $lines } o linellau ac yn torri’r terfyn o { $limit }.
     .note = Mae modiwlau mawr yn anoddach i’w hadolygu.
     .help = Rhannwch { $module } neu leihau’r cyfaint cyfrifoldebau.

--- a/locales/en-GB/module_max_lines.ftl
+++ b/locales/en-GB/module_max_lines.ftl
@@ -1,5 +1,5 @@
 ## Module length guidance.
 
-module_max_400_lines = Module { $module } spans { $lines } lines which exceeds the { $limit } line limit.
+module_max_lines = Module { $module } spans { $lines } lines which exceeds the { $limit } line limit.
     .note = Large modules are harder to navigate and review.
     .help = Split { $module } into smaller modules or reduce its responsibilities.

--- a/locales/gd/module_max_lines.ftl
+++ b/locales/gd/module_max_lines.ftl
@@ -1,5 +1,5 @@
 ## Riaghailt air faid mòideil.
 
-module_max_400_lines = Tha mòideal { $module } a’ leudachadh gu { $lines } loidhnichean agus a’ briseadh an crìoch { $limit }.
+module_max_lines = Tha mòideal { $module } a’ leudachadh gu { $lines } loidhnichean agus a’ briseadh an crìoch { $limit }.
     .note = Tha mòidealan mòra nas duilghe an ath-sgrùdadh.
     .help = Roinn { $module } no lughdaich an luchd dleastanais.

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,10 +13,10 @@ use serde::Deserialize;
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
 #[serde(default, deny_unknown_fields)]
 pub struct SharedConfig {
-    /// Overrides for the `module_max_400_lines` lint. This field falls back to
+    /// Overrides for the `module_max_lines` lint. This field falls back to
     /// its default when omitted from `dylint.toml`, which avoids duplicating the
     /// baseline settings in every workspace.
-    pub module_max_400_lines: ModuleMax400LinesConfig,
+    pub module_max_lines: ModuleMaxLinesConfig,
 }
 
 impl SharedConfig {
@@ -34,7 +34,7 @@ impl SharedConfig {
     /// use whitaker::SharedConfig;
     ///
     /// let config = SharedConfig::load();
-    /// assert_eq!(config.module_max_400_lines.max_lines, 400);
+    /// assert_eq!(config.module_max_lines.max_lines, 400);
     /// # }
     /// ```
     #[must_use]
@@ -55,7 +55,7 @@ impl SharedConfig {
     /// Loads configuration using the supplied loader.
     ///
     /// Each lint crate stores its overrides under a table matching its crate
-    /// name (for example `[module_max_400_lines]`). The `crate_name` parameter
+    /// name (for example `[module_max_lines]`). The `crate_name` parameter
     /// ensures the loader resolves the caller's namespace explicitly. This
     /// helper also exists to support dependency injection in tests so that the
     /// behaviour of `dylint_linting::config_or_default` can be simulated without
@@ -67,7 +67,7 @@ impl SharedConfig {
     /// use whitaker::SharedConfig;
     ///
     /// let config = SharedConfig::load_with("whitaker", |_| SharedConfig::default());
-    /// assert_eq!(config.module_max_400_lines.max_lines, 400);
+    /// assert_eq!(config.module_max_lines.max_lines, 400);
     /// ```
     #[must_use]
     pub fn load_with<F>(crate_name: &str, loader: F) -> Self
@@ -78,22 +78,22 @@ impl SharedConfig {
     }
 }
 
-/// Settings that influence the forthcoming `module_max_400_lines` lint.
+/// Settings that influence the forthcoming `module_max_lines` lint.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(default, deny_unknown_fields)]
-pub struct ModuleMax400LinesConfig {
+pub struct ModuleMaxLinesConfig {
     /// Maximum number of lines permitted per module before the lint fires.
-    #[serde(default = "ModuleMax400LinesConfig::default_max_lines")]
+    #[serde(default = "ModuleMaxLinesConfig::default_max_lines")]
     pub max_lines: usize,
 }
 
-impl ModuleMax400LinesConfig {
+impl ModuleMaxLinesConfig {
     const fn default_max_lines() -> usize {
         400
     }
 }
 
-impl Default for ModuleMax400LinesConfig {
+impl Default for ModuleMaxLinesConfig {
     fn default() -> Self {
         Self {
             max_lines: Self::default_max_lines(),
@@ -110,23 +110,23 @@ mod tests {
     fn defaults_match_the_suite_baseline() {
         let config = SharedConfig::default();
 
-        assert_eq!(config.module_max_400_lines.max_lines, 400);
+        assert_eq!(config.module_max_lines.max_lines, 400);
     }
 
     #[rstest]
     fn deserialises_overrides_from_toml() {
-        let source = "[module_max_400_lines]\nmax_lines = 120\n";
+        let source = "[module_max_lines]\nmax_lines = 120\n";
 
         // Panic with the TOML parser's message so broken overrides are easy to debug.
         let config = toml::from_str::<SharedConfig>(source)
             .expect("expected configuration to parse successfully");
 
-        assert_eq!(config.module_max_400_lines.max_lines, 120);
+        assert_eq!(config.module_max_lines.max_lines, 120);
     }
 
     #[rstest]
     fn propagates_deserialisation_failures() {
-        let source = "[module_max_400_lines]\nmax_lines = \"a lot\"\n";
+        let source = "[module_max_lines]\nmax_lines = \"a lot\"\n";
 
         let outcome: Result<SharedConfig, _> = toml::from_str(source);
 
@@ -140,7 +140,7 @@ mod tests {
     fn rejects_unknown_fields() {
         let source = concat!(
             "unexpected = true\n",
-            "[module_max_400_lines]\n",
+            "[module_max_lines]\n",
             "max_lines = 120\n",
         );
 
@@ -155,14 +155,14 @@ mod tests {
     #[rstest]
     fn load_with_passes_through_the_requested_crate() {
         fn stub_loader(crate_name: &str) -> SharedConfig {
-            assert_eq!(crate_name, "module_max_400_lines");
+            assert_eq!(crate_name, "module_max_lines");
             SharedConfig {
-                module_max_400_lines: ModuleMax400LinesConfig { max_lines: 123 },
+                module_max_lines: ModuleMaxLinesConfig { max_lines: 123 },
             }
         }
 
-        let config = SharedConfig::load_with("module_max_400_lines", stub_loader);
+        let config = SharedConfig::load_with("module_max_lines", stub_loader);
 
-        assert_eq!(config.module_max_400_lines.max_lines, 123);
+        assert_eq!(config.module_max_lines.max_lines, 123);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod config;
 pub mod lints;
 pub mod testing;
 
-pub use config::{ModuleMax400LinesConfig, SharedConfig};
+pub use config::{ModuleMaxLinesConfig, SharedConfig};
 pub use lints::{LintCrateTemplate, TemplateError, TemplateFiles};
 
 /// Returns a greeting for the library.

--- a/src/lints/template/mod.rs
+++ b/src/lints/template/mod.rs
@@ -237,8 +237,7 @@ mod tests {
 
     #[test]
     fn template_rejects_absolute_ui_directory() {
-        let Err(error) =
-            LintCrateTemplate::with_ui_tests_directory("module_max_400_lines", "/tmp/ui")
+        let Err(error) = LintCrateTemplate::with_ui_tests_directory("module_max_lines", "/tmp/ui")
         else {
             panic!("absolute UI directories should be rejected");
         };
@@ -253,7 +252,7 @@ mod tests {
     #[test]
     fn template_rejects_parent_directory_in_ui_directory() {
         let Err(error) =
-            LintCrateTemplate::with_ui_tests_directory("module_max_400_lines", "ui/../secrets")
+            LintCrateTemplate::with_ui_tests_directory("module_max_lines", "ui/../secrets")
         else {
             panic!("parent directory traversal should be rejected");
         };

--- a/src/lints/template/validation.rs
+++ b/src/lints/template/validation.rs
@@ -147,14 +147,14 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case("module_max_400_lines", "MODULE_MAX_400_LINES")]
+    #[case("module_max_lines", "MODULE_MAX_LINES")]
     #[case("no-expect-outside-tests", "NO_EXPECT_OUTSIDE_TESTS")]
     fn constant_from_crate_name(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(lint_constant(input), expected);
     }
 
     #[rstest]
-    #[case("module_max_400_lines", "ModuleMax400Lines")]
+    #[case("module_max_lines", "ModuleMaxLines")]
     #[case("no-expect-outside-tests", "NoExpectOutsideTests")]
     fn pass_struct_from_crate_name(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(pass_struct_name(input), expected);

--- a/tests/config_loading.rs
+++ b/tests/config_loading.rs
@@ -75,13 +75,13 @@ fn no_overrides(config_source: &RefCell<Option<String>>) {
 fn override_max_lines(config_source: &RefCell<Option<String>>, value: usize) {
     config_source
         .borrow_mut()
-        .replace(format!("[module_max_400_lines]\nmax_lines = {value}\n"));
+        .replace(format!("[module_max_lines]\nmax_lines = {value}\n"));
 }
 
 #[given("the workspace config sets the module max line limit to an invalid value")]
 fn invalid_override(config_source: &RefCell<Option<String>>) {
     config_source.borrow_mut().replace(String::from(
-        "[module_max_400_lines]\nmax_lines = \"invalid\"\n",
+        "[module_max_lines]\nmax_lines = \"invalid\"\n",
     ));
 }
 
@@ -90,7 +90,7 @@ fn unknown_fields(config_source: &RefCell<Option<String>>) {
     config_source.borrow_mut().replace(
         concat!(
             "unexpected = true\n",
-            "[module_max_400_lines]\n",
+            "[module_max_lines]\n",
             "max_lines = 120\n",
         )
         .to_owned(),
@@ -108,8 +108,8 @@ fn load_config(
 ) {
     let maybe_source = config_source.borrow().clone();
     let outcome = catch_unwind(AssertUnwindSafe(|| {
-        SharedConfig::load_with("module_max_400_lines", |crate_name| {
-            assert_eq!(crate_name, "module_max_400_lines");
+        SharedConfig::load_with("module_max_lines", |crate_name| {
+            assert_eq!(crate_name, "module_max_lines");
             maybe_source
                 .as_ref()
                 .map_or_else(SharedConfig::default, |input| {
@@ -133,7 +133,7 @@ fn assert_max_lines(load_result: &RefCell<Option<Result<SharedConfig, String>>>,
         None => panic!("configuration should be loaded"),
     };
 
-    assert_eq!(config.module_max_400_lines.max_lines, expected);
+    assert_eq!(config.module_max_lines.max_lines, expected);
 }
 
 #[then("a configuration error is reported")]

--- a/tests/features/lint_template.feature
+++ b/tests/features/lint_template.feature
@@ -41,13 +41,13 @@ Feature: Lint crate template
     Then template creation fails due to a trailing separator -
 
   Scenario: Rejecting absolute UI directories
-    Given the lint crate name is module_max_400_lines
+    Given the lint crate name is module_max_lines
     And the UI tests directory is /tmp/ui
     When I render the lint crate template
     Then template creation fails with an absolute UI directory error pointing to /tmp/ui
 
   Scenario: Rejecting absolute Windows UI directories
-    Given the lint crate name is module_max_400_lines
+    Given the lint crate name is module_max_lines
     And the UI tests directory is C:\\temp\\ui
     When I render the lint crate template
     Then template creation fails with an absolute UI directory error pointing to C:\\temp\\ui
@@ -59,13 +59,13 @@ Feature: Lint crate template
     Then template creation fails with an absolute UI directory error pointing to //server/share/ui
 
   Scenario: Rejecting drive-relative Windows UI directories
-    Given the lint crate name is module_max_400_lines
+    Given the lint crate name is module_max_lines
     And the UI tests directory is C:ui
     When I render the lint crate template
     Then template creation fails with an absolute UI directory error pointing to C:ui
 
   Scenario: Rejecting parent directory segments in the UI directory
-    Given the lint crate name is module_max_400_lines
+    Given the lint crate name is module_max_lines
     And the UI tests directory is ui/../secrets
     When I render the lint crate template
     Then template creation fails because the UI directory traverses upwards
@@ -76,7 +76,7 @@ Feature: Lint crate template
     Then template creation fails with an invalid crate name character U
 
   Scenario: Rejecting blank UI test directories
-    Given the lint crate name is module_max_400_lines
+    Given the lint crate name is module_max_lines
     And the UI tests directory is blank
     When I render the lint crate template
     Then template creation fails with an empty UI directory error


### PR DESCRIPTION
## Summary
- rename the shared configuration type, field, and template expectations from `module_max_400_lines` to `module_max_lines`
- update localisation resources, behaviour specs, and documentation to use the new lint crate name

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_69038a7237b88322843fa86756f5fc66

## Summary by Sourcery

Rename the module_max_400_lines lint and its configuration key to module_max_lines across the entire codebase.

Enhancements:
- Rename SharedConfig field and ModuleMax400LinesConfig type to module_max_lines and ModuleMaxLinesConfig
- Update lint registration, template validation, and crate exports to use the new module_max_lines identifier
- Adjust all tests and configuration loading logic to reference module_max_lines

Documentation:
- Update design documentation, examples, and feature listings to use module_max_lines
- Revise localization resources to reflect the new module_max_lines key

Tests:
- Modify behaviour and UI template tests to expect module_max_lines
- Update config loading and feature tests to reference module_max_lines