### PR TITLE
Remove unused stub module when dylint-driver is disabled

### DIFF
--- a/crates/module_must_have_inner_docs/src/lib.rs
+++ b/crates/module_must_have_inner_docs/src/lib.rs
@@ -28,9 +28,3 @@ mod driver;
 
 #[cfg(feature = "dylint-driver")]
 pub use driver::*;
-
-#[cfg(not(feature = "dylint-driver"))]
-mod stub {
-    #[expect(dead_code, reason = "stub when dylint-driver is disabled")]
-    pub fn module_must_have_inner_docs_disabled_stub() {}
-}


### PR DESCRIPTION
## Summary
- Remove unused stub module that existed when the dylint-driver feature was disabled.

## Changes
### Code
- Deleted the not(feature = "dylint-driver") stub module from
  `crates/module_must_have_inner_docs/src/lib.rs`.
- Kept only the `mod driver;` declaration and the `#[cfg(feature = "dylint-driver")] pub use driver::*;` export.

### Rationale
- Eliminates dead code and simplifies feature gating for the crate. The stub was unused when the dylint-driver feature is not enabled, so removing it reduces maintenance and potential confusion.

### Compatibility
- No API changes. When dylint-driver is enabled, behavior remains the same. When disabled, the crate builds without the stub module.

## Test plan
- [x] Build the workspace with default features
- [x] Build with `dylint-driver` feature enabled
- [x] Build with `dylint-driver` feature disabled (no default enabling)
- [x] Run full test suite if applicable

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/cdbf3bf5-14a7-46ad-a7aa-c78ad2d10a93

## Summary by Sourcery

Enhancements:
- Simplify feature-gated behavior by relying solely on the dylint-driver-backed driver module and removing the no-op stub implementation.