### PR TITLE
Fix rolling-release lint build prerequisites

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -72,7 +72,12 @@ jobs:
           set -euxo pipefail
           TOOLCHAIN="${{ steps.toolchain.outputs.channel }}"
           rustup target add --toolchain "${TOOLCHAIN}" "${{ matrix.target }}"
-          rustup component add --toolchain "${TOOLCHAIN}" rust-src rustc-dev llvm-tools-preview
+          HOST_TARGET="$(rustc "+${TOOLCHAIN}" -vV | awk -F ': ' '/host:/ {print $2}')"
+          rustup component add --toolchain "${TOOLCHAIN}" rust-src
+          rustup component add --toolchain "${TOOLCHAIN}" --target "${HOST_TARGET}" rustc-dev llvm-tools-preview
+          if [ "${HOST_TARGET}" != "${{ matrix.target }}" ]; then
+            rustup component add --toolchain "${TOOLCHAIN}" --target "${{ matrix.target }}" rustc-dev llvm-tools-preview
+          fi
 
       - name: Build lint crates
         run: |

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -145,7 +145,7 @@ def lint_crates_from_resolution_constants() -> list[str]:
     """
     source = RESOLUTION_PATH.read_text(encoding="utf-8")
     lint_match = re.search(
-        r"pub const LINT_CRATES: &\[&str\] = &\[(.*?)\];",
+        r"pub(?:\(crate\))?\s+const\s+LINT_CRATES\s*:\s*&\[\s*&str\s*\]\s*=\s*&\[(.*?)\];",
         source,
         flags=re.DOTALL,
     )
@@ -153,9 +153,12 @@ def lint_crates_from_resolution_constants() -> list[str]:
     lint_crates = re.findall(r'"([^"]+)"', lint_match.group(1))
     assert lint_crates, f"{RESOLUTION_PATH} LINT_CRATES is unexpectedly empty"
 
-    suite_match = re.search(r'pub const SUITE_CRATE: &str = "([^"]+)";', source)
+    suite_match = re.search(
+        r'pub(?:\(crate\))?\s+const\s+SUITE_CRATE\s*:\s*&str\s*=\s*"([^"]+)";',
+        source,
+    )
     assert suite_match, f"unable to parse SUITE_CRATE from {RESOLUTION_PATH}"
-    return lint_crates + [suite_match.group(1)]
+    return [*lint_crates, suite_match.group(1)]
 
 
 def workspace_package_names() -> set[str]:
@@ -300,6 +303,8 @@ def test_workflow_lint_crates_match_installer_constants() -> None:
     """
     workflow_crates = lint_crates_from_workflow()
     canonical_crates = lint_crates_from_resolution_constants()
+    # Ordering is part of this contract: both definitions should evolve in lock-step
+    # for deterministic build logs and packaging expectations.
     assert workflow_crates == canonical_crates, (
         "rolling-release workflow LINT_CRATES drifted from installer constants:\n"
         f"workflow={workflow_crates}\n"


### PR DESCRIPTION
Align the workflow lint crate list with installer canonical constants so package artefact discovery does not fail on missing libraries.

Install pinned nightly components (rust-src, rustc-dev, llvm-tools-preview) for each matrix target before building dylint-driver crates, which fixes missing rustc_* crate failures on\naarch64 Linux.

Add failure-only diagnostics for build/package stages and a workflow contract test that compares workflow LINT_CRATES to installer/src/resolution.rs to prevent future drift.

## Summary by Sourcery

Align rolling-release lint workflow prerequisites with installer crate definitions and ensure builds succeed across targets with better diagnostics.

Bug Fixes:
- Install pinned nightly toolchain components for each matrix target to prevent missing rustc_* crate failures in lint crate builds.
- Update the workflow lint crate list to match installer resolution constants so package artefact discovery does not fail on missing libraries.

Enhancements:
- Add workflow diagnostics steps that run only on failure for lint crate builds and packaging stages.
- Introduce a contract test that enforces parity between workflow LINT_CRATES and installer resolution constants.