### PR TITLE
Add ADR 002: mixed Verus/Kani proof strategy and roadmap updates

### DIFF
--- a/docs/adr-002-formal-proof-strategy-for-clone-detector-pipeline.md
+++ b/docs/adr-002-formal-proof-strategy-for-clone-detector-pipeline.md
@@ -1,0 +1,188 @@
+# Architectural decision record (ADR) 002: formal proof strategy for the clone detector pipeline
+
+## Status
+
+Accepted (2026-03-29): Use Verus for local algebraic and canonicalization
+invariants, Kani for bounded stateful algorithm checks, and ordinary unit and
+behaviour tests for end-to-end clone-detector regression.
+
+## Date
+
+2026-03-29.
+
+## Context and problem statement
+
+Whitaker's clone detector pipeline mixes several different kinds of correctness
+obligations. Some are small semantic invariants over arithmetic and ordering,
+such as validating locality-sensitive hashing (LSH) configuration or
+canonicalizing fragment pairs. Others are bounded behavioural properties over
+stateful algorithms, such as ensuring MinHash sketching is deterministic for a
+fixed input set, or ensuring repeated LSH bucket collisions still emit only one
+candidate pair.
+
+Roadmap item 6.4.3 already established a successful Verus sidecar workflow for
+a narrow arithmetic predicate in the brain-trust decomposition logic. The
+adjacent roadmap items 6.4.4 to 6.4.6 also established the intended split
+between Verus for algebraic reasoning and Kani for bounded graph and adjacency
+checks.
+
+The problem is to choose a proof strategy for the clone detector pipeline that
+raises assurance without forcing every algorithm into the wrong proof model,
+duplicating runtime logic in proof-only code, or replacing ordinary tests with
+formal methods where proofs are a poor fit.
+
+## Decision drivers
+
+- Match the proof tool to the shape of the property being checked.
+- Keep proof scope proportional to the implementation risk and maintenance
+  cost.
+- Preserve deterministic runtime behaviour without adding proof-tool runtime
+  dependencies to the Cargo workspace.
+- Prefer proofs over narrow shipped seams to reduce drift between runtime code
+  and proof artefacts.
+- Keep normal Cargo development workflows independent from proof execution.
+- Use bounded model checking where collection state, iteration order, and
+  insertion order are part of the behaviour under test.
+
+## Requirements
+
+### Functional requirements
+
+- Provide machine-checked assurance for high-value MinHash, LSH, and
+  clone-detector invariants.
+- Cover both local semantic invariants and bounded behavioural properties.
+- Make the ownership of each proof obligation explicit in the roadmap.
+
+### Technical requirements
+
+- Proof tooling must live in sidecar scripts and files rather than normal
+  library dependencies.
+- Verus targets must stay small, explicit, and close to pure runtime seams.
+- Kani targets must exercise real runtime code through bounded harnesses
+  rather than clean-room reimplementations.
+- Runtime APIs may gain narrow proof seams when needed, but the production API
+  should not widen solely for proof convenience.
+- Ordinary unit, behaviour, and regression tests remain required even when a
+  formal proof exists.
+
+## Options considered
+
+### Option A: ordinary tests only
+
+Rely exclusively on unit tests, behaviour tests, and integration tests for the
+clone detector pipeline.
+
+### Option B: Verus for all clone-detector proofs
+
+Model every important clone-detector invariant in Verus, including
+configuration checks, canonicalization, MinHash sketch construction, and full
+LSH bucket enumeration.
+
+### Option C: Kani for all clone-detector proofs
+
+Use Kani harnesses for both local semantic invariants and bounded behavioural
+checks across the clone detector pipeline.
+
+### Option D: mixed Verus and Kani strategy
+
+Use Verus for local algebraic and canonicalization properties, use Kani for
+bounded stateful algorithm checks, and keep ordinary tests for exact
+regression, fixture coverage, and full pipeline observability.
+
+| Topic                             | Option A      | Option B               | Option C               | Option D |
+| --------------------------------- | ------------- | ---------------------- | ---------------------- | -------- |
+| Local arithmetic invariants       | Indirect only | Strong                 | Adequate               | Strong   |
+| Stateful bounded behaviour        | Good          | Costly to model        | Strong                 | Strong   |
+| Collection-heavy algorithms       | Test only     | Poor fit               | Good fit               | Good fit |
+| Proof maintenance cost            | Low           | High                   | Moderate               | Moderate |
+| Drift risk from proof-only models | None          | High                   | Medium                 | Medium   |
+| Coverage of exact regressions     | Strong        | Weak unless duplicated | Weak unless duplicated | Strong   |
+
+_Table 1: Trade-offs between proof strategies for the clone detector pipeline._
+
+## Decision outcome / proposed direction
+
+Adopt Option D.
+
+Whitaker will use a mixed formal-method strategy for clone-detector algorithm
+implementations and detector invariants:
+
+- Use **Verus** for small semantic invariants whose runtime shape is already
+  close to a proof-friendly predicate or constructor.
+- Use **Kani** for bounded behavioural properties over the real MinHash and LSH
+  implementations, especially where stateful collection updates or insertion
+  order affect the observable result.
+- Keep **ordinary tests** for exact regression vectors, fixture-driven
+  scenarios, and end-to-end pipeline behaviour.
+
+Initial target allocation:
+
+- **Verus**
+  - `LshConfig::new` and its `bands * rows == MINHASH_SIZE` invariant.
+  - `CandidatePair::new` canonical lexical ordering and self-pair
+    suppression.
+  - Small pure helpers introduced to state set semantics explicitly, where the
+    proof value justifies the seam.
+- **Kani**
+  - Bounded `MinHasher::sketch` checks for determinism, duplicate-hash
+    insensitivity, and empty-input failure.
+  - Bounded `LshIndex` checks for no self-pairs, canonical pair ordering,
+    repeated-band deduplication, and insertion-order independence for small
+    bounded inputs.
+- **Ordinary tests**
+  - Exact SplitMix64 regression vectors and seed-stream stability.
+  - Token-pass, candidate-generation, and SARIF-emission behaviour suites.
+
+This ADR does not claim that MinHash or LSH statistical quality can be proved
+exhaustively with these tools. The decision covers implementation and detector
+invariants, not probabilistic performance guarantees.
+
+## Goals and non-goals
+
+Goals:
+
+- Use each proof tool where it is the best technical fit.
+- Add formal assurance to the highest-value clone-detector invariants.
+- Keep proof workflows reproducible and explicit in repository tooling.
+- Preserve the existing expectation that tests remain the first regression
+  safety net.
+
+Non-goals:
+
+- Prove the probabilistic collision quality of MinHash or LSH exhaustively.
+- Replace unit, behaviour, or integration tests with proofs.
+- Model the entirety of `BTreeMap` or `BTreeSet` semantics in Verus.
+- Force every clone-detector stage into formal verification before the runtime
+  pipeline exists.
+
+## Migration plan
+
+1. Record this decision in an ADR and add explicit roadmap tasks under `7.2`
+   for the selected Verus and Kani work.
+2. Add clone-detector proof workflow targets and wrapper scripts so Verus and
+   Kani can run reproducibly outside normal Cargo builds.
+3. Implement the first Verus proofs for `LshConfig` and `CandidatePair`.
+4. Implement bounded Kani harnesses for `MinHasher::sketch` and `LshIndex`
+   candidate-pair invariants.
+5. Extend the same split to later clone-detector stages only where the runtime
+   code exposes a stable, proof-worthy seam.
+
+## Known risks and limitations
+
+- Verus becomes expensive quickly once proofs depend on collection internals or
+  bit-level mixing routines rather than small semantic seams.
+- Kani guarantees are bounded by the harness size and search space; they do not
+  replace unbounded mathematical proofs.
+- Proof-only helper seams can drift from production code if they do not stay
+  close to shipped constructors or predicates.
+- Formal proofs may still leave algorithm-quality questions unresolved, such as
+  whether a chosen banding configuration is operationally effective on real
+  repositories.
+
+## Architectural rationale
+
+This decision aligns the clone detector with the proof strategy already used in
+the brain-trust roadmap: Verus for local algebraic correctness, Kani for
+bounded stateful behaviour. That keeps formal methods aligned with Whitaker's
+larger architectural principle of choosing small, coherent modules and testing
+the real implementation rather than elaborate stand-in models.

--- a/docs/adr-002-formal-proof-strategy-for-clone-detector-pipeline.md
+++ b/docs/adr-002-formal-proof-strategy-for-clone-detector-pipeline.md
@@ -38,9 +38,9 @@ formal methods where proofs are a poor fit.
   cost.
 - Preserve deterministic runtime behaviour without adding proof-tool runtime
   dependencies to the Cargo workspace.
-- Prefer proofs over narrow shipped seams to reduce drift between runtime code
+- Prefer proofs to narrow shipped seams to reduce drift between runtime code
   and proof artefacts.
-- Keep normal Cargo development workflows independent from proof execution.
+- Keep normal Cargo development workflows independent of proof execution.
 - Use bounded model checking where collection state, iteration order, and
   insertion order are part of the behaviour under test.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -251,6 +251,27 @@
   fingerprints and spans. See
   [clone detector design](whitaker-clone-detector-design.md) §SARIF emission
   (Run 0). Requires 7.1.1.
+- [ ] 7.2.4. Add sidecar proof workflows and Makefile targets for clone-detector
+  Verus and Kani checks. See
+  [ADR 002](adr-002-formal-proof-strategy-for-clone-detector-pipeline.md).
+- [ ] 7.2.5. Use Verus to prove `LshConfig::new` rejects zero `bands` and
+  `rows`, and enforces `bands * rows == MINHASH_SIZE`. See
+  [ADR 002](adr-002-formal-proof-strategy-for-clone-detector-pipeline.md) and
+  [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.
+- [ ] 7.2.6. Use Verus to prove `CandidatePair::new` canonicalizes fragment
+  ordering and suppresses self-pairs. See
+  [ADR 002](adr-002-formal-proof-strategy-for-clone-detector-pipeline.md) and
+  [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.
+- [ ] 7.2.7. Use Kani to verify bounded `MinHasher::sketch` invariants,
+  including deterministic output, duplicate-hash insensitivity, and empty-input
+  failure. See
+  [ADR 002](adr-002-formal-proof-strategy-for-clone-detector-pipeline.md) and
+  [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.
+- [ ] 7.2.8. Use Kani to verify bounded `LshIndex` invariants, including no
+  self-pairs, canonical pair ordering, repeated-band deduplication, and
+  insertion-order independence. See
+  [ADR 002](adr-002-formal-proof-strategy-for-clone-detector-pipeline.md) and
+  [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.
 
 ### 7.3. AST refinement (Type-3)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -252,24 +252,24 @@
   [clone detector design](whitaker-clone-detector-design.md) §SARIF emission
   (Run 0). Requires 7.1.1.
 - [ ] 7.2.4. Add sidecar proof workflows and Makefile targets for clone-detector
-  Verus and Kani checks. See
+  Verus and Kani checks. Requires 7.2.2. See
   [ADR 002](adr-002-formal-proof-strategy-for-clone-detector-pipeline.md).
 - [ ] 7.2.5. Use Verus to prove `LshConfig::new` rejects zero `bands` and
-  `rows`, and enforces `bands * rows == MINHASH_SIZE`. See
+  `rows`, and enforces `bands * rows == MINHASH_SIZE`. Requires 7.2.4. See
   [ADR 002](adr-002-formal-proof-strategy-for-clone-detector-pipeline.md) and
   [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.
 - [ ] 7.2.6. Use Verus to prove `CandidatePair::new` canonicalizes fragment
-  ordering and suppresses self-pairs. See
+  ordering and suppresses self-pairs. Requires 7.2.4. See
   [ADR 002](adr-002-formal-proof-strategy-for-clone-detector-pipeline.md) and
   [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.
 - [ ] 7.2.7. Use Kani to verify bounded `MinHasher::sketch` invariants,
   including deterministic output, duplicate-hash insensitivity, and empty-input
-  failure. See
+  failure. Requires 7.2.4. See
   [ADR 002](adr-002-formal-proof-strategy-for-clone-detector-pipeline.md) and
   [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.
 - [ ] 7.2.8. Use Kani to verify bounded `LshIndex` invariants, including no
   self-pairs, canonical pair ordering, repeated-band deduplication, and
-  insertion-order independence. See
+  insertion-order independence. Requires 7.2.4. See
   [ADR 002](adr-002-formal-proof-strategy-for-clone-detector-pipeline.md) and
   [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.
 


### PR DESCRIPTION
## Summary
- Introduces ADR 002: formal proof strategy for the clone detector pipeline to guide tool usage. Uses Verus for local algebraic invariants, Kani for bounded stateful checks, and retains ordinary tests as the regression safety net.

## Changes
### Documentation
- Added docs/adr-002-formal-proof-strategy-for-clone-detector-pipeline.md detailing the architectural decision, rationale, options, and migration plan.

### Roadmap
- Updated docs/roadmap.md to reference ADR 002 and to outline concrete sidecar proof tasks:
  - 7.2.4–7.2.8, including Verus proofs for LshConfig and CandidatePair and Kani harnesses for MinHasher::sketch and LshIndex.
  - All tasks link to ADR 002 for rationale and scope.

## Rationale
- Aligns proof work with Whitaker’s architecture: assign each proof to its best-fit tool, keep proof scope proportional to risk, avoid embedding proof-only runtime dependencies, and preserve a strong role for ordinary tests.
- Keeps development workflows reproducible and adjacent to existing runtime code, avoiding drift between proofs and production paths.
- Prefers a mixed approach (Option D) to maximize coverage of local invariants and bounded behavioural properties while preserving clear, maintainable proofs.

## Design overview
- Option D (mixed Verus + Kani):
  - Verus for small semantic invariants and canonicalization predicates.
  - Kani for bounded behavioural properties over runtime components (stateful APIs, sketches, and index logic).
  - Ordinary tests for exact regressions and end-to-end behaviour remain the primary safety net.
- Initial allocations:
  - Verus
    - LshConfig::new invariant: bands * rows == MINHASH_SIZE
    - CandidatePair::new: canonical lexical ordering and self-pair suppression
    - Small pure helpers that require explicit state-set semantics
  - Kani
    - MinHasher::sketch: determinism, duplicate-hash insensitivity, empty-input failure
    - LshIndex: no self-pairs, canonical pair ordering, repeated-band deduplication, insertion-order independence for small inputs
  - Ordinary tests
    - Exact SplitMix64 regression vectors and seed-stream stability
    - Token-pass, candidate-generation, and SARIF-emission behaviour

## Migration plan
1. Record ADR and add explicit roadmap tasks under 7.2 for Verus and Kani work.
2. Add sidecar proof workflow targets and Makefile targets so Verus and Kani can run reproducibly outside normal Cargo builds.
3. Implement the first Verus proofs for LshConfig and CandidatePair.
4. Implement bounded Kani harnesses for MinHasher::sketch and LshIndex invariants.
5. Extend the same split approach to later clone-detector stages where a stable seam exists.

## Known risks and limitations
- Verus proofs can become expensive when they touch collection internals or low-level mixing routines.
- Kani profits are bounded by harness size and search space; they do not replace unbounded proofs.
- Proof-only helpers can drift from production if not kept close to shipped constructors/predicates.
- Formal proofs do not guarantee probabilistic quality of MinHash or LSH; they cover invariants and behaviours, not statistical properties.

## Goals and non-goals
- Goals:
  - Use each tool where it fits best
  - Add formal assurance to high-value clone-detector invariants
  - Keep proof workflows reproducible and explicit
  - Preserve tests as the primary regression safety net
- Non-goals:
  - Exhaustively proving probabilistic collision quality
  - Replacing unit, behaviour, or integration tests with proofs
  - Fully modeling complex data structures (e.g., complete BTree semantics) in proofs
  - Forcing all clone-detector stages into formal verification before runtime pipeline exists


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/9466b10b-bb31-4af9-9422-78d725bc4626

## Summary by Sourcery

Document a mixed Verus/Kani formal proof strategy for the clone detector pipeline and wire it into the roadmap as concrete proof tasks.

Enhancements:
- Extend the roadmap with explicit Verus and Kani sidecar proof tasks for key MinHash, LSH, and candidate-pair invariants.

Documentation:
- Add ADR 002 describing the formal verification strategy for the clone detector pipeline, including tool roles, goals, migration plan, and risks.


📎 **Task**: https://www.devboxer.com/task/8b83817c-5542-4d74-8748-8cb621b22974