### PR TITLE
Unset RUSTUP_TOOLCHAIN in CI to enable coverage components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
         run: make lint
 
       - name: Test and Measure Coverage
+        env:
+          RUSTUP_TOOLCHAIN: ''
         uses: leynos/shared-actions/.github/actions/generate-coverage@c366af3e25f7cfb318dccfe58a92d6df5dffdf17
         with:
           output-path: lcov.info


### PR DESCRIPTION
## Summary
- Unsets RUSTUP_TOOLCHAIN in the Test and Measure Coverage step to allow rustup to install required components during coverage generation.

## Changes
### CI Workflow
- .github/workflows/ci.yml
- In the "Test and Measure Coverage" job, add an environment directive to unset RUSTUP_TOOLCHAIN by setting it to an empty string:

  env:
    RUSTUP_TOOLCHAIN: ''
- This ensures the coverage generation step can install the necessary Rust components without being restricted by a pre-set toolchain.

### Rationale
- Unsetting the variable avoids conflicts where a specific toolchain would block component installation needed for coverage reporting.

## Test plan
- [x] Push branch terragon/unset-rustup-toolchain-env-for-coverage-qwnhi7 and run CI
- [x] Verify the "Test and Measure Coverage" step completes and generates lcov.info
- [x] Ensure no Rust components are blocked during coverage generation

## Notes
- This change is isolated to CI configuration; no code changes were required. The coverage action referenced remains the same.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a7384f1c-6aa6-4600-ab47-4be95c874a18

## Summary by Sourcery

CI:
- Unset RUSTUP_TOOLCHAIN in the "Test and Measure Coverage" step to enable installation of coverage-related Rust components