### PR TITLE
Replace coverage step with make test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,9 @@ jobs:
       - name: Lint
         run: make lint
 
-      - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@c366af3e25f7cfb318dccfe58a92d6df5dffdf17
-        with:
-          output-path: lcov.info
-          format: lcov
+      - name: Test
+        shell: bash
+        run: make test
 
       - name: Publish dry run
         run: make publish-check


### PR DESCRIPTION
## Summary
- Replaces the separate coverage generation step with a direct test run in CI
- Simplifies the CI workflow by removing the generate-coverage action

## Changes

### CI Workflow
- Remove the Test and Measure Coverage step that used leynos/shared-actions/.github/actions/generate-coverage
- Add a new Test step that runs `make test` with a bash shell

## Test plan
- [x] CI pipeline completes successfully by running `make test`
- [x] Local verification by executing `make test`
- [x] Verify that no separate coverage artifact (e.g., lcov.info) is published in CI

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/866b8366-faba-4629-abc8-ab6dc2df1486

## Summary by Sourcery

Replace separate coverage generation step in CI with a direct test invocation using `make test`, simplifying the workflow.

Enhancements:
- Simplify CI workflow by removing the generate-coverage action and merging test and coverage into a single step

CI:
- Replace the Test and Measure Coverage action with a Test step that runs `make test`