### PR TITLE
Fix publish-check target by correcting Makefile flag default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
 RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 MDLINT ?= markdownlint
 NIXIE ?= nixie
-PUBLISH_CHECK_FLAGS ?= --access public # Flags passed to Lading publish; override via env or caller.
+PUBLISH_CHECK_FLAGS ?= # Flags passed to Lading publish; override via env or caller.
 LADING ?= uvx --from git+https://github.com/leynos/lading lading
 
 build: target/debug/$(APP) ## Build debug binary


### PR DESCRIPTION
## Summary
- Correct default for PUBLISH_CHECK_FLAGS in Makefile to allow proper override during publish checks
- Prevents hard-coded public access flag from being applied by default

## Changes

### Makefile
- Change PUBLISH_CHECK_FLAGS default from --access public to an empty value
- Keeps the explanatory comment intact
- This allows caller or environment to set flags for LADING publish without conflicting default

### Rationale
- Aligns with publish workflow expectations and avoids forcing public access by default

## Test plan
- Run make publish-check (or the CI publish-check step) to ensure no default access flags are applied
- Override flags via environment or caller, e.g. PUBLISH_CHECK_FLAGS="--access public" or other options, and confirm behavior
- Ensure other make targets build as before


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c3dfb0b9-9e9b-489a-b63e-553ded62739a

## Summary by Sourcery

Bug Fixes:
- Remove default `--access public` from PUBLISH_CHECK_FLAGS to prevent unintended public access and enable flag overrides