### PR TITLE
Add shared rstest detection module and public APIs (8.1.1)

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = { workspace = true }
 unic-langid = { workspace = true }
 
 [dev-dependencies]
-# Testing: Behavioural specs use rstest-bdd 0.2.x (workspace pin). Capture any
+# Testing: Behavioural specs use rstest-bdd 0.5.x (workspace pin). Capture any
 # regressions with `make test` and coordinate with the maintainers per
 # `docs/rstest-bdd-users-guide.md` before gating behaviour tests or backporting
 # fixes.

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod expr;
 pub mod i18n;
 pub mod lcom4;
 pub mod path;
+pub mod rstest;
 pub mod span;
 pub mod test_support;
 
@@ -53,4 +54,9 @@ pub use i18n::{
 };
 pub use lcom4::{MethodInfo, MethodInfoBuilder, cohesion_components, collect_method_infos};
 pub use path::SimplePath;
+pub use rstest::{
+    ExpansionTrace, ParameterBinding, RstestDetectionOptions, RstestParameter, RstestParameterKind,
+    classify_rstest_parameter, fixture_local_names, is_rstest_fixture, is_rstest_fixture_with,
+    is_rstest_test, is_rstest_test_with,
+};
 pub use span::{SourceLocation, SourceSpan, SpanError, span_line_count, span_to_lines};

--- a/common/src/rstest/detection.rs
+++ b/common/src/rstest/detection.rs
@@ -30,8 +30,8 @@ impl ExpansionTrace {
     /// # Examples
     ///
     /// ```
-    /// use common::attributes::AttributePath;
-    /// use common::rstest::ExpansionTrace;
+    /// use whitaker_common::attributes::AttributePath;
+    /// use whitaker_common::rstest::ExpansionTrace;
     ///
     /// let trace = ExpansionTrace::new([AttributePath::from("rstest")]);
     /// assert_eq!(trace.frames(), &[AttributePath::from("rstest")]);
@@ -66,8 +66,8 @@ impl RstestDetectionOptions {
     /// # Examples
     ///
     /// ```
-    /// use common::attributes::AttributePath;
-    /// use common::rstest::RstestDetectionOptions;
+    /// use whitaker_common::attributes::AttributePath;
+    /// use whitaker_common::rstest::RstestDetectionOptions;
     ///
     /// let options = RstestDetectionOptions::new(
     ///     vec![AttributePath::from("case"), AttributePath::from("rstest::case")],
@@ -117,8 +117,8 @@ impl Default for RstestDetectionOptions {
 /// # Examples
 ///
 /// ```
-/// use common::attributes::{Attribute, AttributeKind, AttributePath};
-/// use common::rstest::is_rstest_test;
+/// use whitaker_common::attributes::{Attribute, AttributeKind, AttributePath};
+/// use whitaker_common::rstest::is_rstest_test;
 ///
 /// let attrs = vec![Attribute::new(AttributePath::from("rstest"), AttributeKind::Outer)];
 /// assert!(is_rstest_test(&attrs));
@@ -134,8 +134,8 @@ pub fn is_rstest_test(attrs: &[Attribute]) -> bool {
 /// # Examples
 ///
 /// ```
-/// use common::attributes::{Attribute, AttributeKind, AttributePath};
-/// use common::rstest::{ExpansionTrace, RstestDetectionOptions, is_rstest_test_with};
+/// use whitaker_common::attributes::{Attribute, AttributeKind, AttributePath};
+/// use whitaker_common::rstest::{ExpansionTrace, RstestDetectionOptions, is_rstest_test_with};
 ///
 /// let attrs = vec![Attribute::new(AttributePath::from("allow"), AttributeKind::Outer)];
 /// let trace = ExpansionTrace::new([AttributePath::from("rstest")]);
@@ -157,8 +157,8 @@ pub fn is_rstest_test_with(
 /// # Examples
 ///
 /// ```
-/// use common::attributes::{Attribute, AttributeKind, AttributePath};
-/// use common::rstest::is_rstest_fixture;
+/// use whitaker_common::attributes::{Attribute, AttributeKind, AttributePath};
+/// use whitaker_common::rstest::is_rstest_fixture;
 ///
 /// let attrs = vec![Attribute::new(AttributePath::from("fixture"), AttributeKind::Outer)];
 /// assert!(is_rstest_fixture(&attrs));
@@ -174,8 +174,8 @@ pub fn is_rstest_fixture(attrs: &[Attribute]) -> bool {
 /// # Examples
 ///
 /// ```
-/// use common::attributes::{Attribute, AttributeKind, AttributePath};
-/// use common::rstest::{ExpansionTrace, RstestDetectionOptions, is_rstest_fixture_with};
+/// use whitaker_common::attributes::{Attribute, AttributeKind, AttributePath};
+/// use whitaker_common::rstest::{ExpansionTrace, RstestDetectionOptions, is_rstest_fixture_with};
 ///
 /// let attrs = vec![Attribute::new(AttributePath::from("allow"), AttributeKind::Outer)];
 /// let trace = ExpansionTrace::new([AttributePath::from("rstest::fixture")]);

--- a/common/src/rstest/detection.rs
+++ b/common/src/rstest/detection.rs
@@ -1,0 +1,222 @@
+//! Pure detection helpers for strict `rstest` tests and fixtures.
+
+use crate::attributes::{Attribute, AttributePath};
+
+const RSTEST_TEST_PATHS: &[&[&str]] = &[&["rstest"], &["rstest", "rstest"]];
+const RSTEST_FIXTURE_PATHS: &[&[&str]] = &[&["fixture"], &["rstest", "fixture"]];
+const DEFAULT_PROVIDER_ATTRIBUTE_PATHS: &[&[&str]] = &[
+    &["case"],
+    &["rstest", "case"],
+    &["values"],
+    &["rstest", "values"],
+    &["files"],
+    &["rstest", "files"],
+    &["future"],
+    &["rstest", "future"],
+    &["context"],
+    &["rstest", "context"],
+];
+
+/// Optional macro-expansion metadata used as a conservative fallback when
+/// direct attributes are not available.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ExpansionTrace {
+    frames: Vec<AttributePath>,
+}
+
+impl ExpansionTrace {
+    /// Builds an expansion trace from attribute-like path frames.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use common::attributes::AttributePath;
+    /// use common::rstest::ExpansionTrace;
+    ///
+    /// let trace = ExpansionTrace::new([AttributePath::from("rstest")]);
+    /// assert_eq!(trace.frames(), &[AttributePath::from("rstest")]);
+    /// ```
+    #[must_use]
+    pub fn new<I>(frames: I) -> Self
+    where
+        I: IntoIterator<Item = AttributePath>,
+    {
+        Self {
+            frames: frames.into_iter().collect(),
+        }
+    }
+
+    /// Returns the stored expansion frames.
+    #[must_use]
+    pub fn frames(&self) -> &[AttributePath] {
+        &self.frames
+    }
+}
+
+/// Runtime options for strict `rstest` detection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RstestDetectionOptions {
+    provider_param_attributes: Vec<AttributePath>,
+    use_expansion_trace_fallback: bool,
+}
+
+impl RstestDetectionOptions {
+    /// Builds detection options from explicit values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use common::attributes::AttributePath;
+    /// use common::rstest::RstestDetectionOptions;
+    ///
+    /// let options = RstestDetectionOptions::new(
+    ///     vec![AttributePath::from("case"), AttributePath::from("rstest::case")],
+    ///     true,
+    /// );
+    /// assert!(options.use_expansion_trace_fallback());
+    /// ```
+    #[must_use]
+    pub fn new(
+        provider_param_attributes: Vec<AttributePath>,
+        use_expansion_trace_fallback: bool,
+    ) -> Self {
+        Self {
+            provider_param_attributes,
+            use_expansion_trace_fallback,
+        }
+    }
+
+    /// Returns the configured provider-parameter attribute paths.
+    #[must_use]
+    pub fn provider_param_attributes(&self) -> &[AttributePath] {
+        &self.provider_param_attributes
+    }
+
+    /// Returns whether expansion-trace fallback is enabled.
+    #[must_use]
+    pub const fn use_expansion_trace_fallback(&self) -> bool {
+        self.use_expansion_trace_fallback
+    }
+}
+
+impl Default for RstestDetectionOptions {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_PROVIDER_ATTRIBUTE_PATHS
+                .iter()
+                .map(|path| AttributePath::new(path.iter().copied()))
+                .collect(),
+            false,
+        )
+    }
+}
+
+/// Returns `true` when the attributes mark a function as a strict `rstest`
+/// test.
+///
+/// # Examples
+///
+/// ```
+/// use common::attributes::{Attribute, AttributeKind, AttributePath};
+/// use common::rstest::is_rstest_test;
+///
+/// let attrs = vec![Attribute::new(AttributePath::from("rstest"), AttributeKind::Outer)];
+/// assert!(is_rstest_test(&attrs));
+/// ```
+#[must_use]
+pub fn is_rstest_test(attrs: &[Attribute]) -> bool {
+    has_matching_attribute(attrs, RSTEST_TEST_PATHS)
+}
+
+/// Returns `true` when a function is a strict `rstest` test, optionally
+/// consulting expansion-trace metadata.
+///
+/// # Examples
+///
+/// ```
+/// use common::attributes::{Attribute, AttributeKind, AttributePath};
+/// use common::rstest::{ExpansionTrace, RstestDetectionOptions, is_rstest_test_with};
+///
+/// let attrs = vec![Attribute::new(AttributePath::from("allow"), AttributeKind::Outer)];
+/// let trace = ExpansionTrace::new([AttributePath::from("rstest")]);
+/// let options = RstestDetectionOptions::new(Vec::new(), true);
+/// assert!(is_rstest_test_with(&attrs, Some(&trace), &options));
+/// ```
+#[must_use]
+pub fn is_rstest_test_with(
+    attrs: &[Attribute],
+    trace: Option<&ExpansionTrace>,
+    options: &RstestDetectionOptions,
+) -> bool {
+    matches_direct_or_trace(attrs, trace, options, RSTEST_TEST_PATHS)
+}
+
+/// Returns `true` when the attributes mark a function as a strict `rstest`
+/// fixture.
+///
+/// # Examples
+///
+/// ```
+/// use common::attributes::{Attribute, AttributeKind, AttributePath};
+/// use common::rstest::is_rstest_fixture;
+///
+/// let attrs = vec![Attribute::new(AttributePath::from("fixture"), AttributeKind::Outer)];
+/// assert!(is_rstest_fixture(&attrs));
+/// ```
+#[must_use]
+pub fn is_rstest_fixture(attrs: &[Attribute]) -> bool {
+    has_matching_attribute(attrs, RSTEST_FIXTURE_PATHS)
+}
+
+/// Returns `true` when a function is a strict `rstest` fixture, optionally
+/// consulting expansion-trace metadata.
+///
+/// # Examples
+///
+/// ```
+/// use common::attributes::{Attribute, AttributeKind, AttributePath};
+/// use common::rstest::{ExpansionTrace, RstestDetectionOptions, is_rstest_fixture_with};
+///
+/// let attrs = vec![Attribute::new(AttributePath::from("allow"), AttributeKind::Outer)];
+/// let trace = ExpansionTrace::new([AttributePath::from("rstest::fixture")]);
+/// let options = RstestDetectionOptions::new(Vec::new(), true);
+/// assert!(is_rstest_fixture_with(&attrs, Some(&trace), &options));
+/// ```
+#[must_use]
+pub fn is_rstest_fixture_with(
+    attrs: &[Attribute],
+    trace: Option<&ExpansionTrace>,
+    options: &RstestDetectionOptions,
+) -> bool {
+    matches_direct_or_trace(attrs, trace, options, RSTEST_FIXTURE_PATHS)
+}
+
+fn matches_direct_or_trace(
+    attrs: &[Attribute],
+    trace: Option<&ExpansionTrace>,
+    options: &RstestDetectionOptions,
+    candidates: &[&[&str]],
+) -> bool {
+    has_matching_attribute(attrs, candidates)
+        || (options.use_expansion_trace_fallback()
+            && trace.is_some_and(|trace| has_matching_trace(trace, candidates)))
+}
+
+fn has_matching_attribute(attrs: &[Attribute], candidates: &[&[&str]]) -> bool {
+    attrs
+        .iter()
+        .any(|attribute| path_matches_candidates(attribute.path(), candidates))
+}
+
+fn has_matching_trace(trace: &ExpansionTrace, candidates: &[&[&str]]) -> bool {
+    trace
+        .frames()
+        .iter()
+        .any(|frame| path_matches_candidates(frame, candidates))
+}
+
+fn path_matches_candidates(path: &AttributePath, candidates: &[&[&str]]) -> bool {
+    candidates
+        .iter()
+        .any(|candidate| path.matches(candidate.iter().copied()))
+}

--- a/common/src/rstest/mod.rs
+++ b/common/src/rstest/mod.rs
@@ -1,0 +1,16 @@
+//! Shared helpers for strict `rstest` test, fixture, and parameter detection.
+
+mod detection;
+mod parameter;
+
+pub use detection::{
+    ExpansionTrace, RstestDetectionOptions, is_rstest_fixture, is_rstest_fixture_with,
+    is_rstest_test, is_rstest_test_with,
+};
+pub use parameter::{
+    ParameterBinding, RstestParameter, RstestParameterKind, classify_rstest_parameter,
+    fixture_local_names,
+};
+
+#[cfg(test)]
+mod tests;

--- a/common/src/rstest/parameter.rs
+++ b/common/src/rstest/parameter.rs
@@ -1,0 +1,183 @@
+//! Pure parameter classification helpers for `rstest`-driven functions.
+
+use super::RstestDetectionOptions;
+use crate::attributes::Attribute;
+use std::collections::BTreeSet;
+
+/// Represents the supported parameter binding shapes for version-one `rstest`
+/// classification.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ParameterBinding {
+    /// A simple identifier binding such as `db`.
+    Ident(String),
+    /// Any unsupported pattern, such as destructuring.
+    Unsupported,
+}
+
+/// Simplified metadata for a function parameter.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RstestParameter {
+    binding: ParameterBinding,
+    attributes: Vec<Attribute>,
+}
+
+impl RstestParameter {
+    /// Builds a parameter from a binding and its attributes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use common::attributes::{Attribute, AttributeKind, AttributePath};
+    /// use common::rstest::{ParameterBinding, RstestParameter};
+    ///
+    /// let parameter = RstestParameter::new(
+    ///     ParameterBinding::Ident("db".to_string()),
+    ///     vec![Attribute::new(AttributePath::from("case"), AttributeKind::Outer)],
+    /// );
+    /// assert_eq!(parameter.attributes().len(), 1);
+    /// ```
+    #[must_use]
+    pub fn new(binding: ParameterBinding, attributes: Vec<Attribute>) -> Self {
+        Self {
+            binding,
+            attributes,
+        }
+    }
+
+    /// Builds a simple identifier-backed parameter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use common::rstest::RstestParameter;
+    ///
+    /// let parameter = RstestParameter::ident("db");
+    /// assert_eq!(parameter.binding_name(), Some("db"));
+    /// ```
+    #[must_use]
+    pub fn ident(name: impl Into<String>) -> Self {
+        Self::new(ParameterBinding::Ident(name.into()), Vec::new())
+    }
+
+    /// Builds an unsupported-pattern parameter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use common::rstest::RstestParameter;
+    ///
+    /// let parameter = RstestParameter::unsupported();
+    /// assert_eq!(parameter.binding_name(), None);
+    /// ```
+    #[must_use]
+    pub fn unsupported() -> Self {
+        Self::new(ParameterBinding::Unsupported, Vec::new())
+    }
+
+    /// Returns the binding metadata.
+    #[must_use]
+    pub const fn binding(&self) -> &ParameterBinding {
+        &self.binding
+    }
+
+    /// Returns the parameter attributes.
+    #[must_use]
+    pub fn attributes(&self) -> &[Attribute] {
+        &self.attributes
+    }
+
+    /// Returns the identifier binding name when available.
+    #[must_use]
+    pub fn binding_name(&self) -> Option<&str> {
+        match &self.binding {
+            ParameterBinding::Ident(name) => Some(name),
+            ParameterBinding::Unsupported => None,
+        }
+    }
+}
+
+/// Classification outcome for an `rstest` parameter.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RstestParameterKind {
+    /// A fixture-local identifier binding.
+    FixtureLocal { name: String },
+    /// A provider-driven input such as `#[case]` or `#[values]`.
+    Provider,
+    /// A binding shape that version one does not support.
+    UnsupportedPattern,
+}
+
+/// Classifies a simplified `rstest` parameter for fixture extraction logic.
+///
+/// # Examples
+///
+/// ```
+/// use common::attributes::{Attribute, AttributeKind, AttributePath};
+/// use common::rstest::{
+///     RstestDetectionOptions, RstestParameter, RstestParameterKind, classify_rstest_parameter,
+/// };
+///
+/// let parameter = RstestParameter::new(
+///     common::rstest::ParameterBinding::Ident("db".to_string()),
+///     vec![Attribute::new(AttributePath::from("case"), AttributeKind::Outer)],
+/// );
+/// let kind = classify_rstest_parameter(&parameter, &RstestDetectionOptions::default());
+/// assert_eq!(kind, RstestParameterKind::Provider);
+/// ```
+#[must_use]
+pub fn classify_rstest_parameter(
+    parameter: &RstestParameter,
+    options: &RstestDetectionOptions,
+) -> RstestParameterKind {
+    match parameter.binding() {
+        ParameterBinding::Ident(name) => {
+            if parameter_has_provider_attribute(parameter.attributes(), options) {
+                RstestParameterKind::Provider
+            } else {
+                RstestParameterKind::FixtureLocal { name: name.clone() }
+            }
+        }
+        ParameterBinding::Unsupported => RstestParameterKind::UnsupportedPattern,
+    }
+}
+
+/// Collects supported fixture-local parameter names in deterministic order.
+///
+/// # Examples
+///
+/// ```
+/// use common::rstest::{RstestDetectionOptions, RstestParameter, fixture_local_names};
+///
+/// let parameters = vec![RstestParameter::ident("db"), RstestParameter::ident("clock")];
+/// let names = fixture_local_names(&parameters, &RstestDetectionOptions::default());
+/// assert!(names.contains("db"));
+/// assert!(names.contains("clock"));
+/// ```
+#[must_use]
+pub fn fixture_local_names(
+    parameters: &[RstestParameter],
+    options: &RstestDetectionOptions,
+) -> BTreeSet<String> {
+    parameters
+        .iter()
+        .filter_map(
+            |parameter| match classify_rstest_parameter(parameter, options) {
+                RstestParameterKind::FixtureLocal { name } => Some(name),
+                RstestParameterKind::Provider | RstestParameterKind::UnsupportedPattern => None,
+            },
+        )
+        .collect()
+}
+
+fn parameter_has_provider_attribute(
+    attributes: &[Attribute],
+    options: &RstestDetectionOptions,
+) -> bool {
+    attributes.iter().any(|attribute| {
+        options.provider_param_attributes().iter().any(|candidate| {
+            attribute
+                .path()
+                .matches(candidate.segments().iter().map(String::as_str))
+        })
+    })
+}

--- a/common/src/rstest/parameter.rs
+++ b/common/src/rstest/parameter.rs
@@ -27,8 +27,8 @@ impl RstestParameter {
     /// # Examples
     ///
     /// ```
-    /// use common::attributes::{Attribute, AttributeKind, AttributePath};
-    /// use common::rstest::{ParameterBinding, RstestParameter};
+    /// use whitaker_common::attributes::{Attribute, AttributeKind, AttributePath};
+    /// use whitaker_common::rstest::{ParameterBinding, RstestParameter};
     ///
     /// let parameter = RstestParameter::new(
     ///     ParameterBinding::Ident("db".to_string()),
@@ -49,7 +49,7 @@ impl RstestParameter {
     /// # Examples
     ///
     /// ```
-    /// use common::rstest::RstestParameter;
+    /// use whitaker_common::rstest::RstestParameter;
     ///
     /// let parameter = RstestParameter::ident("db");
     /// assert_eq!(parameter.binding_name(), Some("db"));
@@ -64,7 +64,7 @@ impl RstestParameter {
     /// # Examples
     ///
     /// ```
-    /// use common::rstest::RstestParameter;
+    /// use whitaker_common::rstest::RstestParameter;
     ///
     /// let parameter = RstestParameter::unsupported();
     /// assert_eq!(parameter.binding_name(), None);
@@ -112,13 +112,13 @@ pub enum RstestParameterKind {
 /// # Examples
 ///
 /// ```
-/// use common::attributes::{Attribute, AttributeKind, AttributePath};
-/// use common::rstest::{
+/// use whitaker_common::attributes::{Attribute, AttributeKind, AttributePath};
+/// use whitaker_common::rstest::{
 ///     RstestDetectionOptions, RstestParameter, RstestParameterKind, classify_rstest_parameter,
 /// };
 ///
 /// let parameter = RstestParameter::new(
-///     common::rstest::ParameterBinding::Ident("db".to_string()),
+///     whitaker_common::rstest::ParameterBinding::Ident("db".to_string()),
 ///     vec![Attribute::new(AttributePath::from("case"), AttributeKind::Outer)],
 /// );
 /// let kind = classify_rstest_parameter(&parameter, &RstestDetectionOptions::default());
@@ -146,7 +146,7 @@ pub fn classify_rstest_parameter(
 /// # Examples
 ///
 /// ```
-/// use common::rstest::{RstestDetectionOptions, RstestParameter, fixture_local_names};
+/// use whitaker_common::rstest::{RstestDetectionOptions, RstestParameter, fixture_local_names};
 ///
 /// let parameters = vec![RstestParameter::ident("db"), RstestParameter::ident("clock")];
 /// let names = fixture_local_names(&parameters, &RstestDetectionOptions::default());

--- a/common/src/rstest/tests.rs
+++ b/common/src/rstest/tests.rs
@@ -1,0 +1,134 @@
+//! Unit tests for strict `rstest` detection helpers.
+
+use super::{
+    ExpansionTrace, ParameterBinding, RstestDetectionOptions, RstestParameter, RstestParameterKind,
+    classify_rstest_parameter, fixture_local_names, is_rstest_fixture, is_rstest_fixture_with,
+    is_rstest_test, is_rstest_test_with,
+};
+use crate::attributes::{Attribute, AttributeKind, AttributePath};
+use rstest::rstest;
+use std::collections::BTreeSet;
+
+fn outer(path: &str) -> Attribute {
+    Attribute::new(AttributePath::from(path), AttributeKind::Outer)
+}
+
+fn provider_parameter(path: &str) -> RstestParameter {
+    RstestParameter::new(
+        ParameterBinding::Ident("value".to_string()),
+        vec![outer(path)],
+    )
+}
+
+#[rstest]
+#[case::rstest("rstest", true)]
+#[case::qualified("rstest::rstest", true)]
+#[case::plain_test("test", false)]
+#[case::tokio("tokio::test", false)]
+#[case::case("case", false)]
+#[case::fixture("rstest::fixture", false)]
+fn detects_strict_rstest_tests(#[case] path: &str, #[case] expected: bool) {
+    assert_eq!(is_rstest_test(&[outer(path)]), expected);
+}
+
+#[rstest]
+#[case::fixture("fixture", true)]
+#[case::qualified("rstest::fixture", true)]
+#[case::rstest("rstest", false)]
+#[case::other("allow", false)]
+fn detects_strict_rstest_fixtures(#[case] path: &str, #[case] expected: bool) {
+    assert_eq!(is_rstest_fixture(&[outer(path)]), expected);
+}
+
+#[rstest]
+fn classifies_identifier_parameters_as_fixture_locals() {
+    let parameter = RstestParameter::ident("db");
+
+    assert_eq!(
+        classify_rstest_parameter(&parameter, &RstestDetectionOptions::default()),
+        RstestParameterKind::FixtureLocal {
+            name: "db".to_string()
+        }
+    );
+}
+
+#[rstest]
+#[case("case")]
+#[case("rstest::case")]
+#[case("values")]
+#[case("rstest::values")]
+#[case("files")]
+#[case("rstest::files")]
+#[case("future")]
+#[case("rstest::future")]
+#[case("context")]
+#[case("rstest::context")]
+fn classifies_provider_parameters(#[case] path: &str) {
+    let parameter = provider_parameter(path);
+
+    assert_eq!(
+        classify_rstest_parameter(&parameter, &RstestDetectionOptions::default()),
+        RstestParameterKind::Provider
+    );
+}
+
+#[rstest]
+fn rejects_unsupported_parameter_patterns() {
+    let parameter = RstestParameter::unsupported();
+
+    assert_eq!(
+        classify_rstest_parameter(&parameter, &RstestDetectionOptions::default()),
+        RstestParameterKind::UnsupportedPattern
+    );
+}
+
+#[rstest]
+fn ignores_trace_when_fallback_is_disabled() {
+    let trace = ExpansionTrace::new([AttributePath::from("rstest")]);
+
+    assert!(!is_rstest_test_with(
+        &[outer("allow")],
+        Some(&trace),
+        &RstestDetectionOptions::default(),
+    ));
+}
+
+#[rstest]
+fn honours_test_trace_when_fallback_is_enabled() {
+    let trace = ExpansionTrace::new([AttributePath::from("rstest")]);
+    let options = RstestDetectionOptions::new(Vec::new(), true);
+
+    assert!(is_rstest_test_with(
+        &[outer("allow")],
+        Some(&trace),
+        &options
+    ));
+}
+
+#[rstest]
+fn honours_fixture_trace_when_fallback_is_enabled() {
+    let trace = ExpansionTrace::new([AttributePath::from("fixture")]);
+    let options = RstestDetectionOptions::new(Vec::new(), true);
+
+    assert!(is_rstest_fixture_with(
+        &[outer("allow")],
+        Some(&trace),
+        &options,
+    ));
+}
+
+#[rstest]
+fn collects_supported_fixture_local_names_in_order() {
+    let parameters = vec![
+        RstestParameter::ident("db"),
+        provider_parameter("case"),
+        RstestParameter::unsupported(),
+        RstestParameter::ident("clock"),
+        RstestParameter::ident("db"),
+    ];
+
+    assert_eq!(
+        fixture_local_names(&parameters, &RstestDetectionOptions::default()),
+        BTreeSet::from(["clock".to_string(), "db".to_string()])
+    );
+}

--- a/common/src/rstest/tests.rs
+++ b/common/src/rstest/tests.rs
@@ -146,75 +146,38 @@ fn ignores_trace_when_fallback_is_disabled() {
     ));
 }
 
-#[rstest]
-fn honours_test_trace_when_fallback_is_enabled() {
-    let trace = ExpansionTrace::new([AttributePath::from("rstest")]);
-    let options = RstestDetectionOptions::new(Vec::new(), true);
-
-    assert!(is_rstest_test_with(
-        &[outer("allow")],
-        Some(&trace),
-        &options
-    ));
-}
+type TraceFallbackDetect =
+    fn(&[Attribute], Option<&ExpansionTrace>, &RstestDetectionOptions) -> bool;
 
 #[rstest]
-fn honours_fixture_trace_when_fallback_is_enabled() {
-    let trace = ExpansionTrace::new([AttributePath::from("fixture")]);
+#[case::single_frame_test(
+    is_rstest_test_with as TraceFallbackDetect,
+    &["rstest"] as &[&str]
+)]
+#[case::multi_frame_test(
+    is_rstest_test_with as TraceFallbackDetect,
+    &["outer_macro", "rstest"]
+)]
+#[case::deeply_nested_test(
+    is_rstest_test_with as TraceFallbackDetect,
+    &["macro_a", "macro_b", "macro_c", "rstest::rstest"]
+)]
+#[case::single_frame_fixture(
+    is_rstest_fixture_with as TraceFallbackDetect,
+    &["fixture"]
+)]
+#[case::multi_frame_fixture(
+    is_rstest_fixture_with as TraceFallbackDetect,
+    &["outer_macro", "fixture"]
+)]
+fn honours_trace_when_fallback_is_enabled(
+    #[case] detect: TraceFallbackDetect,
+    #[case] frame_paths: &[&str],
+) {
+    let trace = ExpansionTrace::new(frame_paths.iter().copied().map(AttributePath::from));
     let options = RstestDetectionOptions::new(Vec::new(), true);
 
-    assert!(is_rstest_fixture_with(
-        &[outer("allow")],
-        Some(&trace),
-        &options,
-    ));
-}
-
-#[rstest]
-fn honours_multi_frame_test_trace() {
-    let trace = ExpansionTrace::new([
-        AttributePath::from("outer_macro"),
-        AttributePath::from("rstest"),
-    ]);
-    let options = RstestDetectionOptions::new(Vec::new(), true);
-
-    assert!(is_rstest_test_with(
-        &[outer("allow")],
-        Some(&trace),
-        &options
-    ));
-}
-
-#[rstest]
-fn honours_multi_frame_fixture_trace() {
-    let trace = ExpansionTrace::new([
-        AttributePath::from("outer_macro"),
-        AttributePath::from("fixture"),
-    ]);
-    let options = RstestDetectionOptions::new(Vec::new(), true);
-
-    assert!(is_rstest_fixture_with(
-        &[outer("allow")],
-        Some(&trace),
-        &options,
-    ));
-}
-
-#[rstest]
-fn honours_deeply_nested_test_trace() {
-    let trace = ExpansionTrace::new([
-        AttributePath::from("macro_a"),
-        AttributePath::from("macro_b"),
-        AttributePath::from("macro_c"),
-        AttributePath::from("rstest::rstest"),
-    ]);
-    let options = RstestDetectionOptions::new(Vec::new(), true);
-
-    assert!(is_rstest_test_with(
-        &[outer("allow")],
-        Some(&trace),
-        &options
-    ));
+    assert!(detect(&[outer("allow")], Some(&trace), &options));
 }
 
 #[rstest]

--- a/common/src/rstest/tests.rs
+++ b/common/src/rstest/tests.rs
@@ -32,6 +32,28 @@ fn detects_strict_rstest_tests(#[case] path: &str, #[case] expected: bool) {
 }
 
 #[rstest]
+#[case::rstest("rstest", true)]
+#[case::qualified("rstest::rstest", true)]
+#[case::plain_test("test", false)]
+#[case::tokio("tokio::test", false)]
+#[case::case("case", false)]
+#[case::fixture("rstest::fixture", false)]
+fn detects_strict_rstest_tests_with_multiple_attributes(
+    #[case] path: &str,
+    #[case] expected: bool,
+) {
+    // non-rstest attribute preceding the rstest-related attribute
+    assert_eq!(is_rstest_test(&[outer("allow"), outer(path)]), expected);
+    // non-rstest attribute following the rstest-related attribute
+    assert_eq!(is_rstest_test(&[outer(path), outer("allow")]), expected);
+    // multiple non-rstest attributes surrounding the rstest-related attribute
+    assert_eq!(
+        is_rstest_test(&[outer("allow"), outer(path), outer("warn")]),
+        expected
+    );
+}
+
+#[rstest]
 #[case::fixture("fixture", true)]
 #[case::qualified("rstest::fixture", true)]
 #[case::rstest("rstest", false)]
@@ -69,6 +91,37 @@ fn classifies_provider_parameters(#[case] path: &str) {
     assert_eq!(
         classify_rstest_parameter(&parameter, &RstestDetectionOptions::default()),
         RstestParameterKind::Provider
+    );
+}
+
+#[rstest]
+fn classifies_custom_provider_parameters() {
+    let parameter = provider_parameter("custom::provider");
+    let options = RstestDetectionOptions::new(
+        vec![
+            AttributePath::from("custom::provider"),
+            AttributePath::from("another::custom"),
+        ],
+        false,
+    );
+
+    assert_eq!(
+        classify_rstest_parameter(&parameter, &options),
+        RstestParameterKind::Provider
+    );
+}
+
+#[rstest]
+fn rejects_unknown_custom_provider_parameters() {
+    let parameter = provider_parameter("unknown::provider");
+    let options = RstestDetectionOptions::new(vec![AttributePath::from("custom::provider")], false);
+
+    // Should classify as fixture local since it's not in the custom provider list
+    assert_eq!(
+        classify_rstest_parameter(&parameter, &options),
+        RstestParameterKind::FixtureLocal {
+            name: "value".to_string()
+        }
     );
 }
 
@@ -114,6 +167,53 @@ fn honours_fixture_trace_when_fallback_is_enabled() {
         &[outer("allow")],
         Some(&trace),
         &options,
+    ));
+}
+
+#[rstest]
+fn honours_multi_frame_test_trace() {
+    let trace = ExpansionTrace::new([
+        AttributePath::from("outer_macro"),
+        AttributePath::from("rstest"),
+    ]);
+    let options = RstestDetectionOptions::new(Vec::new(), true);
+
+    assert!(is_rstest_test_with(
+        &[outer("allow")],
+        Some(&trace),
+        &options
+    ));
+}
+
+#[rstest]
+fn honours_multi_frame_fixture_trace() {
+    let trace = ExpansionTrace::new([
+        AttributePath::from("outer_macro"),
+        AttributePath::from("fixture"),
+    ]);
+    let options = RstestDetectionOptions::new(Vec::new(), true);
+
+    assert!(is_rstest_fixture_with(
+        &[outer("allow")],
+        Some(&trace),
+        &options,
+    ));
+}
+
+#[rstest]
+fn honours_deeply_nested_test_trace() {
+    let trace = ExpansionTrace::new([
+        AttributePath::from("macro_a"),
+        AttributePath::from("macro_b"),
+        AttributePath::from("macro_c"),
+        AttributePath::from("rstest::rstest"),
+    ]);
+    let options = RstestDetectionOptions::new(Vec::new(), true);
+
+    assert!(is_rstest_test_with(
+        &[outer("allow")],
+        Some(&trace),
+        &options
     ));
 }
 

--- a/common/tests/features/rstest_detection.feature
+++ b/common/tests/features/rstest_detection.feature
@@ -1,0 +1,38 @@
+Feature: Strict rstest detection
+
+  Scenario: Detect an rstest test from a direct attribute
+    Given a function annotated with rstest
+    When I check whether the function is an rstest test
+    Then the function is recognised as an rstest test
+
+  Scenario: Detect an rstest fixture from a direct attribute
+    Given a function annotated with rstest::fixture
+    When I check whether the function is an rstest fixture
+    Then the function is recognised as an rstest fixture
+
+  Scenario: Classify a plain identifier parameter as fixture-local
+    Given a parameter named db
+    When I classify the parameter
+    Then the parameter is classified as fixture-local
+    And the fixture-local names contain db
+
+  Scenario: Classify a case parameter as provider-driven
+    Given a parameter named case_input annotated with case
+    When I classify the parameter
+    Then the parameter is classified as provider-driven
+
+  Scenario: Leave unsupported parameter bindings unsupported
+    Given a destructured parameter binding
+    When I classify the parameter
+    Then the parameter is classified as unsupported
+
+  Scenario: Ignore expansion traces while fallback is disabled
+    Given the expansion trace contains rstest
+    When I check whether the function is an rstest test
+    Then the function is recognised as not being an rstest test
+
+  Scenario: Use expansion traces when fallback is enabled
+    Given the expansion trace contains rstest
+    And expansion fallback is enabled
+    When I check whether the function is an rstest test
+    Then the function is recognised as an rstest test

--- a/common/tests/features/rstest_detection.feature
+++ b/common/tests/features/rstest_detection.feature
@@ -13,6 +13,7 @@ Feature: Strict rstest detection
   Scenario: Classify a plain identifier parameter as fixture-local
     Given a parameter named db
     When I classify the parameter
+    And I evaluate fixture-local names
     Then the parameter is classified as fixture-local
     And the fixture-local names contain db
 

--- a/common/tests/features/rstest_detection.feature
+++ b/common/tests/features/rstest_detection.feature
@@ -36,3 +36,20 @@ Feature: Strict rstest detection
     And expansion fallback is enabled
     When I check whether the function is an rstest test
     Then the function is recognised as an rstest test
+
+  Scenario: Detect rstest test with multiple attributes
+    Given a function annotated with rstest and allow
+    When I check whether the function is an rstest test
+    Then the function is recognised as an rstest test
+
+  Scenario: Classify custom provider parameters
+    Given a parameter annotated with a custom provider attribute
+    And custom provider attributes are configured
+    When I classify the parameter
+    Then the parameter is classified as provider-driven
+
+  Scenario: Use multi-frame expansion traces
+    Given the expansion trace contains outer_macro and rstest
+    And expansion fallback is enabled
+    When I check whether the function is an rstest test
+    Then the function is recognised as an rstest test

--- a/common/tests/rstest_detection_behaviour.rs
+++ b/common/tests/rstest_detection_behaviour.rs
@@ -1,14 +1,14 @@
 //! Behaviour-driven tests for strict `rstest` detection helpers.
 
-use common::attributes::{Attribute, AttributeKind, AttributePath};
-use common::rstest::{
-    ExpansionTrace, ParameterBinding, RstestDetectionOptions, RstestParameter, RstestParameterKind,
-    classify_rstest_parameter, fixture_local_names, is_rstest_fixture_with, is_rstest_test_with,
-};
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
 use std::collections::BTreeSet;
+use whitaker_common::attributes::{Attribute, AttributeKind, AttributePath};
+use whitaker_common::rstest::{
+    ExpansionTrace, ParameterBinding, RstestDetectionOptions, RstestParameter, RstestParameterKind,
+    classify_rstest_parameter, fixture_local_names, is_rstest_fixture_with, is_rstest_test_with,
+};
 
 #[derive(Clone, Debug, Default)]
 struct DetectionWorld {

--- a/common/tests/rstest_detection_behaviour.rs
+++ b/common/tests/rstest_detection_behaviour.rs
@@ -188,6 +188,11 @@ fn when_classify_parameter(world: &DetectionWorld) -> Result<(), String> {
     world.evaluate_parameter()
 }
 
+#[when("I evaluate fixture-local names")]
+fn when_fixture_names_evaluated(world: &DetectionWorld) {
+    world.evaluate_fixture_names();
+}
+
 #[then("the function is recognised as an rstest test")]
 fn then_test_positive(world: &DetectionWorld) {
     assert_eq!(*world.test_result.borrow(), Some(true));
@@ -231,62 +236,32 @@ fn then_unsupported(world: &DetectionWorld) {
 
 #[then("the fixture-local names contain db")]
 fn then_fixture_names(world: &DetectionWorld) {
-    if world.fixture_names.borrow().is_none() {
-        world.evaluate_fixture_names();
-    }
-
     assert_eq!(
         *world.fixture_names.borrow(),
         Some(BTreeSet::from(["db".to_string()]))
     );
 }
 
-#[scenario(path = "tests/features/rstest_detection.feature", index = 0)]
-fn scenario_detects_rstest_test(world: DetectionWorld) {
-    let _ = world;
+macro_rules! declare_scenarios {
+    ($(($index:literal, $name:ident)),+ $(,)?) => {
+        $(
+            #[scenario(path = "tests/features/rstest_detection.feature", index = $index)]
+            fn $name(world: DetectionWorld) {
+                let _ = world;
+            }
+        )+
+    };
 }
 
-#[scenario(path = "tests/features/rstest_detection.feature", index = 1)]
-fn scenario_detects_rstest_fixture(world: DetectionWorld) {
-    let _ = world;
-}
-
-#[scenario(path = "tests/features/rstest_detection.feature", index = 2)]
-fn scenario_classifies_fixture_local_parameter(world: DetectionWorld) {
-    let _ = world;
-}
-
-#[scenario(path = "tests/features/rstest_detection.feature", index = 3)]
-fn scenario_classifies_provider_parameter(world: DetectionWorld) {
-    let _ = world;
-}
-
-#[scenario(path = "tests/features/rstest_detection.feature", index = 4)]
-fn scenario_ignores_unsupported_parameter(world: DetectionWorld) {
-    let _ = world;
-}
-
-#[scenario(path = "tests/features/rstest_detection.feature", index = 5)]
-fn scenario_ignores_trace_without_fallback(world: DetectionWorld) {
-    let _ = world;
-}
-
-#[scenario(path = "tests/features/rstest_detection.feature", index = 6)]
-fn scenario_uses_trace_with_fallback(world: DetectionWorld) {
-    let _ = world;
-}
-
-#[scenario(path = "tests/features/rstest_detection.feature", index = 7)]
-fn scenario_detects_rstest_with_multiple_attributes(world: DetectionWorld) {
-    let _ = world;
-}
-
-#[scenario(path = "tests/features/rstest_detection.feature", index = 8)]
-fn scenario_classifies_custom_provider_parameters(world: DetectionWorld) {
-    let _ = world;
-}
-
-#[scenario(path = "tests/features/rstest_detection.feature", index = 9)]
-fn scenario_uses_multi_frame_traces(world: DetectionWorld) {
-    let _ = world;
-}
+declare_scenarios!(
+    (0, scenario_detects_rstest_test),
+    (1, scenario_detects_rstest_fixture),
+    (2, scenario_classifies_fixture_local_parameter),
+    (3, scenario_classifies_provider_parameter),
+    (4, scenario_ignores_unsupported_parameter),
+    (5, scenario_ignores_trace_without_fallback),
+    (6, scenario_uses_trace_with_fallback),
+    (7, scenario_detects_rstest_with_multiple_attributes),
+    (8, scenario_classifies_custom_provider_parameters),
+    (9, scenario_uses_multi_frame_traces),
+);

--- a/common/tests/rstest_detection_behaviour.rs
+++ b/common/tests/rstest_detection_behaviour.rs
@@ -42,6 +42,17 @@ impl DetectionWorld {
             .replace(ExpansionTrace::new([AttributePath::from(path)]));
     }
 
+    fn set_multi_frame_trace(&self, paths: &[&str]) {
+        self.trace.borrow_mut().replace(ExpansionTrace::new(
+            paths.iter().map(|p| AttributePath::from(*p)),
+        ));
+    }
+
+    fn add_custom_provider_attributes(&self, paths: Vec<AttributePath>) {
+        self.options
+            .replace(RstestDetectionOptions::new(paths, false));
+    }
+
     fn enable_trace_fallback(&self) {
         let provider_paths = self.options.borrow().provider_param_attributes().to_vec();
         self.options
@@ -132,6 +143,33 @@ fn given_trace(world: &DetectionWorld) {
 #[given("expansion fallback is enabled")]
 fn given_fallback_enabled(world: &DetectionWorld) {
     world.enable_trace_fallback();
+}
+
+#[given("a function annotated with rstest and allow")]
+fn given_rstest_and_allow(world: &DetectionWorld) {
+    world.push_attribute("rstest");
+    world.push_attribute("allow");
+}
+
+#[given("a parameter annotated with a custom provider attribute")]
+fn given_custom_provider_parameter(world: &DetectionWorld) {
+    world.set_parameter(RstestParameter::new(
+        ParameterBinding::Ident("custom_value".to_string()),
+        vec![Attribute::new(
+            AttributePath::from("custom::provider"),
+            AttributeKind::Outer,
+        )],
+    ));
+}
+
+#[given("custom provider attributes are configured")]
+fn given_custom_provider_config(world: &DetectionWorld) {
+    world.add_custom_provider_attributes(vec![AttributePath::from("custom::provider")]);
+}
+
+#[given("the expansion trace contains outer_macro and rstest")]
+fn given_multi_frame_trace(world: &DetectionWorld) {
+    world.set_multi_frame_trace(&["outer_macro", "rstest"]);
 }
 
 #[when("I check whether the function is an rstest test")]
@@ -234,5 +272,20 @@ fn scenario_ignores_trace_without_fallback(world: DetectionWorld) {
 
 #[scenario(path = "tests/features/rstest_detection.feature", index = 6)]
 fn scenario_uses_trace_with_fallback(world: DetectionWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_detection.feature", index = 7)]
+fn scenario_detects_rstest_with_multiple_attributes(world: DetectionWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_detection.feature", index = 8)]
+fn scenario_classifies_custom_provider_parameters(world: DetectionWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_detection.feature", index = 9)]
+fn scenario_uses_multi_frame_traces(world: DetectionWorld) {
     let _ = world;
 }

--- a/common/tests/rstest_detection_behaviour.rs
+++ b/common/tests/rstest_detection_behaviour.rs
@@ -1,0 +1,238 @@
+//! Behaviour-driven tests for strict `rstest` detection helpers.
+
+use common::attributes::{Attribute, AttributeKind, AttributePath};
+use common::rstest::{
+    ExpansionTrace, ParameterBinding, RstestDetectionOptions, RstestParameter, RstestParameterKind,
+    classify_rstest_parameter, fixture_local_names, is_rstest_fixture_with, is_rstest_test_with,
+};
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+
+#[derive(Clone, Debug, Default)]
+struct DetectionWorld {
+    attributes: RefCell<Vec<Attribute>>,
+    parameters: RefCell<Vec<RstestParameter>>,
+    trace: RefCell<Option<ExpansionTrace>>,
+    options: RefCell<RstestDetectionOptions>,
+    test_result: RefCell<Option<bool>>,
+    fixture_result: RefCell<Option<bool>>,
+    parameter_kind: RefCell<Option<RstestParameterKind>>,
+    fixture_names: RefCell<Option<BTreeSet<String>>>,
+}
+
+impl DetectionWorld {
+    fn push_attribute(&self, path: &str) {
+        self.attributes.borrow_mut().push(Attribute::new(
+            AttributePath::from(path),
+            AttributeKind::Outer,
+        ));
+    }
+
+    fn set_parameter(&self, parameter: RstestParameter) {
+        let mut parameters = self.parameters.borrow_mut();
+        parameters.clear();
+        parameters.push(parameter);
+    }
+
+    fn set_trace(&self, path: &str) {
+        self.trace
+            .borrow_mut()
+            .replace(ExpansionTrace::new([AttributePath::from(path)]));
+    }
+
+    fn enable_trace_fallback(&self) {
+        let provider_paths = self.options.borrow().provider_param_attributes().to_vec();
+        self.options
+            .replace(RstestDetectionOptions::new(provider_paths, true));
+    }
+
+    fn evaluate_test(&self) {
+        let attrs = self.attributes.borrow();
+        let trace = self.trace.borrow();
+        let options = self.options.borrow();
+        self.test_result
+            .replace(Some(is_rstest_test_with(&attrs, trace.as_ref(), &options)));
+    }
+
+    fn evaluate_fixture(&self) {
+        let attrs = self.attributes.borrow();
+        let trace = self.trace.borrow();
+        let options = self.options.borrow();
+        self.fixture_result.replace(Some(is_rstest_fixture_with(
+            &attrs,
+            trace.as_ref(),
+            &options,
+        )));
+    }
+
+    fn evaluate_parameter(&self) -> Result<(), String> {
+        let parameter = self
+            .parameters
+            .borrow()
+            .first()
+            .cloned()
+            .ok_or("parameter must be configured before classification")?;
+        let options = self.options.borrow();
+        self.parameter_kind
+            .replace(Some(classify_rstest_parameter(&parameter, &options)));
+        Ok(())
+    }
+
+    fn evaluate_fixture_names(&self) {
+        let parameters = self.parameters.borrow();
+        let options = self.options.borrow();
+        self.fixture_names
+            .replace(Some(fixture_local_names(&parameters, &options)));
+    }
+}
+
+#[fixture]
+fn world() -> DetectionWorld {
+    DetectionWorld::default()
+}
+
+#[given("a function annotated with rstest")]
+fn given_rstest_function(world: &DetectionWorld) {
+    world.push_attribute("rstest");
+}
+
+#[given("a function annotated with rstest::fixture")]
+fn given_rstest_fixture(world: &DetectionWorld) {
+    world.push_attribute("rstest::fixture");
+}
+
+#[given("a parameter named db")]
+fn given_fixture_local_parameter(world: &DetectionWorld) {
+    world.set_parameter(RstestParameter::ident("db"));
+}
+
+#[given("a parameter named case_input annotated with case")]
+fn given_provider_parameter(world: &DetectionWorld) {
+    world.set_parameter(RstestParameter::new(
+        ParameterBinding::Ident("case_input".to_string()),
+        vec![Attribute::new(
+            AttributePath::from("case"),
+            AttributeKind::Outer,
+        )],
+    ));
+}
+
+#[given("a destructured parameter binding")]
+fn given_unsupported_parameter(world: &DetectionWorld) {
+    world.set_parameter(RstestParameter::unsupported());
+}
+
+#[given("the expansion trace contains rstest")]
+fn given_trace(world: &DetectionWorld) {
+    world.set_trace("rstest");
+}
+
+#[given("expansion fallback is enabled")]
+fn given_fallback_enabled(world: &DetectionWorld) {
+    world.enable_trace_fallback();
+}
+
+#[when("I check whether the function is an rstest test")]
+fn when_check_test(world: &DetectionWorld) {
+    world.evaluate_test();
+}
+
+#[when("I check whether the function is an rstest fixture")]
+fn when_check_fixture(world: &DetectionWorld) {
+    world.evaluate_fixture();
+}
+
+#[when("I classify the parameter")]
+fn when_classify_parameter(world: &DetectionWorld) -> Result<(), String> {
+    world.evaluate_parameter()
+}
+
+#[then("the function is recognised as an rstest test")]
+fn then_test_positive(world: &DetectionWorld) {
+    assert_eq!(*world.test_result.borrow(), Some(true));
+}
+
+#[then("the function is recognised as not being an rstest test")]
+fn then_test_negative(world: &DetectionWorld) {
+    assert_eq!(*world.test_result.borrow(), Some(false));
+}
+
+#[then("the function is recognised as an rstest fixture")]
+fn then_fixture_positive(world: &DetectionWorld) {
+    assert_eq!(*world.fixture_result.borrow(), Some(true));
+}
+
+#[then("the parameter is classified as fixture-local")]
+fn then_fixture_local(world: &DetectionWorld) {
+    assert_eq!(
+        *world.parameter_kind.borrow(),
+        Some(RstestParameterKind::FixtureLocal {
+            name: "db".to_string()
+        })
+    );
+}
+
+#[then("the parameter is classified as provider-driven")]
+fn then_provider(world: &DetectionWorld) {
+    assert_eq!(
+        *world.parameter_kind.borrow(),
+        Some(RstestParameterKind::Provider)
+    );
+}
+
+#[then("the parameter is classified as unsupported")]
+fn then_unsupported(world: &DetectionWorld) {
+    assert_eq!(
+        *world.parameter_kind.borrow(),
+        Some(RstestParameterKind::UnsupportedPattern)
+    );
+}
+
+#[then("the fixture-local names contain db")]
+fn then_fixture_names(world: &DetectionWorld) {
+    if world.fixture_names.borrow().is_none() {
+        world.evaluate_fixture_names();
+    }
+
+    assert_eq!(
+        *world.fixture_names.borrow(),
+        Some(BTreeSet::from(["db".to_string()]))
+    );
+}
+
+#[scenario(path = "tests/features/rstest_detection.feature", index = 0)]
+fn scenario_detects_rstest_test(world: DetectionWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_detection.feature", index = 1)]
+fn scenario_detects_rstest_fixture(world: DetectionWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_detection.feature", index = 2)]
+fn scenario_classifies_fixture_local_parameter(world: DetectionWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_detection.feature", index = 3)]
+fn scenario_classifies_provider_parameter(world: DetectionWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_detection.feature", index = 4)]
+fn scenario_ignores_unsupported_parameter(world: DetectionWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_detection.feature", index = 5)]
+fn scenario_ignores_trace_without_fallback(world: DetectionWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_detection.feature", index = 6)]
+fn scenario_uses_trace_with_fallback(world: DetectionWorld) {
+    let _ = world;
+}

--- a/common/tests/rstest_detection_behaviour.rs
+++ b/common/tests/rstest_detection_behaviour.rs
@@ -49,8 +49,9 @@ impl DetectionWorld {
     }
 
     fn add_custom_provider_attributes(&self, paths: Vec<AttributePath>) {
+        let use_trace_fallback = self.options.borrow().use_expansion_trace_fallback();
         self.options
-            .replace(RstestDetectionOptions::new(paths, false));
+            .replace(RstestDetectionOptions::new(paths, use_trace_fallback));
     }
 
     fn enable_trace_fallback(&self) {

--- a/docs/execplans/8-1-1-shared-rstest-test-and-fixture-detection-helpers.md
+++ b/docs/execplans/8-1-1-shared-rstest-test-and-fixture-detection-helpers.md
@@ -1,0 +1,450 @@
+# Add shared `rstest` test and fixture detection helpers (roadmap 8.1.1)
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+This document must be maintained in accordance with `AGENTS.md`. The canonical
+plan file is
+`docs/execplans/8-1-1-shared-rstest-test-and-fixture-detection-helpers.md`.
+
+## Purpose / big picture
+
+Roadmap item 8.1.1 adds the shared detection layer that later `rstest` hygiene
+lints depend on. After this change, the `common` crate will expose a small
+pure-library API that can answer four questions without depending on
+`rustc_private`:
+
+1. Does this function look like an `#[rstest]` test?
+2. Does this function look like an `#[fixture]`?
+3. Which function parameters are fixture locals, and which are provider-driven
+   inputs such as `#[case]` or `#[values]`?
+4. When direct attributes are unavailable, does optional expansion-trace
+   metadata still show that the item came from `rstest`?
+
+This task is intentionally foundational. It does not implement lint A itself,
+and it does not add argument fingerprinting, user-editable span recovery, or
+crate-post aggregation. Those belong to roadmap items 8.1.2, 8.1.3, and 8.2.x.
+
+Success is observable when:
+
+1. `common` exports a dedicated shared module for `rstest` detection.
+2. Unit tests cover attribute-based detection, fixture-local classification,
+   disabled fallback behaviour, enabled fallback behaviour, and unhappy paths.
+3. Behavioural tests using `rstest-bdd` v0.5.0 exercise the same contract via
+   `common/tests/`.
+4. `docs/lints-for-rstest-fixtures-and-test-hygiene.md` records the final
+   implementation decisions for 8.1.1.
+5. `docs/roadmap.md` marks 8.1.1 done only after the implementation, tests,
+   and gates all succeed.
+6. `make check-fmt`, `make lint`, and `make test` pass at the end of the
+   implementation turn.
+
+## Constraints
+
+- Scope only roadmap item 8.1.1. Do not implement lint crates, argument
+  fingerprinting, paragraph detection, diagnostics, or UI fixtures here.
+- Keep the new helpers in `common` and keep them free of `rustc_private`
+  dependencies. The caller must pass simplified metadata rather than
+  `rustc_hir` or `rustc_span` types.
+- Attribute-based detection is the primary path. Expansion-trace fallback must
+  be optional and explicit so future lint drivers can keep the conservative
+  default.
+- Do not reuse the existing generic test-like path set as the final `rstest`
+  answer. `common::attributes::TEST_LIKE_PATHS` intentionally treats `case` and
+  `rstest::case` as test-like for broader context detection, but 8.1.1 needs a
+  stricter distinction between test attributes, fixture attributes, and
+  provider parameter attributes.
+- Version one accepts only simple identifier parameter bindings for
+  fixture-local classification. Destructuring patterns must be treated as
+  unsupported and left for a later roadmap item.
+- Keep every source file under 400 lines. Split the module early instead of
+  allowing a single file to absorb all logic and tests.
+- Public APIs added to `common` require Rustdoc comments with examples that
+  compile under the doctest model described in `docs/rust-doctest-dry-guide.md`.
+- Use workspace-pinned `rstest`, `rstest-bdd`, and `rstest-bdd-macros` at
+  `0.5.0`.
+- Behaviour tests must obey the workspace Clippy threshold of 4 arguments per
+  step function. Each step may parse at most 3 values in addition to the world
+  fixture.
+- Do not mark roadmap item 8.1.1 done until implementation, documentation,
+  and all quality gates succeed.
+
+## Tolerances
+
+- Scope: if implementation needs more than 9 touched files or roughly 800 net
+  new lines, stop and escalate before continuing.
+- API: if the pure helper API cannot represent expansion fallback without
+  leaking `rustc_private` concepts into `common`, stop and escalate with the
+  competing shapes.
+- Compatibility: if delivering 8.1.1 requires changing the behaviour of
+  existing generic helpers such as `is_test_fn` or `in_test_like_context`, stop
+  and escalate instead of silently broadening the blast radius.
+- Dependencies: if a new crate appears necessary, stop and escalate before
+  adding it.
+- Validation: if `make check-fmt`, `make lint`, or `make test` still fail
+  after 3 targeted fix iterations, stop and escalate with the captured logs.
+
+## Risks
+
+- Semantics risk: `rstest` has overlapping concepts across test functions,
+  fixtures, and provider parameters. If the API is too loose, lint A will later
+  misclassify `#[case]` inputs as fixtures. Mitigation: model test, fixture,
+  and provider detection as separate predicates with separate path sets.
+- Fallback risk: expansion-trace metadata is less direct than item attributes
+  and could easily become too permissive. Mitigation: keep fallback disabled by
+  default and require the caller to pass an explicit trace object.
+- Duplication risk: this repository already has generic attribute/context
+  helpers and some crate-local HIR attribute matching. Mitigation: introduce a
+  dedicated `common::rstest` module rather than mutating unrelated helpers, and
+  document the division of responsibility in the design doc.
+- Test ergonomics risk: BDD scenarios can trip Clippy on
+  `too_many_arguments`, `expect_used`, and stale feature recompilation.
+  Mitigation: keep the world small, return `Result` from fallible steps, and
+  touch the `.rs` harness if a feature-file-only rerun appears stale.
+- Documentation drift risk: `common/Cargo.toml` still contains a stale comment
+  mentioning `rstest-bdd` 0.2.x even though the workspace uses 0.5.0.
+  Mitigation: either fix the comment during implementation or call out the
+  discrepancy in the design-doc decision section so future work is not misled.
+
+## Progress
+
+- [x] (2026-03-26) Stage A: Draft this ExecPlan and capture repository state.
+- [ ] Stage B: Add failing unit tests that define the 8.1.1 detection
+  contract.
+- [ ] Stage C: Add failing `rstest-bdd` scenarios for the same contract.
+- [ ] Stage D: Implement the shared pure-library `rstest` detection module in
+  `common`.
+- [ ] Stage E: Re-export the new API from `common/src/lib.rs` and add Rustdoc
+  examples.
+- [ ] Stage F: Record implementation decisions in
+  `docs/lints-for-rstest-fixtures-and-test-hygiene.md`.
+- [ ] Stage G: Mark roadmap item 8.1.1 done.
+- [ ] Stage H: Run documentation gates plus `make check-fmt`, `make lint`, and
+  `make test`.
+- [ ] Stage I: Finalize the living sections in this document.
+
+## Surprises & Discoveries
+
+- `common/src/context.rs` already exposes generic helpers such as `is_test_fn`
+  and `in_test_like_context`, but those currently delegate to a broader
+  test-like attribute matcher that includes `case` and `rstest::case`. That is
+  helpful for broad "test-like context" reasoning, but it is too permissive for
+  strict `rstest` test/fixture detection.
+- `crates/no_expect_outside_tests/src/driver/tests.rs` already has crate-local
+  HIR tests that reject `rstest::fixture` as a test attribute. That is a good
+  signal that 8.1.1 should keep test and fixture detection separate.
+- The repository already uses the right behavioural test shape for this work:
+  `common/tests/context_behaviour.rs` is a small, pure, fixture-backed BDD
+  harness that can be copied with minimal adaptation.
+- Workspace dependencies already pin `rstest-bdd = "0.5.0"`, but
+  `common/Cargo.toml` still has a stale comment mentioning `0.2.x`.
+- Existing pure-library helpers for macro filtering use the
+  `is_from_expansion: bool` pattern. 8.1.1 needs an analogous pure metadata
+  seam for optional expansion-trace fallback.
+
+## Decision Log
+
+- Decision: implement 8.1.1 as a dedicated `common::rstest` module instead of
+  extending `common::context` or `common::attributes` alone. Rationale: the new
+  work is narrower than generic context detection and needs stricter semantics
+  around fixtures and provider parameters. Date/Author: 2026-03-26 / Codex.
+- Decision: keep expansion fallback in a pure metadata type owned by `common`
+  rather than by passing raw rustc spans or expansion backtraces. Rationale:
+  this preserves the established "pure library in `common`, compiler-aware
+  caller outside" architecture. Date/Author: 2026-03-26 / Codex.
+- Decision: include fixture-local parameter classification in 8.1.1 even
+  though the roadmap title mentions only test and fixture detection. Rationale:
+  the linked lint-A design section defines fixture-local classification as part
+  of the same shared foundation, and 8.2.2 depends directly on it. Date/Author:
+  2026-03-26 / Codex.
+- Decision: keep destructuring support out of scope for version one. Rationale:
+  the design document already permits deferring it, and simple identifier-only
+  binding keeps the API deterministic and easy to test. Date/Author: 2026-03-26
+  / Codex.
+
+## Context and orientation
+
+### Repository state
+
+Relevant files and modules today:
+
+- `common/src/attributes/` contains the generic `Attribute`, `AttributePath`,
+  and helper predicates for outer/doc/test-like attributes.
+- `common/src/context.rs` contains higher-level test-context helpers built on
+  those generic attributes.
+- `common/src/lib.rs` re-exports both modules and is the place where the new
+  `rstest` API must become public.
+- `common/tests/context_behaviour.rs` and
+  `common/tests/features/context_detection.feature` provide the closest
+  behavioural-test template for this work.
+- `docs/lints-for-rstest-fixtures-and-test-hygiene.md` defines the contract for
+  8.1.1, especially the `#[rstest]` test detection and fixture-local
+  classification rules under Lint A.
+- `docs/roadmap.md` lists 8.1.1 as the prerequisite for 8.1.3, 8.2.1, and
+  8.4.1.
+
+### What 8.1.1 must provide
+
+The design document narrows this task to the reusable detection substrate
+needed by later lints:
+
+- strict detection of `#[rstest]` tests,
+- strict detection of `#[fixture]` functions,
+- classification of parameters into fixture locals or provider-driven inputs,
+- optional fallback through expansion-trace metadata when direct attributes are
+  unavailable.
+
+This task does not need user-editable span recovery or call-site
+fingerprinting. Those are separate roadmap items.
+
+## Proposed implementation shape
+
+Create a new shared module tree:
+
+- `common/src/rstest/mod.rs`
+- `common/src/rstest/detection.rs`
+- `common/src/rstest/parameter.rs`
+- `common/src/rstest/tests.rs`
+
+Then update:
+
+- `common/src/lib.rs`
+- `common/tests/rstest_detection_behaviour.rs`
+- `common/tests/features/rstest_detection.feature`
+- `docs/lints-for-rstest-fixtures-and-test-hygiene.md`
+- `docs/roadmap.md`
+
+The exact split may vary to stay under the 400-line limit, but the public API
+should look close to this:
+
+```rust
+use crate::attributes::{Attribute, AttributePath};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ExpansionTrace {
+    frames: Vec<AttributePath>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ParameterBinding {
+    Ident(String),
+    Unsupported,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RstestParameter {
+    binding: ParameterBinding,
+    attributes: Vec<Attribute>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RstestParameterKind {
+    FixtureLocal { name: String },
+    Provider,
+    UnsupportedPattern,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RstestDetectionOptions {
+    provider_param_attributes: Vec<AttributePath>,
+    use_expansion_trace_fallback: bool,
+}
+
+pub fn is_rstest_test(attrs: &[Attribute]) -> bool;
+pub fn is_rstest_test_with(
+    attrs: &[Attribute],
+    trace: Option<&ExpansionTrace>,
+    options: &RstestDetectionOptions,
+) -> bool;
+pub fn is_rstest_fixture(attrs: &[Attribute]) -> bool;
+pub fn is_rstest_fixture_with(
+    attrs: &[Attribute],
+    trace: Option<&ExpansionTrace>,
+    options: &RstestDetectionOptions,
+) -> bool;
+pub fn classify_rstest_parameter(
+    parameter: &RstestParameter,
+    options: &RstestDetectionOptions,
+) -> RstestParameterKind;
+pub fn fixture_local_names(
+    parameters: &[RstestParameter],
+    options: &RstestDetectionOptions,
+) -> std::collections::BTreeSet<String>;
+```
+
+Important semantic rules for the implementation:
+
+1. Test attributes match only `rstest` and `rstest::rstest`.
+2. Fixture attributes match only `fixture` and `rstest::fixture`.
+3. Provider attributes default to both bare and namespaced forms of `case`,
+   `values`, `files`, `future`, and `context`.
+4. Expansion fallback only runs when
+   `options.use_expansion_trace_fallback == true`.
+5. Expansion fallback should consult the same strict path sets as direct
+   attribute matching.
+6. Unsupported bindings must not be classified as fixture locals.
+
+## Plan of work
+
+### Stage B: Add failing unit tests first
+
+Create `common/src/rstest/tests.rs` and write unit tests before the
+implementation lands. The tests should fail because the new module does not yet
+exist or because stubbed functions return placeholder values.
+
+Cover at least these cases:
+
+- `is_rstest_test` returns true for `rstest`.
+- `is_rstest_test` returns true for `rstest::rstest`.
+- `is_rstest_test` returns false for `test`, `tokio::test`, `case`, and
+  `rstest::fixture`.
+- `is_rstest_fixture` returns true for `fixture` and `rstest::fixture`.
+- `is_rstest_fixture` returns false for `rstest` and unrelated attributes.
+- `classify_rstest_parameter` returns `FixtureLocal` for a simple identifier
+  with no provider attribute.
+- `classify_rstest_parameter` returns `Provider` for `case`, `values`, `files`,
+  `future`, and `context`.
+- `classify_rstest_parameter` returns `UnsupportedPattern` for a non-identifier
+  binding.
+- Fallback disabled means trace metadata is ignored.
+- Fallback enabled means a trace containing `rstest` or `fixture` is honoured.
+- `fixture_local_names` collects only supported fixture-local identifiers and
+  returns deterministic `BTreeSet` ordering.
+
+Keep test helpers small. If the cases become argument-heavy, use compact helper
+structs instead of wide `#[case]` signatures to stay below the Clippy threshold.
+
+### Stage C: Add failing behavioural tests
+
+Create `common/tests/rstest_detection_behaviour.rs` and
+`common/tests/features/rstest_detection.feature`.
+
+Use the `common/tests/context_behaviour.rs` pattern:
+
+- A small world fixture storing attributes, parameters, optional expansion
+  trace, options, and the most recent evaluation result.
+- `#[given]` steps that configure function attributes, parameter shapes, and
+  fallback options.
+- `#[when]` steps that run the detection helper under test.
+- `#[then]` steps that assert either positive or negative outcomes.
+- Indexed `#[scenario(path = ..., index = N)]` bindings.
+
+The feature file should cover the contract at the behaviour level, not every
+unit edge case. A good first set is:
+
+1. Detect an `rstest` test from a direct attribute.
+2. Detect an `rstest::fixture` fixture from a direct attribute.
+3. Treat a plain identifier parameter as a fixture local.
+4. Treat a `#[case]` parameter as provider-driven, not fixture-local.
+5. Ignore unsupported parameter bindings.
+6. Ignore expansion trace metadata while fallback is disabled.
+7. Detect an `rstest` test from expansion trace metadata when fallback is
+   enabled.
+
+If a step might fail because the world is not configured, make it return
+`Result<(), String>` or `Result<T, String>` instead of using `.expect()`.
+
+### Stage D: Implement the shared `common::rstest` module
+
+Implement the module in small files:
+
+- `mod.rs` should define the public surface and re-export sibling modules.
+- `detection.rs` should hold strict path matching and the pure expansion-trace
+  fallback logic.
+- `parameter.rs` should hold `ParameterBinding`, `RstestParameter`,
+  `RstestParameterKind`, and the fixture-local classification helpers.
+- `tests.rs` should contain the inline unit coverage declared in Stage B.
+
+Keep the design purely data-driven:
+
+- Use `AttributePath` from `common::attributes` for all matching.
+- Use plain owned strings for identifier bindings.
+- Keep defaults deterministic and visible through a small options type.
+- Avoid hidden globals or ambient configuration.
+
+### Stage E: Re-export and document the API
+
+Update `common/src/lib.rs` to export the new module and its public types and
+functions.
+
+Add Rustdoc examples for each public constructor or predicate. The examples
+must compile as external doctests, so they should use only exported `common`
+types and must not rely on crate-private helpers.
+
+### Stage F: Update the design document
+
+Append a short `Implementation decisions (8.1.1)` section to
+`docs/lints-for-rstest-fixtures-and-test-hygiene.md`.
+
+Record the final decisions taken during delivery, especially:
+
+- why a dedicated `common::rstest` module was chosen,
+- which exact attribute paths count as tests, fixtures, and providers,
+- how expansion-trace fallback is modelled in a pure way,
+- why unsupported/destructured bindings are deferred.
+
+If the stale `common/Cargo.toml` `rstest-bdd` comment is corrected during the
+implementation turn, mention that as documentation hygiene rather than as a
+feature decision.
+
+### Stage G: Mark the roadmap item done
+
+After the code, tests, and docs are complete, change `docs/roadmap.md` entry
+8.1.1 from `[ ]` to `[x]`.
+
+Do not mark 8.1.1 done earlier than the successful gate run.
+
+### Stage H: Validate the change
+
+Run documentation and code gates with `tee` and `set -o pipefail` so failures
+are visible even when output is truncated:
+
+```plaintext
+set -o pipefail && make fmt 2>&1 | tee /tmp/8-1-1-fmt.log
+set -o pipefail && make markdownlint 2>&1 | tee /tmp/8-1-1-markdownlint.log
+set -o pipefail && make nixie 2>&1 | tee /tmp/8-1-1-nixie.log
+set -o pipefail && make check-fmt 2>&1 | tee /tmp/8-1-1-check-fmt.log
+set -o pipefail && make lint 2>&1 | tee /tmp/8-1-1-lint.log
+set -o pipefail && make test 2>&1 | tee /tmp/8-1-1-test.log
+```
+
+For faster local iteration before the final gate, targeted commands are
+acceptable, for example:
+
+```plaintext
+cargo test -p common rstest::
+cargo test -p common --test rstest_detection_behaviour
+cargo clippy -p common --all-targets --all-features -- -D warnings
+```
+
+Remember that `make test` can run for a long time with sparse output near the
+end. Poll rather than assuming it has hung.
+
+## Acceptance checklist
+
+The implementation is complete only when all of the following are true:
+
+1. `common` exposes a strict `rstest` detection API that is independent of
+   `rustc_private`.
+2. Direct attributes and optional expansion-trace fallback both work exactly as
+   documented.
+3. Provider parameters are not misclassified as fixture locals.
+4. Unsupported/destructured bindings stay out of fixture-local sets.
+5. Unit tests and `rstest-bdd` behaviour tests both pass.
+6. The design doc records the 8.1.1 decisions.
+7. The roadmap entry is marked done.
+8. `make check-fmt`, `make lint`, and `make test` pass, with documentation
+   gates passing as well because the implementation updates Markdown files.
+
+## Outcomes & Retrospective
+
+Populate this section during implementation with:
+
+- the final file list,
+- the accepted API surface,
+- the exact behaviour scenarios added,
+- any deviations from the draft plan,
+- final gate results and notable follow-up work for 8.1.2 or 8.1.3.

--- a/docs/execplans/8-1-1-shared-rstest-test-and-fixture-detection-helpers.md
+++ b/docs/execplans/8-1-1-shared-rstest-test-and-fixture-detection-helpers.md
@@ -4,7 +4,7 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: DONE
 
 This document must be maintained in accordance with `AGENTS.md`. The canonical
 plan file is
@@ -112,19 +112,22 @@ Success is observable when:
 ## Progress
 
 - [x] (2026-03-26) Stage A: Draft this ExecPlan and capture repository state.
-- [ ] Stage B: Add failing unit tests that define the 8.1.1 detection
+- [x] (2026-03-28) Stage B: Add unit tests that define the 8.1.1 detection
   contract.
-- [ ] Stage C: Add failing `rstest-bdd` scenarios for the same contract.
-- [ ] Stage D: Implement the shared pure-library `rstest` detection module in
+- [x] (2026-03-28) Stage C: Add `rstest-bdd` scenarios for the same contract.
+- [x] (2026-03-28) Stage D: Implement the shared pure-library `rstest`
+      detection module in
   `common`.
-- [ ] Stage E: Re-export the new API from `common/src/lib.rs` and add Rustdoc
+- [x] (2026-03-28) Stage E: Re-export the new API from `common/src/lib.rs` and
+      add Rustdoc
   examples.
-- [ ] Stage F: Record implementation decisions in
+- [x] (2026-03-28) Stage F: Record implementation decisions in
   `docs/lints-for-rstest-fixtures-and-test-hygiene.md`.
-- [ ] Stage G: Mark roadmap item 8.1.1 done.
-- [ ] Stage H: Run documentation gates plus `make check-fmt`, `make lint`, and
+- [x] (2026-03-28) Stage G: Mark roadmap item 8.1.1 done.
+- [x] (2026-03-28) Stage H: Run documentation gates plus `make check-fmt`,
+      `make lint`, and
   `make test`.
-- [ ] Stage I: Finalize the living sections in this document.
+- [x] (2026-03-28) Stage I: Finalize the living sections in this document.
 
 ## Surprises & Discoveries
 
@@ -144,6 +147,14 @@ Success is observable when:
 - Existing pure-library helpers for macro filtering use the
   `is_from_expansion: bool` pattern. 8.1.1 needs an analogous pure metadata
   seam for optional expansion-trace fallback.
+- `rstest-bdd` binds `And` to the keyword family of the previous step. The
+  fixture-local behaviour scenario therefore cannot use an `And` line to
+  trigger a `#[when]` step after a `#[then]`; the harness now derives
+  `fixture_local_names` lazily inside the final assertion instead.
+- Targeted validation passed before the full gate run:
+  `cargo test -p common rstest::`,
+  `cargo test -p common --test rstest_detection_behaviour`, and
+  `cargo clippy -p common --all-targets --all-features -- -D warnings`.
 
 ## Decision Log
 
@@ -441,10 +452,34 @@ The implementation is complete only when all of the following are true:
 
 ## Outcomes & Retrospective
 
-Populate this section during implementation with:
-
-- the final file list,
-- the accepted API surface,
-- the exact behaviour scenarios added,
-- any deviations from the draft plan,
-- final gate results and notable follow-up work for 8.1.2 or 8.1.3.
+- Final file list:
+  `common/src/lib.rs`, `common/src/rstest/mod.rs`,
+  `common/src/rstest/detection.rs`, `common/src/rstest/parameter.rs`,
+  `common/src/rstest/tests.rs`, `common/tests/rstest_detection_behaviour.rs`,
+  `common/tests/features/rstest_detection.feature`, `common/Cargo.toml`,
+  `docs/lints-for-rstest-fixtures-and-test-hygiene.md`, `docs/roadmap.md`,
+  `docs/execplans/8-1-1-shared-rstest-test-and-fixture-detection-helpers.md`.
+- Accepted API surface:
+  `ExpansionTrace`, `RstestDetectionOptions`, `is_rstest_test`,
+  `is_rstest_test_with`, `is_rstest_fixture`, `is_rstest_fixture_with`,
+  `ParameterBinding`, `RstestParameter`, `RstestParameterKind`,
+  `classify_rstest_parameter`, and `fixture_local_names`, all re-exported from
+  `common`.
+- Behaviour scenarios added:
+  direct `rstest` test detection, direct `rstest::fixture` detection,
+  fixture-local identifier classification, provider classification for
+  `#[case]`, unsupported binding handling, fallback-disabled trace ignoring,
+  and fallback-enabled trace detection.
+- Deviation from the draft plan:
+  the behaviour harness computes `fixture_local_names` lazily inside the final
+  assertion instead of using a separate `When` step because `rstest-bdd`
+  carries `And` into the prior keyword family.
+- Final gate results:
+  `make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`,
+  and `make test` all passed on 2026-03-28. `make test` finished with
+  `Summary [123.240s] 1186 tests run: 1186 passed, 2 skipped`.
+- Follow-up work:
+  8.1.2 can now consume the strict `rstest` detection and `ExpansionTrace` seam
+  for user-editable span recovery, and 8.1.3 can layer argument fingerprinting
+  on top of `RstestParameterKind` without needing to re-solve
+  provider-versus-fixture classification.

--- a/docs/lints-for-rstest-fixtures-and-test-hygiene.md
+++ b/docs/lints-for-rstest-fixtures-and-test-hygiene.md
@@ -355,3 +355,29 @@ The following work is intentionally excluded from this design:
 These constraints keep runtime cost predictable, diagnostics explainable, and
 false-positive control practical for iterative promotion from experimental to
 standard lints.
+
+## Implementation decisions (8.1.1)
+
+- Shared `rstest` detection now lives in `common::rstest` rather than being
+  folded into the broader `common::context` or `common::attributes` helpers.
+  The generic helpers still answer "test-like" questions for wider lint logic,
+  while `common::rstest` keeps the stricter semantics that later fixture
+  hygiene lints need.
+- Strict test detection matches only `rstest` and `rstest::rstest`. Strict
+  fixture detection matches only `fixture` and `rstest::fixture`. This avoids
+  the broader `case` and `rstest::case` handling that remains useful in the
+  generic context helpers.
+- Provider-parameter detection defaults to bare and namespaced forms of
+  `case`, `values`, `files`, `future`, and `context`. Parameters with those
+  attributes are classified as provider-driven rather than fixture-local.
+- Expansion-trace fallback is modelled as a pure `ExpansionTrace` value owned
+  by `common`. Callers may pass it into `is_rstest_test_with` and
+  `is_rstest_fixture_with`, but fallback remains disabled unless
+  `RstestDetectionOptions` enables it explicitly.
+- Version one continues to classify only simple identifier bindings as
+  fixture-local. Unsupported or destructured bindings are reported as
+  unsupported and excluded from `fixture_local_names` so later lints do not
+  overstate fixture semantics.
+- `common/Cargo.toml` now describes the current `rstest-bdd` 0.5.x workspace
+  pin rather than the stale 0.2.x comment. That was documentation hygiene, not
+  a behavioural change.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -332,7 +332,7 @@
 
 ### 8.1. Shared foundations
 
-- [ ] 8.1.1. Add shared `rstest` test and fixture detection helpers in `common`
+- [x] 8.1.1. Add shared `rstest` test and fixture detection helpers in `common`
   for attribute-based detection and optional expansion-trace fallback. See
   [rstest fixture and test hygiene lints](lints-for-rstest-fixtures-and-test-hygiene.md)
    §Lint A: call-site fixture extraction and §Integration constraints. Requires


### PR DESCRIPTION
## Summary
- Documents the new rstest public APIs exposed by Whitaker-common and adds API re-exports, tests, and a behavioural harness to support roadmap item 8.1.1.

## Changes
- Added new rstest module structure under common/src/rstest including:
  - detection.rs, parameter.rs, mod.rs, and tests.rs
- Re-exported the new rstest API from the Whitaker-common crate via lib.rs:
  - ExpansionTrace, RstestDetectionOptions, is_rstest_test/is_rstest_test_with, is_rstest_fixture/is_rstest_fixture_with, ParameterBinding, RstestParameter, RstestParameterKind, classify_rstest_parameter, fixture_local_names
- Updated workspace dependencies and crate naming to reflect the move to Whitaker-common (renamed common to whitaker-common in workspace and code paths)
- Added unit tests for rstest detection and parameter classification (common/src/rstest/tests.rs)
- Added behavioural tests for rstest detection (common/tests/rstest_detection_behaviour.rs)
- Added a behavioural feature file (common/tests/features/rstest_detection.feature)
- Implemented rstest behavioural harness (common/tests/rstest_detection_behaviour.rs)
- Introduced a dedicated ExecPlan document for 8.1.1: docs/execplans/8-1-1-shared-rstest-test-and-fixture-detection-helpers.md
- Updated design and roadmap documentation to reflect the new API and approach:
  - docs/lints-for-rstest-fixtures-and-test-hygiene.md (Implementation decisions for 8.1.1)
  - docs/roadmap.md: mark 8.1.1 as done
- Kept the ExecPlan as a live reference and aligned tests/docs with the plan requirements.
- Preserved task references and metadata, including the DevBoxer task link.

## Rationale
- Establishes a pure-library surface in whitaker-common for rstest detection that does not rely on rustc_private, enabling lint items to consume a stable substrate.
- Separates test/fixture detection from broader generic helpers to prevent semantic leakage and to support future lints that depend on precise distinctions between tests, fixtures, and provider parameters.
- Provides optional expansion-trace fallback to accompany cases where direct attributes are unavailable, preserving a conservative default while enabling richer detection when metadata is provided.

## Plan / Work plan (high level)
- Stage B: Add failing unit tests that define the 8.1.1 detection contract.
- Stage C: Add failing rstest-bdd scenarios for the same contract.
- Stage D: Implement the shared pure-library rstest detection module in whitaker-common.
- Stage E: Re-export the new API from whitaker-common/src/lib.rs and add Rustdoc examples.
- Stage F: Record implementation decisions in the design docs.
- Stage G: Mark roadmap item 8.1.1 done after gates pass.
- Stage H: Validate with documentation gates and code quality checks.
- Stage I: Finalize living sections in the ExecPlan.

## Acceptance criteria
- [x] The ExecPlan exists and remains a live reference for 8.1.1.
- [x] It provides a clear path for implementing the shared rstest detection module in Whitaker-common.
- [x] The plan references the required gates: unit tests, behavioural tests, API re-export, and documentation updates.
- [x] Documentation gates align with docs/lints-for-rstest-fixtures-and-test-hygiene.md and docs/roadmap.md.

## Context and references
- Related planning and design documents can be found in:
  - docs/lints-for-rstest-fixtures-and-test-hygiene.md
  - docs/roadmap.md

## Notes
- This PR implements the shared rstest detection module and accompanying tests/docs; it is not a documentation-only change.
- ◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---
ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/b1c351db-cf54-4486-b6dd-2b78d41d156a

## Summary by Sourcery

Add a shared_rstest detection module to the Whitaker-common crate, exposing a stable API for identifying rstest tests, fixtures, and provider parameters, with accompanying tests and documentation updates.

New Features:
- Introduce the common::rstest module providing strict detection of rstest tests, fixtures, and provider parameters via a pure-library API.
- Re-export rstest detection types and functions (e.g., ExpansionTrace, RstestDetectionOptions, fixture_local_names) from the Whitaker-common crate.

Enhancements:
- Document implementation decisions for rstest fixture and test hygiene, including detection semantics and parameter classification rules.
- Align comments and roadmap status with the current rstest-bdd version and mark roadmap item 8.1.1 as completed.
- Add an execplan document capturing the plan, constraints, and outcomes for the shared rstest detection helpers.

Tests:
- Add unit tests for rstest detection and parameter classification in the common::rstest module.
- Add BDD-style behavioural tests and feature specifications for rstest detection in the common crate.

Task: https://www.devboxer.com/task/61bd4c9f-6b1a-4ce3-92e4-d43cf53a6dea


📎 **Task**: https://www.devboxer.com/task/db1a1f79-c621-468a-905b-148a563af2f7