### PR TITLE
Add UI tests for locale fallbacks (default, Welsh, and unsupported)

### DIFF
--- a/crates/module_must_have_inner_docs/src/tests/ui.rs
+++ b/crates/module_must_have_inner_docs/src/tests/ui.rs
@@ -2,29 +2,31 @@
 //! English and Welsh locales.
 
 use common::test_support::LocaleOverride;
+use rstest::rstest;
 use serial_test::serial;
 
-#[test]
+/// Runs UI regression tests for the `module_must_have_inner_docs` lint under
+/// different locale configurations, verifying that diagnostics render correctly.
+///
+/// # Cases
+///
+/// - `default_locale`: Uses the default English locale (`"ui"` fixtures, `None`).
+/// - `welsh_locale`: Uses Welsh localisation (`"ui-cy"` fixtures, `Some("cy")`).
+/// - `unsupported_locale_falls_back_to_english`: Uses an unsupported locale
+///   (`"xx-YY"`), expecting fallback to English (`"ui"` fixtures).
+///
+/// # Example
+///
+/// ```ignore
+/// // Default locale case: matches "ui" baselines with no locale override.
+/// ui_tests_across_locales("ui", None);
+/// ```
+#[rstest]
+#[case::default_locale("ui", None)]
+#[case::welsh_locale("ui-cy", Some("cy"))]
+#[case::unsupported_locale_falls_back_to_english("ui", Some("xx-YY"))]
 #[serial]
-fn ui() {
-    run_ui_with_locale("ui", None);
-}
-
-#[test]
-#[serial]
-fn ui_runs_in_welsh_locale() {
-    run_ui_with_locale("ui-cy", Some("cy"));
-}
-
-#[test]
-#[serial]
-fn ui_falls_back_to_english_for_unsupported_locale() {
-    // Use an obviously unsupported locale; diagnostics should still render,
-    // implicitly falling back to English and matching the "ui" baselines.
-    run_ui_with_locale("ui", Some("xx-YY"));
-}
-
-fn run_ui_with_locale(directory: &str, locale: Option<&str>) {
+fn ui_tests_across_locales(#[case] directory: &str, #[case] locale: Option<&str>) {
     let _guard = locale.map(LocaleOverride::set);
     whitaker::run_ui_tests!(directory).expect("UI tests should execute without diffs");
 }


### PR DESCRIPTION
## Summary
- Rework tests/ui.rs to parameterize across locales via rstest: ui_tests_across_locales(directory, locale) with cases:
  - default_locale("ui", None)
  - welsh_locale("ui-cy", Some("cy"))
  - unsupported_locale_falls_back_to_english("ui", Some("xx-YY"))
- Removed separate ui_runs_in_welsh_locale test; replaced with parameterized approach
- Applies #[serial] to guard UI tests from parallel execution
- Welsh locale verification remains included as part of the parameterized suite

## Changes
- Update tests/ui.rs to implement a single parameterized UI test function
- Introduce ui_tests_across_locales(directory: &str, locale: Option<&str>) with #[case] variations
- Remove the separate welsh-only test
- Keep diagnostics/UI baseline diffs deterministic by selecting an obviously unsupported locale

## Test plan
- [x] Run UI tests for the module_must_have_inner_docs crate
- [x] Verify the parameterized test passes and diffs are clean
- [x] Confirm English fallback occurs for an obviously unsupported locale
- [x] Ensure Welsh locale case continues to verify Welsh rendering

## Notes
- This test ensures deterministic baselines by selecting clearly invalid locale, preventing accidental false positives from other locale configurations.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---
ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/164fb130-afbf-4650-a4ba-73e6e50477b7

📝 Closes #68

## Summary by Sourcery

Tests:
- Add a UI test that runs with obviously unsupported locale and asserts diagnostics match the English UI baselines.
