### PR TITLE
Publish ergonomic rstest fixture for TestCluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,6 +2143,7 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-macros",
  "serde",
+ "tempfile",
  "thiserror 2.0.17",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,11 @@ thiserror = { workspace = true }
 common = { path = "common" }
 
 dylint_linting = { workspace = true, optional = true }
+rstest = "0.26.1"
+tempfile = "3.10.1"
 
 [dev-dependencies]
 common = { path = "common" }
-rstest = "0.26.1"
 rstest-bdd = "0.1.0-alpha4"
 rstest-bdd-macros = "0.1.0-alpha4"
 dylint_testing = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # Whitaker
 
-This is a generated project using [Copier](https://copier.readthedocs.io/).
+Whitaker ships shared infrastructure for building and testing Dylint crates. In
+addition to the lint template and UI harness, it now exposes an ergonomic
+`rstest` fixture that provisions a disposable `TestCluster` for integration
+tests.
+
+## Zero-config test cluster fixture
+
+Import the shared fixture and list `test_cluster` in your `#[rstest]`
+parameters to receive a ready-to-use Postgres-style cluster. No manual setup or
+teardown is required; the `TempDir` backing the cluster is deleted
+automatically when the fixture drops.
+
+```rust
+use rstest::rstest;
+use whitaker::testing::cluster::{test_cluster, TestCluster};
+
+#[rstest]
+fn verifies_schema(test_cluster: TestCluster) {
+    assert!(test_cluster.connection_uri().starts_with("postgresql://"));
+    assert_eq!(test_cluster.database(), "whitaker_test");
+}
+```
+
+For bespoke scenarios, start from `TestCluster::builder()` and override
+identifiers, ports, or bootstrap statements before calling `build()`. The
+builder validates identifiers, rejects destructive SQL by default, and records
+applied statements so behavioural tests can assert on setup without touching a
+real database.

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -84,9 +84,9 @@ Core Principles of Calculation:
 Cognitive Complexity is incremented based on three main rules 8:
 
 1. **Breaks in Linear Flow:** Each time the code breaks the normal linear
-   reading flow (e.g., loops, conditionals like
-   `if`/`else`/`switch`, `try-catch` blocks, jumps to labels, and sequences of
-   logical operators like `&&` and `||`), a penalty is applied.
+   reading flow (e.g., loops, conditionals like `if`/`else`/`switch`,
+   `try-catch` blocks, jumps to labels, and sequences of logical operators like
+   `&&` and `||`), a penalty is applied.
 
 2. **Nesting:** Each level of nesting of these flow-breaking structures adds an
    additional penalty. This is because deeper nesting makes it harder to keep

--- a/docs/ortho-config-users-guide.md
+++ b/docs/ortho-config-users-guide.md
@@ -1,0 +1,27 @@
+# Ortho Config User's Guide
+
+This guide explains how Whitaker keeps integration-test configuration
+orthogonal ("ortho config") so fixtures can be composed without leaking state
+across scenarios.
+
+1. **Prefer builders over global state.** `TestCluster::builder()` exposes
+   setters for every tunable field. Modify the builder inside fixtures or BDD
+   steps rather than mutating environment variables so changes remain local to
+   each test.
+2. **Layer overrides in a predictable order.** When a scenario needs bespoke
+   behaviour, start from the defaults supplied by the shared fixture, apply the
+   minimum number of overrides (for example, `builder.database("demo")`), and
+   only then call `build()`. Avoid post-construction mutation so assertions can
+   treat the returned `TestCluster` as immutable state.
+3. **Use `rstest` fixtures for dependency injection.** The exported
+   `test_cluster` fixture keeps cluster setup orthogonal to the assertions. BDD
+   steps that require additional configuration (for example, destructive
+   bootstrap statements) should compose their own fixtures on top of the shared
+   one rather than re-implementing the defaults.
+4. **Document every assumption.** When a test relies on optional behaviour,
+   note it in the relevant Markdown guide (for example, `docs/users-guide.md`)
+   so future contributors understand the expected layering order.
+
+Combined with the RAII semantics of `TempDir`, this approach keeps
+configuration changes scoped, comprehensible, and easy to reason about under
+parallel test execution.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,6 +37,12 @@
   - [x] Allow locale selection via `DYLINT_LOCALE` and `dylint.toml`, and add UI
         smoke tests that run under at least one non-English locale.
 
+- [x] Phase 2b — Provide an ergonomic RAII fixture
+  - [x] Integrate the zero-config RAII fixture with the `rstest` harness by
+        publishing the shared `test_cluster` fixture and behavioural coverage.
+  - [x] Document default usage patterns in the README, doctests, and user guides
+        so integration tests adopt the fixture without bespoke setup.
+
 - [ ] Phase 3 — Aggregated packaging and installer
   - [ ] Assemble the `suite` cdylib using constituent features and combined lint
         pass wiring.

--- a/docs/rstest-bdd-users-guide.md
+++ b/docs/rstest-bdd-users-guide.md
@@ -321,24 +321,23 @@ Best practices for writing effective scenarios include:
 
 - **Use placeholders for dynamic values.** Pattern strings may include
   `format!`-style placeholders such as `{count:u32}`. Type hints narrow the
-  match. Numeric hints support all Rust primitives
-  (`u8..u128`, `i8..i128`, `usize`, `isize`, `f32`, `f64`). Floating-point
-  hints accept integers, decimal forms with optional leading or trailing
-  digits, scientific notation (for example, `1e3`, `-1E-9`), and the special
-  values `NaN`, `inf`, and `Infinity` (matched case-insensitively). Matching is
-  anchored: the entire step text must match the pattern; partial matches do not
-  succeed. Escape literal braces with `{{` and `}}`. Use
-  `\` to match a single backslash. A trailing `\` or any other backslash escape
-  is treated literally, so `\d` matches the two-character sequence `\d`. Nested
-  braces inside placeholders are not supported. Placeholders follow
-  `{name[:type]}`; `name` must start with a letter or underscore and may
-  contain letters, digits, or underscores (`[A-Za-z_][A-Za-z0-9_]*`).
-  Whitespace within the type hint is ignored (for example, `{count: u32}` and
-  `{count:u32}` are both accepted), but whitespace is not allowed between the
-  name and the colon. Prefer the compact form `{count:u32}` in new code. When a
-  pattern contains no placeholders, the step text must match exactly. Unknown
-  type hints are treated as generic placeholders and capture any non-newline
-  text greedily.
+  match. Numeric hints support all Rust primitives (`u8..u128`, `i8..i128`,
+  `usize`, `isize`, `f32`, `f64`). Floating-point hints accept integers,
+  decimal forms with optional leading or trailing digits, scientific notation
+  (for example, `1e3`, `-1E-9`), and the special values `NaN`, `inf`, and
+  `Infinity` (matched case-insensitively). Matching is anchored: the entire
+  step text must match the pattern; partial matches do not succeed. Escape
+  literal braces with `{{` and `}}`. Use `\` to match a single backslash. A
+  trailing `\` or any other backslash escape is treated literally, so `\d`
+  matches the two-character sequence `\d`. Nested braces inside placeholders
+  are not supported. Placeholders follow `{name[:type]}`; `name` must start
+  with a letter or underscore and may contain letters, digits, or underscores
+  (`[A-Za-z_][A-Za-z0-9_]*`). Whitespace within the type hint is ignored (for
+  example, `{count: u32}` and `{count:u32}` are both accepted), but whitespace
+  is not allowed between the name and the colon. Prefer the compact form
+  `{count:u32}` in new code. When a pattern contains no placeholders, the step
+  text must match exactly. Unknown type hints are treated as generic
+  placeholders and capture any non-newline text greedily.
 
 ## Data tables and Docstrings
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -46,6 +46,29 @@ Run `make test` from the workspace root to execute unit, behaviour, and UI
 harness tests. The shared target enables `rstest` fixtures and `rstest-bdd`
 scenarios, ensuring each lint crate benefits from the consistent test harness.
 
+## Zero-config integration fixtures
+
+Whitaker exposes `whitaker::testing::cluster::test_cluster`, an `rstest`
+fixture that provisions a disposable Postgres-style cluster backed by a
+temporary directory. Import the fixture and list `test_cluster` in your test
+parameters to receive a ready connection URI without writing setup code:
+
+```rust
+use rstest::rstest;
+use whitaker::testing::cluster::{test_cluster, TestCluster};
+
+#[rstest]
+fn writes_data(test_cluster: TestCluster) {
+    assert!(test_cluster.connection_uri().starts_with("postgresql://"));
+}
+```
+
+For bespoke scenarios, call `TestCluster::builder()` and override the username,
+database, or port before invoking `build()`. Builders reject invalid
+identifiers, guard against destructive `DROP DATABASE` statements, and record
+every bootstrap statement so behaviour-driven tests can assert on the setup
+path via `cluster.executed_statements()`.
+
 ## Localised diagnostics
 
 Whitaker bundles Fluent resources under `locales/` so every lint can present

--- a/docs/zero-config-raii-postgres-test-fixture-design.md
+++ b/docs/zero-config-raii-postgres-test-fixture-design.md
@@ -1,0 +1,61 @@
+# Zero-Config RAII Postgres Test Fixture
+
+This document records the design decisions behind the
+`whitaker::testing::cluster` module, which exposes an ergonomic, disposable
+Postgres-style cluster for integration tests.
+
+## Objectives
+
+- Provide a "works by default" fixture (`test_cluster`) so `rstest` suites can
+  exercise integration behaviour without hand-written setup.
+- Keep the implementation hermetic: tests should not require Docker or a real
+  Postgres binary, yet still surface realistic ergonomics such as connection
+  URIs and bootstrap scripts.
+- Enforce safe defaults via RAII so temporary directories are cleaned
+  automatically and destructive SQL statements are blocked unless explicitly
+  enabled.
+
+## Key Decisions
+
+1. **Simulated cluster backed by `tempfile::TempDir`:** The fixture allocates a
+   UTF-8 data directory inside a `TempDir`. Dropping the `TestCluster` removes
+   the directory automatically, satisfying the RAII requirement and keeping
+   tests isolated across processes.
+2. **Validation mirrors common Postgres rules:** Usernames and database names
+   must start with an ASCII alphabetic character and may only contain
+   alphanumerics or underscores. Ports must live in the 1024–65535 range so
+   tests never conflict with privileged sockets.
+3. **Destructive bootstrap statements are denied by default:** `DROP DATABASE`
+   and `DROP SCHEMA` statements raise `ClusterError::UnsafeBootstrapStatement`.
+   Test authors can opt in via `allow_destructive_bootstrap(true)` when they
+   intentionally exercise failure flows.
+4. **`rstest` fixture baked into the library:** Exporting the `#[fixture]
+   fn test_cluster() -> TestCluster` helper lets downstream integration tests
+   opt in by naming the fixture in their parameter list without declaring any
+   boilerplate. The fixture panics if the builder fails, keeping failures loud
+   and early.
+5. **Statement recording instead of a live database:** Rather than launching a
+   real database, the builder records all bootstrap statements. Tests can
+   assert that specific migrations ran while enjoying deterministic execution
+   in CI.
+
+## Testing Strategy
+
+- **Unit tests** cover invalid identifiers, unsafe statements, and successful
+  bootstrap logging inside `src/testing/cluster.rs`.
+- **Behaviour-driven tests** (`tests/test_cluster.rs` and
+  `tests/features/test_cluster.feature`) exercise the exported fixture plus the
+  happy and unhappy builder paths, ensuring `rstest-bdd` remains the canonical
+  way to describe integration expectations.
+- **Doctests and README excerpts** show the intended usage so future
+  contributors reach for the fixture before re-implementing ad hoc setup.
+
+## Future Enhancements
+
+- Allow callers to specify a fake password so connection URIs more closely
+  resemble production deployments.
+- Store structured bootstrap metadata (for example, tags or execution timing)
+  so behaviour tests can assert on migration ordering without parsing strings.
+- Provide serial-test guards for future environment mutations (for example,
+  injecting `PGHOST`) so the fixture can evolve toward launching a real
+  database when needed.

--- a/src/testing/cluster.rs
+++ b/src/testing/cluster.rs
@@ -1,0 +1,324 @@
+//! Zero-configuration RAII fixtures for integration tests.
+//!
+//! The [`TestCluster`] type simulates a disposable Postgres-style deployment
+//! backed by a temporary directory. Builders validate identifiers, prevent
+//! destructive bootstrap statements, and record every statement applied during
+//! setup so tests can assert on preparatory work without connecting to a real
+//! database.
+//!
+//! ```no_run
+//! use rstest::rstest;
+//! use whitaker::testing::cluster::{test_cluster, TestCluster};
+//!
+//! #[rstest]
+//! fn runs_queries_against_cluster(test_cluster: TestCluster) {
+//!     assert!(test_cluster.connection_uri().starts_with("postgresql://"));
+//!     assert_eq!(test_cluster.database(), "whitaker_test");
+//! }
+//! ```
+//!
+//! ```
+//! use whitaker::testing::cluster::TestCluster;
+//!
+//! let mut builder = TestCluster::builder();
+//! builder.database("demo_db").port(15_500).bootstrap_statement("CREATE TABLE demo (id INT)");
+//! let cluster = builder.build().expect("cluster should build");
+//! assert_eq!(cluster.database(), "demo_db");
+//! assert_eq!(cluster.executed_statements(), ["CREATE TABLE demo (id INT)"]);
+//! ```
+
+use std::path::PathBuf;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use rstest::fixture;
+use tempfile::TempDir;
+use thiserror::Error;
+
+const DEFAULT_DATABASE: &str = "whitaker_test";
+const DEFAULT_USERNAME: &str = "postgres";
+const DEFAULT_PORT: u16 = 15_432;
+
+/// Errors that can occur while preparing a [`TestCluster`].
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum ClusterError {
+    /// The simulated data directory could not be created.
+    #[error("cluster workspace could not be created: {message}")]
+    WorkspaceCreation { message: String },
+    /// The temporary directory path was not valid UTF-8.
+    #[error("cluster workspace path is not valid UTF-8: {path:?}")]
+    NonUtf8Path { path: PathBuf },
+    /// Database identifiers must be ASCII letters, digits, or underscores.
+    #[error("database name must be ASCII alphanumeric with underscores: {provided}")]
+    InvalidDatabaseName { provided: String },
+    /// Usernames share the same validation as database identifiers.
+    #[error("username must be ASCII alphanumeric with underscores: {provided}")]
+    InvalidUsername { provided: String },
+    /// Ports must avoid privileged ranges.
+    #[error("port must fall between 1024 and 65535 inclusive: {provided}")]
+    InvalidPort { provided: u16 },
+    /// Bootstrap statements must contain characters once trimmed.
+    #[error("bootstrap statements must not be empty")]
+    EmptyBootstrapStatement,
+    /// Destructive statements are rejected by default for safety.
+    #[error("bootstrap statement contains destructive verbs: {statement}")]
+    UnsafeBootstrapStatement { statement: String },
+}
+
+/// Disposable Postgres-style cluster for integration tests.
+#[derive(Debug)]
+pub struct TestCluster {
+    _root: TempDir,
+    data_dir: Utf8PathBuf,
+    username: String,
+    database: String,
+    port: u16,
+    executed_statements: Vec<String>,
+}
+
+impl TestCluster {
+    /// Returns a builder pre-populated with safe defaults.
+    #[must_use]
+    pub fn builder() -> TestClusterBuilder {
+        TestClusterBuilder::default()
+    }
+
+    /// Data directory backing the simulated cluster.
+    #[must_use]
+    pub fn data_directory(&self) -> &Utf8Path {
+        self.data_dir.as_ref()
+    }
+
+    /// Username that the fixture exposes.
+    #[must_use]
+    pub const fn username(&self) -> &str {
+        self.username.as_str()
+    }
+
+    /// Database name configured for the fixture.
+    #[must_use]
+    pub const fn database(&self) -> &str {
+        self.database.as_str()
+    }
+
+    /// Port exposed via the connection URI.
+    #[must_use]
+    pub const fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Connection string suitable for clients that accept libpq URIs.
+    #[must_use]
+    pub fn connection_uri(&self) -> String {
+        format!(
+            "postgresql://{}@localhost:{}/{}",
+            self.username, self.port, self.database,
+        )
+    }
+
+    /// Statements applied while bootstrapping the cluster.
+    #[must_use]
+    pub fn executed_statements(&self) -> &[String] {
+        &self.executed_statements
+    }
+}
+
+/// Configures and constructs [`TestCluster`] instances.
+#[derive(Clone, Debug)]
+pub struct TestClusterBuilder {
+    username: String,
+    database: String,
+    port: u16,
+    bootstrap: Vec<String>,
+    allow_destructive: bool,
+}
+
+impl Default for TestClusterBuilder {
+    fn default() -> Self {
+        Self {
+            username: DEFAULT_USERNAME.to_owned(),
+            database: DEFAULT_DATABASE.to_owned(),
+            port: DEFAULT_PORT,
+            bootstrap: Vec::new(),
+            allow_destructive: false,
+        }
+    }
+}
+
+impl TestClusterBuilder {
+    /// Overrides the simulated username used by the fixture.
+    pub fn username(&mut self, username: impl Into<String>) -> &mut Self {
+        self.username = username.into();
+        self
+    }
+
+    /// Overrides the database name exposed by the fixture.
+    pub fn database(&mut self, database: impl Into<String>) -> &mut Self {
+        self.database = database.into();
+        self
+    }
+
+    /// Overrides the TCP port recorded in the connection URI.
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "builder mutators rely on heap-backed state that is not const"
+    )]
+    pub fn port(&mut self, port: u16) -> &mut Self {
+        self.port = port;
+        self
+    }
+
+    /// Appends a bootstrap statement applied during cluster creation.
+    pub fn bootstrap_statement(&mut self, statement: impl Into<String>) -> &mut Self {
+        self.bootstrap.push(statement.into());
+        self
+    }
+
+    /// Allows destructive statements such as `DROP DATABASE` during bootstrap.
+    #[expect(
+        clippy::missing_const_for_fn,
+        reason = "builder mutators rely on heap-backed state that is not const"
+    )]
+    pub fn allow_destructive_bootstrap(&mut self, allow: bool) -> &mut Self {
+        self.allow_destructive = allow;
+        self
+    }
+
+    /// Builds the [`TestCluster`], validating identifiers and bootstrap input.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClusterError`] when identifiers are invalid, the port falls
+    /// outside the accepted range, bootstrap statements are empty or
+    /// destructive, or when the temporary data directory cannot be created.
+    pub fn build(&self) -> Result<TestCluster, ClusterError> {
+        validate_identifier(&self.database)
+            .map_err(|provided| ClusterError::InvalidDatabaseName { provided })?;
+        validate_identifier(&self.username)
+            .map_err(|provided| ClusterError::InvalidUsername { provided })?;
+        validate_port(self.port)?;
+
+        let root = TempDir::new().map_err(|error| ClusterError::WorkspaceCreation {
+            message: error.to_string(),
+        })?;
+        let data_dir = Utf8PathBuf::from_path_buf(root.path().to_path_buf())
+            .map_err(|path| ClusterError::NonUtf8Path { path })?;
+
+        let mut executed_statements = Vec::with_capacity(self.bootstrap.len());
+        for statement in &self.bootstrap {
+            let trimmed = statement.trim();
+            if trimmed.is_empty() {
+                return Err(ClusterError::EmptyBootstrapStatement);
+            }
+            guard_statement(trimmed, self.allow_destructive)?;
+            executed_statements.push(trimmed.to_owned());
+        }
+
+        Ok(TestCluster {
+            _root: root,
+            data_dir,
+            username: self.username.clone(),
+            database: self.database.clone(),
+            port: self.port,
+            executed_statements,
+        })
+    }
+}
+
+fn validate_identifier(candidate: &str) -> Result<(), String> {
+    let trimmed = candidate.trim();
+    if trimmed.is_empty() {
+        return Err(trimmed.to_owned());
+    }
+
+    let mut chars = trimmed.chars();
+    match chars.next() {
+        Some(first) if is_identifier_lead(first) => {}
+        _ => return Err(trimmed.to_owned()),
+    }
+
+    if chars.all(is_identifier_continue) {
+        Ok(())
+    } else {
+        Err(trimmed.to_owned())
+    }
+}
+
+const fn is_identifier_lead(value: char) -> bool {
+    value.is_ascii_alphabetic()
+}
+
+const fn is_identifier_continue(value: char) -> bool {
+    value.is_ascii_alphanumeric() || value == '_'
+}
+
+const fn validate_port(port: u16) -> Result<(), ClusterError> {
+    match port {
+        1_024..=65_535 => Ok(()),
+        _ => Err(ClusterError::InvalidPort { provided: port }),
+    }
+}
+
+fn guard_statement(statement: &str, allow_destructive: bool) -> Result<(), ClusterError> {
+    if allow_destructive {
+        return Ok(());
+    }
+
+    let lowered = statement.to_ascii_lowercase();
+    if lowered.contains("drop database") || lowered.contains("drop schema") {
+        return Err(ClusterError::UnsafeBootstrapStatement {
+            statement: statement.to_owned(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Ready-to-use `rstest` fixture that yields a [`TestCluster`] configured with
+/// the default builder settings.
+#[fixture]
+#[must_use]
+pub fn test_cluster() -> TestCluster {
+    TestCluster::builder()
+        .build()
+        .unwrap_or_else(|error| panic!("default cluster configuration failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_database() {
+        let mut builder = TestCluster::builder();
+        builder.database("   ");
+        let error = builder.build().expect_err("builder should fail");
+        assert!(matches!(error, ClusterError::InvalidDatabaseName { .. }));
+    }
+
+    #[test]
+    fn rejects_reserved_port() {
+        let mut builder = TestCluster::builder();
+        builder.port(42);
+        let error = builder.build().expect_err("builder should fail");
+        assert_eq!(error, ClusterError::InvalidPort { provided: 42 });
+    }
+
+    #[test]
+    fn rejects_destructive_bootstrap() {
+        let mut builder = TestCluster::builder();
+        builder.bootstrap_statement("DROP DATABASE demo");
+        let error = builder.build().expect_err("bootstrap should fail");
+        assert!(matches!(
+            error,
+            ClusterError::UnsafeBootstrapStatement { .. }
+        ));
+    }
+
+    #[test]
+    fn records_bootstrap_statements() {
+        let mut builder = TestCluster::builder();
+        builder.bootstrap_statement("CREATE TABLE demo(id INT)");
+        let cluster = builder.build().expect("cluster should build");
+        assert_eq!(cluster.executed_statements(), ["CREATE TABLE demo(id INT)"]);
+    }
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,3 +1,4 @@
 //! Shared test infrastructure used by Whitaker lint crates.
 
+pub mod cluster;
 pub mod ui;

--- a/tests/features/test_cluster.feature
+++ b/tests/features/test_cluster.feature
@@ -1,0 +1,34 @@
+Feature: Zero-config test cluster
+  The RAII fixture should provide a ready connection URI without bespoke
+  setup rituals.
+
+  Scenario: Building with defaults
+    Given a fresh cluster builder
+    When the cluster is built
+    Then building succeeds with database whitaker_test
+
+  Scenario: Rejecting invalid database names
+    Given a fresh cluster builder
+    And the database name is ""
+    When the cluster is built
+    Then building fails with an invalid database name error
+
+  Scenario: Rejecting reserved ports
+    Given a fresh cluster builder
+    And the cluster port is 42
+    When the cluster is built
+    Then building fails with an invalid port error
+
+  Scenario: Recording bootstrap statements
+    Given a fresh cluster builder
+    And the database name is demo_db
+    And a bootstrap statement "CREATE EXTENSION citext" is queued
+    When the cluster is built
+    Then building succeeds with database demo_db
+    And the applied statements include "CREATE EXTENSION citext"
+
+  Scenario: Blocking destructive bootstrap statements
+    Given a fresh cluster builder
+    And a bootstrap statement "DROP DATABASE prod" is queued
+    When the cluster is built
+    Then building fails with an unsafe statement error

--- a/tests/test_cluster.rs
+++ b/tests/test_cluster.rs
@@ -1,0 +1,201 @@
+//! Behaviour-driven tests for the zero-config `TestCluster` fixture.
+
+use std::{cell::RefCell, str::FromStr};
+
+use rstest::{fixture, rstest};
+use rstest_bdd_macros::{given, scenario, then, when};
+use whitaker::testing::cluster::{ClusterError, TestCluster, TestClusterBuilder, test_cluster};
+
+#[derive(Debug)]
+struct StepString(String);
+
+impl FromStr for StepString {
+    type Err = core::convert::Infallible;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let trimmed = input.trim();
+        Ok(Self(trimmed.trim_matches('"').to_owned()))
+    }
+}
+
+impl StepString {
+    fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+fn normalised_statement(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches(|candidate| matches!(candidate, '"' | '\''))
+        .to_owned()
+}
+
+#[derive(Default)]
+struct ClusterWorld {
+    builder: RefCell<TestClusterBuilder>,
+    result: RefCell<Option<Result<TestCluster, ClusterError>>>,
+}
+
+#[fixture]
+fn cluster_world() -> ClusterWorld {
+    ClusterWorld::default()
+}
+
+#[given("a fresh cluster builder")]
+fn reset_builder(cluster_world: &ClusterWorld) {
+    *cluster_world.builder.borrow_mut() = TestCluster::builder();
+    cluster_world.result.borrow_mut().take();
+}
+
+#[given("the database name is {name}")]
+fn override_database(cluster_world: &ClusterWorld, name: String) {
+    cluster_world.builder.borrow_mut().database(name);
+}
+
+#[given("the username is {name}")]
+fn override_username(cluster_world: &ClusterWorld, name: String) {
+    cluster_world.builder.borrow_mut().username(name);
+}
+
+#[given("the cluster port is {port}")]
+fn override_port(cluster_world: &ClusterWorld, port: u16) {
+    cluster_world.builder.borrow_mut().port(port);
+}
+
+#[given("a bootstrap statement {statement} is queued")]
+fn queue_statement(cluster_world: &ClusterWorld, statement: String) {
+    cluster_world
+        .builder
+        .borrow_mut()
+        .bootstrap_statement(statement);
+}
+
+#[given("destructive bootstrap statements are allowed")]
+fn allow_destructive(cluster_world: &ClusterWorld) {
+    cluster_world
+        .builder
+        .borrow_mut()
+        .allow_destructive_bootstrap(true);
+}
+
+#[when("the cluster is built")]
+fn build_cluster(cluster_world: &ClusterWorld) {
+    let builder = cluster_world.builder.borrow().clone();
+    let outcome = builder.build();
+    cluster_world.result.borrow_mut().replace(outcome);
+}
+
+#[then("building succeeds with database {name}")]
+fn assert_success(cluster_world: &ClusterWorld, name: StepString) {
+    let borrow = cluster_world.result.borrow();
+    let Some(outcome) = borrow.as_ref() else {
+        panic!("cluster should be built");
+    };
+
+    let expected = name.into_inner();
+
+    match outcome {
+        Ok(cluster) => assert_eq!(cluster.database(), expected.as_str()),
+        Err(error) => panic!("expected cluster success, found {error}"),
+    }
+}
+
+#[then("the applied statements include {statement}")]
+fn assert_statements(cluster_world: &ClusterWorld, statement: StepString) {
+    let borrow = cluster_world.result.borrow();
+    let Some(outcome) = borrow.as_ref() else {
+        panic!("cluster should be built");
+    };
+
+    let cluster = match outcome {
+        Ok(cluster) => cluster,
+        Err(error) => panic!("expected cluster success, found {error}"),
+    };
+    let value = statement.into_inner();
+    let expected = normalised_statement(value.as_str());
+    assert!(
+        cluster
+            .executed_statements()
+            .iter()
+            .any(|candidate| normalised_statement(candidate) == expected),
+        "expected bootstrap statements to include {expected}"
+    );
+}
+
+#[then("building fails with an invalid database name error")]
+fn assert_invalid_database(cluster_world: &ClusterWorld) {
+    let borrow = cluster_world.result.borrow();
+    let Some(result) = borrow.as_ref() else {
+        panic!("cluster should be built");
+    };
+
+    match result {
+        Err(ClusterError::InvalidDatabaseName { .. }) => {}
+        Err(other) => panic!("expected invalid database error, found {other}"),
+        Ok(cluster) => panic!("expected failure, found success for {cluster:?}"),
+    }
+}
+
+#[then("building fails with an invalid port error")]
+fn assert_invalid_port(cluster_world: &ClusterWorld) {
+    let borrow = cluster_world.result.borrow();
+    let Some(result) = borrow.as_ref() else {
+        panic!("cluster should be built");
+    };
+
+    match result {
+        Err(ClusterError::InvalidPort { .. }) => {}
+        Err(other) => panic!("expected invalid port error, found {other}"),
+        Ok(cluster) => panic!("expected failure, found success for {cluster:?}"),
+    }
+}
+
+#[then("building fails with an unsafe statement error")]
+fn assert_unsafe_statement(cluster_world: &ClusterWorld) {
+    let borrow = cluster_world.result.borrow();
+    let Some(result) = borrow.as_ref() else {
+        panic!("cluster should be built");
+    };
+
+    match result {
+        Err(ClusterError::UnsafeBootstrapStatement { .. }) => {}
+        Err(other) => panic!("expected unsafe statement error, found {other}"),
+        Ok(cluster) => panic!("expected failure, found success for {cluster:?}"),
+    }
+}
+
+#[scenario(path = "tests/features/test_cluster.feature", index = 0)]
+fn scenario_builds_with_defaults(cluster_world: ClusterWorld) {
+    let _ = cluster_world;
+}
+
+#[scenario(path = "tests/features/test_cluster.feature", index = 1)]
+fn scenario_rejects_invalid_database(cluster_world: ClusterWorld) {
+    let _ = cluster_world;
+}
+
+#[scenario(path = "tests/features/test_cluster.feature", index = 2)]
+fn scenario_rejects_reserved_port(cluster_world: ClusterWorld) {
+    let _ = cluster_world;
+}
+
+#[scenario(path = "tests/features/test_cluster.feature", index = 3)]
+fn scenario_records_bootstrap(cluster_world: ClusterWorld) {
+    let _ = cluster_world;
+}
+
+#[scenario(path = "tests/features/test_cluster.feature", index = 4)]
+fn scenario_blocks_destructive_bootstrap(cluster_world: ClusterWorld) {
+    let _ = cluster_world;
+}
+
+#[rstest]
+fn fixture_requires_no_setup(test_cluster: TestCluster) {
+    assert_eq!(test_cluster.username(), "postgres");
+    assert!(
+        test_cluster
+            .connection_uri()
+            .contains(test_cluster.database())
+    );
+}


### PR DESCRIPTION
## Summary
- Introduces a zero-config, RAII Postgres-style test fixture for integration tests using rstest.
- Exposes a `TestCluster` builder with validation and safety checks, and an ergonomic `test_cluster` rstest fixture.
- Records bootstrap statements, enabling tests to assert setup steps without a live database.
- Includes documentation, tests, and dependency updates to support the new fixture.

## Changes
### Core functionality
- New module `src/testing/cluster.rs` implementing:
  - `TestCluster` (data dir, credentials, port, executed statements, URIs)
  - `TestClusterBuilder` with `username`, `database`, `port`, `bootstrap_statement`, and `allow_destructive_bootstrap` controls
  - Validation for identifiers (must start with ASCII letter, contain only ASCII alphanumerics/underscore)
  - Port range check (1024..=65535)
  - RAII-backed temp directory management via `TempDir`
  - Bootstrap statement handling: non-empty, optional destructive statements guarded by default, and recorded
- Public API highlights:
  - `TestCluster::builder()`, `data_directory()`, `username()`, `database()`, `port()`, `connection_uri()`, `executed_statements()`
  - Builder methods: `username()`, `database()`, `port()`, `bootstrap_statement()`, `allow_destructive_bootstrap()`, `build()`
  - Rstest fixture: `test_cluster()` (yields a ready cluster by default)

### Tests
- Added behaviour-driven and unit tests:
  - `tests/features/test_cluster.feature` defines end-to-end scenarios
  - `tests/test_cluster.rs` covers core expectations (valid/invalid inputs, bootstrap recording, safety)
- Coverage includes: default build, invalid database name, reserved port, destructive bootstrap handling, and statement recording

### Documentation
- New docs:
  - `docs/ortho-config-users-guide.md` (orthogonal configuration guidance for fixtures)
  - `docs/zero-config-raii-postgres-test-fixture-design.md` (design rationale for the fixture)
- Updated docs:
  - `docs/users-guide.md` (section on zero-config integration fixtures)
  - `docs/rstest-bdd-users-guide.md` (text tweaks related to placeholders and type hints)
- README updated to highlight the new ergonomic fixture and usage example

### Dependency updates
- Cargo.toml: added `rstest` and `tempfile` dependencies to support the fixture and RAII-backed temp dirs
- Cargo.lock updated accordingly

## How to use
- Basic usage with the default fixture:
  ```rust
  use whitaker::testing::cluster::{test_cluster, TestCluster};
  use rstest::rstest;

  #[rstest]
  fn verifies_cluster(test_cluster: TestCluster) {
      assert!(test_cluster.connection_uri().starts_with("postgresql://"));
      assert_eq!(test_cluster.database(), "whitaker_test");
  }
  ```

- Customizing the cluster:
  ```rust
  let cluster = TestCluster::builder()
      .database("demo_db")
      .port(15_500)
      .bootstrap_statement("CREATE TABLE demo (id INT)")
      .build()
      .expect("cluster should build");
  assert_eq!(cluster.database(), "demo_db");
  assert_eq!(cluster.executed_statements(), &["CREATE TABLE demo (id INT)"]);
  ```

- Safety notes:
  - By default, destructive statements like `DROP DATABASE` are blocked.
  - To test destructive paths, call `allow_destructive_bootstrap(true)` on the builder.

## Tests and CI
- Behaviour-driven tests exercise both default and edge-case scenarios via `rstest-bdd` integration.
- Local tests validate identifier validation, port range, bootstrap recording, and safety checks.

## Migration / Notes
- This change is additive and does not alter existing lint crates. The new fixture is opt-in via imports and usage.

## Test plan
- Validate unit tests for identifier/port validation and statement guarding.
- Run behaviour-driven tests (`tests/features/test_cluster.feature`).
- Ensure `Cargo.lock` resolves with the new dependencies across CI environments.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f9ad8edb-95ef-4cbb-a1ff-16cba048df26

## Summary by Sourcery

Introduce a zero-configuration RAII Postgres-style `TestCluster` fixture for integration tests, exposing a builder API with validation, safe defaults, and bootstrap statement recording, and update docs, tests, and dependencies to support it.

New Features:
- Add `TestCluster` and `TestClusterBuilder` types with identifier and port validation, RAII temp directory management, and bootstrap statement support
- Provide a default `#[fixture] fn test_cluster()` for `rstest` that yields a ready-to-use disposable cluster
- Record bootstrap statements so tests can assert setup steps without a real database

Build:
- Add `rstest` and `tempfile` dependencies for fixture and RAII directory support

Documentation:
- Add a detailed design doc and orthogonal config guide
- Update README and user guides to document the new zero-config fixture and usage examples
- Tweak existing rstest-bdd and roadmap docs to reference the fixture

Tests:
- Add unit tests for identifier/port validation, unsafe bootstrap guarding, and statement recording
- Add behaviour-driven tests and feature scenarios covering default configuration, invalid inputs, and destructive statement policies