### PR TITLE
Upgrade rstest-bdd to v0.1.0 (stable)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,10 +80,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -222,6 +246,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +295,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,10 +315,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs-next"
@@ -331,7 +412,7 @@ dependencies = [
  "serde",
  "tar",
  "thiserror 2.0.17",
- "toml",
+ "toml 0.9.8",
 ]
 
 [[package]]
@@ -346,7 +427,7 @@ dependencies = [
  "rustversion",
  "serde",
  "thiserror 2.0.17",
- "toml",
+ "toml 0.9.8",
 ]
 
 [[package]]
@@ -425,10 +506,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+
+[[package]]
+name = "fluent"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
 
 [[package]]
 name = "fluent-bundle"
@@ -650,6 +750,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +872,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "i18n-config"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a217bbb075dcaefb292efa78897fc0678245ca67f265d12c351e42268fcb0305"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "log",
+ "parking_lot",
+ "rust-embed",
+ "sys-locale",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1441,32 +1598,40 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd"
-version = "0.1.0-alpha4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ba71895dfbfa7c211f93d2e0a5303b6c16ce3df3493caa8259381521d7e59b"
+checksum = "c0c58a595280bc9d8386a1888aac2264838ce90f29450dfa50d4b9a00cbbcc63"
 dependencies = [
  "ctor",
+ "derive_more",
+ "fluent",
  "gherkin",
  "hashbrown",
+ "i18n-embed",
  "inventory",
  "log",
+ "once_cell",
  "regex",
  "rstest-bdd-patterns",
+ "rust-embed",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "unic-langid",
 ]
 
 [[package]]
 name = "rstest-bdd-macros"
-version = "0.1.0-alpha4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55203268dc22a1120a17e6c3abd746876da92bd00a2cd2db4e0125d5e32a293"
+checksum = "7db2930cac8d70e8a7d4aab1e0b6782b6aadfef3b68d6acf91179e8433ec44df"
 dependencies = [
  "camino",
  "cap-std",
  "cfg-if",
+ "convert_case 0.6.0",
  "gherkin",
+ "once_cell",
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
@@ -1479,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "rstest-bdd-patterns"
-version = "0.1.0-alpha4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e86cae3abdbeecef13e120bdedaa6d96e9d3fee9b83efa58b86fc250fdf32f"
+checksum = "dee8d9e47e63602b9061a3d73e48c0248f49d5bc730d64a8b27750f09342f81b"
 dependencies = [
  "regex",
  "thiserror 1.0.69",
@@ -1503,6 +1668,40 @@ dependencies = [
  "rustc_version",
  "syn 2.0.106",
  "unicode-ident",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.106",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]
@@ -1719,6 +1918,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1997,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1900,6 +2119,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
@@ -1998,6 +2226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2247,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
 dependencies = [
+ "serde",
  "tinystr",
 ]
 
@@ -2051,6 +2286,12 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -2148,7 +2389,7 @@ dependencies = [
  "rstest-bdd-macros",
  "serde",
  "thiserror 2.0.17",
- "toml",
+ "toml 0.9.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ dylint_linting = { workspace = true, optional = true }
 [dev-dependencies]
 common = { path = "common" }
 rstest = "0.26.1"
-rstest-bdd = "0.1.0-alpha4"
-rstest-bdd-macros = "0.1.0-alpha4"
+rstest-bdd = "0.1.0"
+rstest-bdd-macros = "0.1.0"
 dylint_testing = { workspace = true }
 
 [lints.clippy]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,14 +12,13 @@ thiserror = { workspace = true }
 log = { workspace = true }
 
 [dev-dependencies]
-# Testing: Behavioural specs pin rstest-bdd crates to 0.1.0-alpha4 while we
-# await a stable release. These alpha builds may regress; capture any failures
-# with `make test` and report them via the troubleshooting guidance in
-# `docs/rstest-bdd-users-guide.md`. Where blockers arise, coordinate with the
-# maintainers to backport fixes or temporarily gate the affected feature tests.
+# Testing: Behavioural specs now target rstest-bdd 0.1.0, the first stable
+# release. Capture any regressions with `make test` and coordinate with the
+# maintainers per `docs/rstest-bdd-users-guide.md` before gating behaviour
+# tests or backporting fixes.
 rstest = "0.26.1"
-rstest-bdd = "0.1.0-alpha4"
-rstest-bdd-macros = "0.1.0-alpha4"
+rstest-bdd = "0.1.0"
+rstest-bdd-macros = "0.1.0"
 regex = "1.10.4"
 logtest = "2.0.0"
 tempfile = "3.14"

--- a/crates/function_attrs_follow_docs/Cargo.toml
+++ b/crates/function_attrs_follow_docs/Cargo.toml
@@ -38,7 +38,7 @@ whitaker = { path = "../../", features = ["dylint-driver"], optional = true }
 
 [dev-dependencies]
 rstest = { version = "0.26.1" }
-rstest-bdd = { version = "0.1.0-alpha4" }
-rstest-bdd-macros = { version = "0.1.0-alpha4" }
+rstest-bdd = { version = "0.1.0" }
+rstest-bdd-macros = { version = "0.1.0" }
 dylint_testing = { workspace = true }
 serial_test = "3.1.0"

--- a/crates/module_max_lines/Cargo.toml
+++ b/crates/module_max_lines/Cargo.toml
@@ -35,8 +35,8 @@ fluent-templates = { workspace = true, optional = true }
 [dev-dependencies]
 camino = { workspace = true }
 rstest = { version = "0.26.1" }
-rstest-bdd = { version = "0.1.0-alpha4" }
-rstest-bdd-macros = { version = "0.1.0-alpha4" }
+rstest-bdd = { version = "0.1.0" }
+rstest-bdd-macros = { version = "0.1.0" }
 dylint_testing = { workspace = true }
 tempfile = "3.14.0"
 glob = "0.3"

--- a/crates/no_expect_outside_tests/Cargo.toml
+++ b/crates/no_expect_outside_tests/Cargo.toml
@@ -38,6 +38,6 @@ log = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest = { version = "0.26.1" }
-rstest-bdd = { version = "0.1.0-alpha4" }
-rstest-bdd-macros = { version = "0.1.0-alpha4" }
+rstest-bdd = { version = "0.1.0" }
+rstest-bdd-macros = { version = "0.1.0" }
 dylint_testing = { workspace = true }

--- a/docs/rstest-bdd-users-guide.md
+++ b/docs/rstest-bdd-users-guide.md
@@ -284,14 +284,14 @@ To enable validation pin a feature in your `dev-dependencies`:
 
 ```toml
 [dev-dependencies]
-rstest-bdd-macros = { version = "0.1.0-alpha4", features = ["compile-time-validation"] }
+rstest-bdd-macros = { version = "0.1.0", features = ["compile-time-validation"] }
 ```
 
 For strict checking use:
 
 ```toml
 [dev-dependencies]
-rstest-bdd-macros = { version = "0.1.0-alpha4", features = ["strict-compile-time-validation"] }
+rstest-bdd-macros = { version = "0.1.0", features = ["strict-compile-time-validation"] }
 ```
 
 Steps are only validated when one of these features is enabled.

--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -144,8 +144,10 @@ Utilities shared by lints:
   without rewriting the table. Unknown fields are rejected via
   `deny_unknown_fields` so configuration typos fail fast during deserialization.
 - Unit and behaviour coverage lean on `rstest` fixtures and `rstest-bdd`
-  scenarios (v0.1.0-alpha4) to exercise happy, unhappy, and edge cases without
+  scenarios (v0.1.0) to exercise happy, unhappy, and edge cases without
   duplicating setup logic.
+- Adopt the rstest-bdd 0.1.0 stable release to eliminate alpha regressions
+  whilst keeping compile-time validation consistent across lint crates.
 
 ### Localisation infrastructure
 


### PR DESCRIPTION
## Summary
- Upgrades rstest-bdd and rstest-bdd-macros to stable v0.1.0 across the workspace.
- Updates documentation and lockfile to reflect the stable release.

## Changes

### Dependency updates
- Root Cargo.toml: dev-dependencies rstest-bdd and rstest-bdd-macros set to "0.1.0" (from alpha4).
- All crates under crates/* update dev-dependencies accordingly:
  - rstest-bdd = "0.1.0"
  - rstest-bdd-macros = "0.1.0"
- Cargo.lock updated to reflect the new, stable dependency graph.

### Documentation updates
- docs/rstest-bdd-users-guide.md:
  - Replace alpha4 references with 0.1.0 in examples involving compile-time validation.
- docs/whitaker-dylint-suite-design.md:
  - Update references from v0.1.0-alpha4 to v0.1.0 stable.
  - Add note about adopting the stable release to reduce alpha regressions.
- common/Cargo.toml:
  - Update guidance text to reflect stable 0.1.0 usage instead of alpha versions.

### Other
- No code changes; this is a dependency/stability update. Behavior should remain the same aside from version bumps.

## Test plan
- Build and run workspace tests: `cargo test --workspace`.
- Verify that rstest-bdd-related tests compile and pass.
- Validate compile-time validation usage where applicable in tests.
- CI should pass with the stable release after this change.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b11a5235-2128-410d-8ffd-bc019359bb9c

## Summary by Sourcery

Upgrade rstest-bdd and rstest-bdd-macros to the first stable v0.1.0 release across the workspace, update documentation to reference the new version, and regenerate the lockfile to reflect the stable dependency graph.

Enhancements:
- Upgrade rstest-bdd and rstest-bdd-macros dev-dependencies to v0.1.0 across all crates
- Revise testing guidance in common/Cargo.toml to target the stable release instead of alpha

Build:
- Refresh Cargo.lock to reflect the new stable dependency graph

Documentation:
- Replace alpha4 version references with 0.1.0 in rstest-bdd user guide and design documentation, adding notes on stable adoption