### PR TITLE
Fix unused import causing compilation error and add CLI test helper

### DIFF
--- a/installer/tests/behaviour_cli.rs
+++ b/installer/tests/behaviour_cli.rs
@@ -119,10 +119,15 @@ fn when_installer_cli_run(cli_world: &CliWorld) {
     cli_world.output.replace(Some(output));
 }
 
+/// Helper function to retrieve the command output from the CLI world.
+fn get_output(cli_world: &CliWorld) -> std::cell::Ref<'_, Output> {
+    let output = cli_world.output.borrow();
+    std::cell::Ref::map(output, |opt| opt.as_ref().expect("output not set"))
+}
+
 #[then("the CLI exits successfully")]
 fn then_cli_exits_successfully(cli_world: &CliWorld) {
-    let output = cli_world.output.borrow();
-    let output = output.as_ref().expect("output not set");
+    let output = get_output(cli_world);
     assert!(
         output.status.success(),
         "expected success, stderr: {}",
@@ -150,8 +155,7 @@ fn then_dry_run_output_is_shown(cli_world: &CliWorld) {
 
 #[then("the CLI exits with an error")]
 fn then_cli_exits_with_error(cli_world: &CliWorld) {
-    let output = cli_world.output.borrow();
-    let output = output.as_ref().expect("output not set");
+    let output = get_output(cli_world);
     assert!(
         !output.status.success(),
         "expected failure, stdout: {}, stderr: {}",

--- a/installer/tests/behaviour_staging.rs
+++ b/installer/tests/behaviour_staging.rs
@@ -6,7 +6,9 @@
 use camino::Utf8PathBuf;
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
-use std::cell::{Cell, RefCell};
+#[cfg(unix)]
+use std::cell::Cell;
+use std::cell::RefCell;
 use whitaker_installer::builder::CrateName;
 use whitaker_installer::stager::Stager;
 


### PR DESCRIPTION
## Summary
- Fix an unused import causing compilation error by gating the Cell import behind a cfg(unix) flag
- Add a small helper to retrieve CLI command output in tests to simplify assertions and avoid repetitive borrow/unwrap patterns

## Changes

### Testing utilities
- installer/tests/behaviour_cli.rs
  - Introduce get_output(cli_world) -> std::cell::Ref<'_, Output> to centralize and simplify retrieval of CLI output
  - Update assertions to use get_output(cli_world) instead of duplicating borrow/unwrap logic

### Platform-specific imports
- installer/tests/behaviour_staging.rs
  - Replace unconditional import of std::cell::{Cell, RefCell} with gated import:
    - #[cfg(unix)] use std::cell::Cell;
    - use std::cell::RefCell;
  - This avoids unused-import compilation errors on non-Unix targets and preserves required imports on Unix

## Rationale
- The unconditional import of Cell caused a compilation error on some targets due to it being unused in certain configurations. Selecting the import with #[cfg(unix)] fixes the cross-platform build issue.
- Centralizing CLI output retrieval in a helper improves test readability and reduces boilerplate in multiple assertions.

## Test plan
- Run cargo test on Unix and non-Unix targets to ensure the platform-specific imports compile cleanly
- Verify that behaviour_cli tests pass and behaviour_staging builds across platforms
- Specifically, confirm CLI tests use get_output for output extraction and no longer rely on repeated borrow/unwraps

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a75c78b8-58f3-4cd2-a037-49993aa283a4

## Summary by Sourcery

Improve CLI test ergonomics and fix a platform-specific import issue in staging tests.

New Features:
- Add a reusable helper to retrieve CLI command output in tests for simpler and clearer assertions.

Bug Fixes:
- Gate the Cell import in staging tests behind a Unix-specific cfg to avoid unused-import compilation errors on non-Unix targets.

Tests:
- Refactor CLI behaviour tests to use the shared output helper instead of duplicating borrow and unwrap logic.