### PR TITLE
Avoid lint false positives by marking unknown snippet failures

### DIFF
--- a/crates/module_must_have_inner_docs/src/driver.rs
+++ b/crates/module_must_have_inner_docs/src/driver.rs
@@ -242,6 +242,11 @@ fn detect_module_docs_in_span(source_map: &SourceMap, module_body: Span) -> Modu
     }
 }
 
+/// Maps a module doc disposition to the primary diagnostic span.
+///
+/// Returns `None` for `HasLeadingDoc` and `Unknown`,
+/// `Some(module_body.shrink_to_lo())` for `MissingDocs`, and `Some(span)` for
+/// `FirstInnerIsNotDoc(span)`.
 fn primary_span_for_disposition(
     disposition: ModuleDocDisposition,
     module_body: Span,

--- a/crates/module_must_have_inner_docs/src/tests/span_to_snippet.rs
+++ b/crates/module_must_have_inner_docs/src/tests/span_to_snippet.rs
@@ -1,20 +1,21 @@
 //! Span-to-snippet tests for module doc detection fallbacks.
 
 use super::{ModuleDocDisposition, detect_module_docs_in_span, primary_span_for_disposition};
+use rstest::{fixture, rstest};
 use rustc_span::source_map::{FilePathMapping, SourceMap};
 use rustc_span::{FileName, Span};
 
-#[test]
-fn span_to_snippet_failure_returns_unknown() {
-    let (source_map, span) = unresolvable_span();
+#[rstest]
+fn span_to_snippet_failure_returns_unknown(unresolvable_span_fixture: (SourceMap, Span)) {
+    let (source_map, span) = unresolvable_span_fixture;
     let disposition = detect_module_docs_in_span(&source_map, span);
 
     assert_eq!(disposition, ModuleDocDisposition::Unknown);
 }
 
-#[test]
-fn span_to_snippet_failure_skips_diagnostic() {
-    let (source_map, span) = unresolvable_span();
+#[rstest]
+fn span_to_snippet_failure_skips_diagnostic(unresolvable_span_fixture: (SourceMap, Span)) {
+    let (source_map, span) = unresolvable_span_fixture;
     let disposition = detect_module_docs_in_span(&source_map, span);
 
     assert_eq!(disposition, ModuleDocDisposition::Unknown);
@@ -24,6 +25,14 @@ fn span_to_snippet_failure_skips_diagnostic() {
     );
 }
 
+#[fixture]
+fn unresolvable_span_fixture() -> (SourceMap, Span) {
+    unresolvable_span()
+}
+
+/// Builds a cross-file span (start in "first.rs", end in "second.rs") with the
+/// root context so the `SourceMap` cannot resolve it to a single file. This
+/// deliberate edge case exercises the snippet resolution failure path.
 fn unresolvable_span() -> (SourceMap, Span) {
     let source_map = SourceMap::new(FilePathMapping::empty());
     let first =


### PR DESCRIPTION
## Summary
- Fix false positive lint on module docs by gracefully handling unknown snippet failures
- Introduces an Unknown variant to represent unresolved spans and skip analysis when needed

## Changes
### Core Logic
- Treat ModuleDocDisposition::Unknown the same as ModuleDocDisposition::HasLeadingDoc for early returns in the lint pass
- Extend ModuleDocDisposition with an Unknown variant and accompanying documentation
- When span_to_snippet fails, return ModuleDocDisposition::Unknown instead of MissingDocs

### Behavior
- Lint will skip analysis for modules whose source cannot be inspected (e.g., macro-expanded or generated code with unresolved spans), preventing false positives

### Rationale
- Previously, failures to obtain a snippet would yield a MissingDocs result, which could trigger a false positive lint. By introducing Unknown and skipping such cases, we avoid reporting spurious diagnostics and improve reliability on generated or transformed code

### Tests
- [x] Run the existing lint/test suite to ensure no regressions on normal code paths
- [x] Add unit/integration tests that simulate an Unknown path (span_to_snippet failure) to verify the lint skips reporting in that scenario
- [x] Validate that typical modules with proper inner docs still report correctly
- [x] Added span_to_snippet unit test to verify Unknown is returned when snippet resolution fails

📎 **Task**: https://www.devboxer.com/task/efb81653-c7a4-4de4-9e75-6cc690ed868e

Closes #65