### PR TITLE
Document binstall release requirements

### DIFF
--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -1333,7 +1333,7 @@ not want to compile from source. Matching the default binstall naming and
 layout keeps configuration minimal and reduces release automation complexity.
 Because cargo-binstall resolves the latest version from crates.io, every
 published version must have a corresponding GitHub Release with matching
-assets, otherwise `cargo binstall` will fail for the most recent version.
+assets; otherwise `cargo binstall` will fail for the most recent version.
 
 **Release workflow requirements:**
 


### PR DESCRIPTION
Clarify that cargo-binstall resolves versions via crates.io, so GitHub releases must exist for every published version. Add an explicit metadata template for pkg-url and bin-dir, including the Windows archive override and placeholder usage.

## Summary by Sourcery

Document cargo-binstall release and metadata requirements for the whitaker installer.

Documentation:
- Clarify that every crates.io-published version of whitaker-installer must have a matching GitHub Release with corresponding assets for cargo-binstall to work.
- Add an explicit cargo-binstall metadata template illustrating pkg-url, bin-dir, pkg-fmt, and Windows-specific archive overrides, including placeholder usage.