### PR TITLE
Emit Run 0 SARIF for accepted Type-1 and Type-2 clone pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,7 +3297,9 @@ dependencies = [
  "rstest-bdd",
  "rstest-bdd-macros",
  "rustc_lexer",
+ "sha2",
  "thiserror 2.0.18",
+ "whitaker_sarif",
 ]
 
 [[package]]

--- a/crates/whitaker_clones_core/Cargo.toml
+++ b/crates/whitaker_clones_core/Cargo.toml
@@ -12,6 +12,8 @@ documentation.workspace = true
 [dependencies]
 thiserror = { workspace = true }
 rustc_lexer = { workspace = true }
+sha2 = { workspace = true }
+whitaker_sarif = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/whitaker_clones_core/src/lib.rs
+++ b/crates/whitaker_clones_core/src/lib.rs
@@ -9,13 +9,19 @@
 //! - Winnowing to retain stable representative fingerprints.
 //! - Deterministic MinHash sketches over retained fingerprints.
 //! - Locality-sensitive hashing (LSH) candidate generation.
+//! - Token-pass acceptance and SARIF Run 0 emission for accepted pairs.
 
 pub mod index;
+pub mod run0;
 pub mod token;
 
 pub use index::{
     CandidatePair, FragmentId, IndexError, IndexResult, LshConfig, LshIndex, MINHASH_SIZE,
     MinHashSignature, MinHasher,
+};
+pub use run0::{
+    AcceptedPair, Run0Error, Run0Result, SimilarityRatio, SimilarityThreshold, TokenFragment,
+    TokenPassConfig, accept_candidate_pairs, emit_run0,
 };
 pub use token::{
     Fingerprint, IdentifierSymbol, LiteralSymbol, NormProfile, NormalizedToken,

--- a/crates/whitaker_clones_core/src/run0/emit.rs
+++ b/crates/whitaker_clones_core/src/run0/emit.rs
@@ -45,8 +45,6 @@ pub fn accept_candidate_pairs(
                 right_fragment: right.id().as_str().to_owned(),
             });
         }
-        ensure_non_empty(left)?;
-        ensure_non_empty(right)?;
 
         let Some(score) =
             jaccard_similarity(left.retained_fingerprints(), right.retained_fingerprints())

--- a/crates/whitaker_clones_core/src/run0/emit.rs
+++ b/crates/whitaker_clones_core/src/run0/emit.rs
@@ -1,0 +1,330 @@
+//! Candidate acceptance and SARIF Run 0 emission.
+
+use std::collections::BTreeMap;
+
+use sha2::{Digest, Sha256};
+use whitaker_sarif::{
+    Level, LocationBuilder, RelatedLocation, ResultBuilder, Run, RunBuilder, WHITAKER_FRAGMENT_KEY,
+    WHK001_ID, WHK002_ID, WhitakerPropertiesBuilder, all_rules, deduplicate_results,
+};
+
+use crate::{CandidatePair, NormProfile};
+
+use super::{
+    error::{Run0Error, Run0Result},
+    score::{SimilarityRatio, jaccard_similarity, select_rule_profile},
+    span::region_for_range,
+    types::{AcceptedPair, TokenFragment, TokenPassConfig},
+};
+
+/// Accepts canonical candidate pairs for later Run 0 emission.
+///
+/// The resolved rule profile matches each fragment's normalization profile:
+/// Type-1 fragments can only emit `WHK001`, and Type-2 fragments can only emit
+/// `WHK002`.
+///
+/// # Errors
+///
+/// Returns a typed error when fragments are missing, empty, mixed-profile, or
+/// thresholds are malformed.
+pub fn accept_candidate_pairs(
+    fragments: &[TokenFragment],
+    candidates: &[CandidatePair],
+    config: &TokenPassConfig,
+) -> Run0Result<Vec<AcceptedPair>> {
+    config.type1_threshold().validate()?;
+    config.type2_threshold().validate()?;
+
+    let fragment_map = fragment_map(fragments);
+    let mut accepted = Vec::new();
+    for pair in candidates {
+        let (left, right) = resolve_pair(&fragment_map, pair)?;
+        if left.profile() != right.profile() {
+            return Err(Run0Error::MixedProfiles {
+                left_fragment: left.id().as_str().to_owned(),
+                right_fragment: right.id().as_str().to_owned(),
+            });
+        }
+        ensure_non_empty(left)?;
+        ensure_non_empty(right)?;
+
+        let Some(score) =
+            jaccard_similarity(left.retained_fingerprints(), right.retained_fingerprints())
+        else {
+            return Err(Run0Error::EmptyFingerprintSet {
+                fragment_id: left.id().as_str().to_owned(),
+            });
+        };
+        let Some(profile) = select_rule_profile(
+            left.profile(),
+            score,
+            config.type1_threshold(),
+            config.type2_threshold(),
+        ) else {
+            continue;
+        };
+        accepted.push(AcceptedPair::new(pair.clone(), profile, score));
+    }
+
+    accepted.sort_by(|left, right| {
+        left.pair()
+            .cmp(right.pair())
+            .then_with(|| profile_sort_key(left.profile()).cmp(&profile_sort_key(right.profile())))
+    });
+    accepted
+        .dedup_by(|left, right| left.pair() == right.pair() && left.profile() == right.profile());
+    Ok(accepted)
+}
+
+/// Emits SARIF Run 0 results for accepted token-pass pairs.
+///
+/// # Errors
+///
+/// Returns a typed error when accepted pairs reference missing fragments or
+/// malformed fingerprint ranges.
+pub fn emit_run0(
+    fragments: &[TokenFragment],
+    accepted_pairs: &[AcceptedPair],
+    config: &TokenPassConfig,
+) -> Run0Result<Run> {
+    let fragment_map = fragment_map(fragments);
+    let mut results = Vec::new();
+    for accepted in accepted_pairs {
+        let (left, right) = resolve_pair(&fragment_map, accepted.pair())?;
+        ensure_non_empty(left)?;
+        ensure_non_empty(right)?;
+        results.push(build_result(left, right, accepted, config)?);
+    }
+    results.sort_by(result_sort_key);
+    let deduplicated = deduplicate_results(&results);
+
+    let mut run =
+        RunBuilder::new(config.tool_name(), config.tool_version()).with_rules(all_rules());
+    for result in deduplicated {
+        run = run.with_result(result);
+    }
+    Ok(run.build())
+}
+
+fn build_result(
+    primary: &TokenFragment,
+    peer: &TokenFragment,
+    accepted: &AcceptedPair,
+    config: &TokenPassConfig,
+) -> Run0Result<whitaker_sarif::SarifResult> {
+    let primary_range = primary_fingerprint(primary)?.range.clone();
+    let peer_range = primary_fingerprint(peer)?.range.clone();
+    let primary_region =
+        region_for_range(primary.id().as_str(), primary.source_text(), primary_range)?;
+    let peer_region = region_for_range(peer.id().as_str(), peer.source_text(), peer_range)?;
+
+    let rule_id = match accepted.profile() {
+        NormProfile::T1 => WHK001_ID,
+        NormProfile::T2 => WHK002_ID,
+    };
+    let score = accepted.score();
+    let score_text = score.as_decimal_string();
+    let pair_fingerprint = pair_fingerprint(accepted);
+    let token_hash = token_hash(primary, peer);
+    let properties = WhitakerPropertiesBuilder::new(profile_name(accepted.profile()))
+        .with_k(config.shingle_size())
+        .with_window(config.winnow_window())
+        .with_jaccard(score_to_f64(score)?)
+        .with_cosine(0.0)
+        .with_group_id(0)
+        .with_class_size(2)
+        .build()?
+        .try_to_value()?;
+    let primary_label = format!("{}:{}", primary.file_uri(), compact_span(&primary_region));
+    let peer_label = format!("{}:{}", peer.file_uri(), compact_span(&peer_region));
+
+    ResultBuilder::new(rule_id)
+        .with_level(Level::Warning)
+        .with_message(build_message(
+            accepted.profile(),
+            &primary_label,
+            &peer_label,
+            &score_text,
+        ))
+        .with_location(
+            LocationBuilder::new(primary.file_uri())
+                .with_region(primary_region)
+                .build(),
+        )
+        .with_related_location(RelatedLocation {
+            id: 1,
+            message: Some(whitaker_sarif::Message {
+                text: format!("Peer clone fragment: {}", peer.id().as_str()),
+            }),
+            physical_location: whitaker_sarif::PhysicalLocation {
+                artifact_location: whitaker_sarif::ArtifactLocation {
+                    uri: peer.file_uri().to_owned(),
+                    uri_base_id: None,
+                },
+                region: Some(peer_region),
+            },
+        })
+        .with_fingerprint(WHITAKER_FRAGMENT_KEY, pair_fingerprint)
+        .with_fingerprint("tokenHash", token_hash)
+        .with_properties(properties)
+        .build()
+        .map_err(Run0Error::from)
+}
+
+fn build_message(
+    profile: NormProfile,
+    primary_label: &str,
+    peer_label: &str,
+    score_text: &str,
+) -> String {
+    format!(
+        "Type-{} clone: {} <-> {} (sim = {})",
+        profile_number(profile),
+        primary_label,
+        peer_label,
+        score_text
+    )
+}
+
+fn compact_span(region: &whitaker_sarif::Region) -> String {
+    format!(
+        "{}:{}-{}:{}",
+        region.start_line,
+        region.start_column.unwrap_or(1),
+        region.end_line.unwrap_or(region.start_line),
+        region
+            .end_column
+            .unwrap_or(region.start_column.unwrap_or(1))
+    )
+}
+
+fn profile_number(profile: NormProfile) -> &'static str {
+    match profile {
+        NormProfile::T1 => "1",
+        NormProfile::T2 => "2",
+    }
+}
+
+fn profile_name(profile: NormProfile) -> &'static str {
+    match profile {
+        NormProfile::T1 => "T1",
+        NormProfile::T2 => "T2",
+    }
+}
+
+fn profile_sort_key(profile: NormProfile) -> u8 {
+    match profile {
+        NormProfile::T1 => 1,
+        NormProfile::T2 => 2,
+    }
+}
+
+fn score_to_f64(score: SimilarityRatio) -> Run0Result<f64> {
+    let value = score.as_decimal_string();
+    value
+        .parse::<f64>()
+        .map_err(|_| Run0Error::InvalidScore { value })
+}
+
+fn fragment_map(fragments: &[TokenFragment]) -> BTreeMap<&str, &TokenFragment> {
+    fragments
+        .iter()
+        .map(|fragment| (fragment.id().as_str(), fragment))
+        .collect()
+}
+
+fn resolve_pair<'a>(
+    fragment_map: &'a BTreeMap<&str, &'a TokenFragment>,
+    pair: &CandidatePair,
+) -> Run0Result<(&'a TokenFragment, &'a TokenFragment)> {
+    let left = fragment_map
+        .get(pair.left().as_str())
+        .copied()
+        .ok_or_else(|| Run0Error::MissingFragment {
+            fragment_id: pair.left().as_str().to_owned(),
+        })?;
+    let right = fragment_map
+        .get(pair.right().as_str())
+        .copied()
+        .ok_or_else(|| Run0Error::MissingFragment {
+            fragment_id: pair.right().as_str().to_owned(),
+        })?;
+    Ok((left, right))
+}
+
+fn ensure_non_empty(fragment: &TokenFragment) -> Run0Result<()> {
+    if fragment.retained_fingerprints().is_empty() {
+        return Err(Run0Error::EmptyFingerprintSet {
+            fragment_id: fragment.id().as_str().to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn primary_fingerprint(fragment: &TokenFragment) -> Run0Result<&crate::Fingerprint> {
+    fragment
+        .retained_fingerprints()
+        .first()
+        .ok_or_else(|| Run0Error::EmptyFingerprintSet {
+            fragment_id: fragment.id().as_str().to_owned(),
+        })
+}
+
+fn pair_fingerprint(accepted: &AcceptedPair) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(accepted.pair().left().as_str().as_bytes());
+    hasher.update([0]);
+    hasher.update(accepted.pair().right().as_str().as_bytes());
+    hasher.update([0]);
+    hasher.update(profile_name(accepted.profile()).as_bytes());
+    digest_hex(hasher.finalize())
+}
+
+fn token_hash(left: &TokenFragment, right: &TokenFragment) -> String {
+    let mut values = left
+        .retained_fingerprints()
+        .iter()
+        .chain(right.retained_fingerprints().iter())
+        .map(|fingerprint| fingerprint.hash)
+        .collect::<Vec<_>>();
+    values.sort_unstable();
+    values.dedup();
+
+    let mut hasher = Sha256::new();
+    for value in values {
+        hasher.update(value.to_be_bytes());
+    }
+    digest_hex(hasher.finalize())
+}
+
+fn digest_hex(bytes: impl AsRef<[u8]>) -> String {
+    let mut output = String::new();
+    for byte in bytes.as_ref() {
+        output.push(hex_digit(byte >> 4));
+        output.push(hex_digit(byte & 0x0f));
+    }
+    output
+}
+
+fn hex_digit(value: u8) -> char {
+    match value {
+        0..=9 => char::from(b'0'.saturating_add(value)),
+        _ => char::from(b'a'.saturating_add(value.saturating_sub(10))),
+    }
+}
+
+fn result_sort_key(
+    result: &whitaker_sarif::SarifResult,
+    other: &whitaker_sarif::SarifResult,
+) -> std::cmp::Ordering {
+    result
+        .rule_id
+        .cmp(&other.rule_id)
+        .then_with(|| {
+            result
+                .partial_fingerprints
+                .get(WHITAKER_FRAGMENT_KEY)
+                .cmp(&other.partial_fingerprints.get(WHITAKER_FRAGMENT_KEY))
+        })
+        .then_with(|| result.message.text.cmp(&other.message.text))
+}

--- a/crates/whitaker_clones_core/src/run0/emit.rs
+++ b/crates/whitaker_clones_core/src/run0/emit.rs
@@ -49,8 +49,13 @@ pub fn accept_candidate_pairs(
         let Some(score) =
             jaccard_similarity(left.retained_fingerprints(), right.retained_fingerprints())
         else {
+            let empty_fragment_id = if left.retained_fingerprints().is_empty() {
+                left.id().as_str().to_owned()
+            } else {
+                right.id().as_str().to_owned()
+            };
             return Err(Run0Error::EmptyFingerprintSet {
-                fragment_id: left.id().as_str().to_owned(),
+                fragment_id: empty_fragment_id,
             });
         };
         let Some(profile) = select_rule_profile(

--- a/crates/whitaker_clones_core/src/run0/error.rs
+++ b/crates/whitaker_clones_core/src/run0/error.rs
@@ -1,0 +1,75 @@
+//! Typed errors for token-pass acceptance and SARIF emission.
+
+use thiserror::Error;
+
+/// Result type for Run 0 acceptance and emission operations.
+pub type Run0Result<T> = Result<T, Run0Error>;
+
+/// Errors raised while accepting candidate pairs or emitting SARIF Run 0.
+#[derive(Debug, Error)]
+pub enum Run0Error {
+    /// A candidate or accepted pair referenced an unknown fragment ID.
+    #[error("missing token fragment `{fragment_id}`")]
+    MissingFragment {
+        /// Fragment identifier that was referenced but not supplied.
+        fragment_id: String,
+    },
+
+    /// A fragment had no retained fingerprints, so set-based scoring was not possible.
+    #[error("token fragment `{fragment_id}` must retain at least one fingerprint")]
+    EmptyFingerprintSet {
+        /// Fragment identifier with an empty retained set.
+        fragment_id: String,
+    },
+
+    /// The pair resolved to fragments emitted under different normalization profiles.
+    #[error(
+        "candidate pair `{left_fragment}` and `{right_fragment}` must share the same normalization profile"
+    )]
+    MixedProfiles {
+        /// Left fragment identifier.
+        left_fragment: String,
+        /// Right fragment identifier.
+        right_fragment: String,
+    },
+
+    /// A configured threshold was malformed.
+    #[error("similarity threshold `{name}` must satisfy 0 < numerator <= denominator")]
+    InvalidThreshold {
+        /// Human-readable threshold name.
+        name: String,
+    },
+
+    /// A retained fingerprint byte range could not be mapped back to source text.
+    #[error(
+        "fingerprint range {start}..{end} for `{fragment_id}` is invalid for source length {source_len}"
+    )]
+    InvalidFingerprintRange {
+        /// Fragment identifier.
+        fragment_id: String,
+        /// Range start.
+        start: usize,
+        /// Range end.
+        end: usize,
+        /// Source length in bytes.
+        source_len: usize,
+    },
+
+    /// The source text was not valid UTF-8 at the reported byte boundary.
+    #[error("fingerprint range for `{fragment_id}` does not align to UTF-8 character boundaries")]
+    InvalidUtf8Boundary {
+        /// Fragment identifier.
+        fragment_id: String,
+    },
+
+    /// SARIF model construction failed.
+    #[error(transparent)]
+    Sarif(#[from] whitaker_sarif::SarifError),
+
+    /// Internal decimal parsing for Whitaker properties failed unexpectedly.
+    #[error("failed to convert similarity ratio `{value}` into a finite SARIF score")]
+    InvalidScore {
+        /// The decimal string that failed to parse.
+        value: String,
+    },
+}

--- a/crates/whitaker_clones_core/src/run0/mod.rs
+++ b/crates/whitaker_clones_core/src/run0/mod.rs
@@ -12,6 +12,8 @@ pub use score::{SimilarityRatio, SimilarityThreshold};
 pub use types::{AcceptedPair, TokenFragment, TokenPassConfig};
 
 #[cfg(test)]
+mod test_helpers;
+#[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod tests_emit;

--- a/crates/whitaker_clones_core/src/run0/mod.rs
+++ b/crates/whitaker_clones_core/src/run0/mod.rs
@@ -13,3 +13,5 @@ pub use types::{AcceptedPair, TokenFragment, TokenPassConfig};
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_emit;

--- a/crates/whitaker_clones_core/src/run0/mod.rs
+++ b/crates/whitaker_clones_core/src/run0/mod.rs
@@ -1,0 +1,15 @@
+//! Token-pass acceptance and SARIF Run 0 emission.
+
+mod emit;
+mod error;
+mod score;
+mod span;
+mod types;
+
+pub use emit::{accept_candidate_pairs, emit_run0};
+pub use error::{Run0Error, Run0Result};
+pub use score::{SimilarityRatio, SimilarityThreshold};
+pub use types::{AcceptedPair, TokenFragment, TokenPassConfig};
+
+#[cfg(test)]
+mod tests;

--- a/crates/whitaker_clones_core/src/run0/score.rs
+++ b/crates/whitaker_clones_core/src/run0/score.rs
@@ -177,6 +177,13 @@ fn unique_hashes(fingerprints: &[Fingerprint]) -> BTreeSet<u64> {
         .collect()
 }
 
+/// Compares a Jaccard score against a threshold using cross-multiplication.
+///
+/// Assumes fingerprint counts (intersection and union) are many orders of
+/// magnitude smaller than `usize::MAX` in practical use. Uses `saturating_mul`
+/// to avoid panics on pathological inputs; clamped results only occur in
+/// extreme/unrealistic cases. Callers should validate counts if they may
+/// approach `usize::MAX`.
 fn meets_threshold(score: SimilarityRatio, threshold: SimilarityThreshold) -> bool {
     score.intersection.saturating_mul(threshold.denominator)
         >= score.union.saturating_mul(threshold.numerator)

--- a/crates/whitaker_clones_core/src/run0/score.rs
+++ b/crates/whitaker_clones_core/src/run0/score.rs
@@ -157,15 +157,13 @@ fn meets_threshold(score: SimilarityRatio, threshold: SimilarityThreshold) -> bo
 }
 
 fn repeated_division(numerator: usize, denominator: usize) -> Option<(usize, usize)> {
+    debug_assert!(denominator != 0, "denominator must be non-zero");
     if denominator == 0 {
         return None;
     }
 
-    let mut quotient = 0usize;
-    let mut remainder = numerator;
-    while remainder >= denominator {
-        remainder = remainder.saturating_sub(denominator);
-        quotient = quotient.saturating_add(1);
-    }
+    let quotient = numerator / denominator;
+    let remainder = numerator % denominator;
+
     Some((quotient, remainder))
 }

--- a/crates/whitaker_clones_core/src/run0/score.rs
+++ b/crates/whitaker_clones_core/src/run0/score.rs
@@ -9,6 +9,17 @@ use super::error::{Run0Error, Run0Result};
 /// Integer-backed Jaccard similarity ratio.
 ///
 /// The score represents `intersection / union` using set semantics.
+///
+/// # Examples
+///
+/// ```
+/// use whitaker_clones_core::run0::SimilarityRatio;
+///
+/// let ratio = SimilarityRatio::new(3, 5);
+/// assert_eq!(ratio.intersection(), 3);
+/// assert_eq!(ratio.union(), 5);
+/// assert_eq!(ratio.as_decimal_string(), "0.600000");
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SimilarityRatio {
     intersection: usize,
@@ -60,6 +71,17 @@ impl SimilarityRatio {
 }
 
 /// Integer-backed threshold for a similarity ratio.
+///
+/// # Examples
+///
+/// ```
+/// use whitaker_clones_core::run0::SimilarityThreshold;
+///
+/// let threshold = SimilarityThreshold::new("custom", 4, 5)
+///     .expect("valid threshold");
+/// assert_eq!(threshold.numerator(), 4);
+/// assert_eq!(threshold.denominator(), 5);
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SimilarityThreshold {
     name: &'static str,
@@ -81,7 +103,11 @@ impl SimilarityThreshold {
 
     /// Creates a threshold without validation for trusted internal defaults.
     #[must_use]
-    pub const fn new_unchecked(name: &'static str, numerator: usize, denominator: usize) -> Self {
+    pub(crate) const fn new_unchecked(
+        name: &'static str,
+        numerator: usize,
+        denominator: usize,
+    ) -> Self {
         Self {
             name,
             numerator,

--- a/crates/whitaker_clones_core/src/run0/score.rs
+++ b/crates/whitaker_clones_core/src/run0/score.rs
@@ -101,8 +101,13 @@ impl SimilarityThreshold {
         self.denominator
     }
 
+    /// Returns `true` if the threshold represents a ratio within `(0, 1]`.
+    fn is_valid(self) -> bool {
+        self.numerator != 0 && self.denominator != 0 && self.numerator <= self.denominator
+    }
+
     pub(crate) fn validate(self) -> Run0Result<()> {
-        if self.numerator == 0 || self.denominator == 0 || self.numerator > self.denominator {
+        if !self.is_valid() {
             return Err(Run0Error::InvalidThreshold {
                 name: self.name.to_owned(),
             });

--- a/crates/whitaker_clones_core/src/run0/score.rs
+++ b/crates/whitaker_clones_core/src/run0/score.rs
@@ -1,0 +1,166 @@
+//! Integer-only token-pass similarity scoring helpers.
+
+use std::collections::BTreeSet;
+
+use crate::{Fingerprint, NormProfile};
+
+use super::error::{Run0Error, Run0Result};
+
+/// Integer-backed Jaccard similarity ratio.
+///
+/// The score represents `intersection / union` using set semantics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SimilarityRatio {
+    intersection: usize,
+    union: usize,
+}
+
+impl SimilarityRatio {
+    /// Creates a ratio from raw set counts.
+    #[must_use]
+    pub const fn new(intersection: usize, union: usize) -> Self {
+        Self {
+            intersection,
+            union,
+        }
+    }
+
+    /// Returns the numerator of the ratio.
+    #[must_use]
+    pub const fn intersection(self) -> usize {
+        self.intersection
+    }
+
+    /// Returns the denominator of the ratio.
+    #[must_use]
+    pub const fn union(self) -> usize {
+        self.union
+    }
+
+    /// Formats the ratio as a six-decimal string without floating-point arithmetic.
+    #[must_use]
+    pub fn as_decimal_string(self) -> String {
+        let Some((integer, remainder)) = repeated_division(self.intersection, self.union) else {
+            return "0.000000".to_owned();
+        };
+
+        let mut decimals = String::new();
+        let mut current = remainder;
+        for _ in 0..6 {
+            current = current.saturating_mul(10);
+            let (digit, next_remainder) = repeated_division(current, self.union).unwrap_or((0, 0));
+            decimals.push(char::from(
+                b'0'.saturating_add(u8::try_from(digit).unwrap_or(0)),
+            ));
+            current = next_remainder;
+        }
+
+        format!("{integer}.{decimals}")
+    }
+}
+
+/// Integer-backed threshold for a similarity ratio.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SimilarityThreshold {
+    name: &'static str,
+    numerator: usize,
+    denominator: usize,
+}
+
+impl SimilarityThreshold {
+    /// Validates and creates a new threshold.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Run0Error::InvalidThreshold`] if the threshold is not within `(0, 1]`.
+    pub fn new(name: &'static str, numerator: usize, denominator: usize) -> Run0Result<Self> {
+        let threshold = Self::new_unchecked(name, numerator, denominator);
+        threshold.validate()?;
+        Ok(threshold)
+    }
+
+    /// Creates a threshold without validation for trusted internal defaults.
+    #[must_use]
+    pub const fn new_unchecked(name: &'static str, numerator: usize, denominator: usize) -> Self {
+        Self {
+            name,
+            numerator,
+            denominator,
+        }
+    }
+
+    /// Returns the threshold numerator.
+    #[must_use]
+    pub const fn numerator(self) -> usize {
+        self.numerator
+    }
+
+    /// Returns the threshold denominator.
+    #[must_use]
+    pub const fn denominator(self) -> usize {
+        self.denominator
+    }
+
+    pub(crate) fn validate(self) -> Run0Result<()> {
+        if self.numerator == 0 || self.denominator == 0 || self.numerator > self.denominator {
+            return Err(Run0Error::InvalidThreshold {
+                name: self.name.to_owned(),
+            });
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn select_rule_profile(
+    profile: NormProfile,
+    score: SimilarityRatio,
+    type1_threshold: SimilarityThreshold,
+    type2_threshold: SimilarityThreshold,
+) -> Option<NormProfile> {
+    match profile {
+        NormProfile::T1 if meets_threshold(score, type1_threshold) => Some(NormProfile::T1),
+        NormProfile::T2 if meets_threshold(score, type2_threshold) => Some(NormProfile::T2),
+        _ => None,
+    }
+}
+
+pub(crate) fn jaccard_similarity(
+    left: &[Fingerprint],
+    right: &[Fingerprint],
+) -> Option<SimilarityRatio> {
+    let left_hashes = unique_hashes(left);
+    let right_hashes = unique_hashes(right);
+    if left_hashes.is_empty() || right_hashes.is_empty() {
+        return None;
+    }
+
+    let intersection = left_hashes.intersection(&right_hashes).count();
+    let union = left_hashes.union(&right_hashes).count();
+    Some(SimilarityRatio::new(intersection, union))
+}
+
+fn unique_hashes(fingerprints: &[Fingerprint]) -> BTreeSet<u64> {
+    fingerprints
+        .iter()
+        .map(|fingerprint| fingerprint.hash)
+        .collect()
+}
+
+fn meets_threshold(score: SimilarityRatio, threshold: SimilarityThreshold) -> bool {
+    score.intersection.saturating_mul(threshold.denominator)
+        >= score.union.saturating_mul(threshold.numerator)
+}
+
+fn repeated_division(numerator: usize, denominator: usize) -> Option<(usize, usize)> {
+    if denominator == 0 {
+        return None;
+    }
+
+    let mut quotient = 0usize;
+    let mut remainder = numerator;
+    while remainder >= denominator {
+        remainder = remainder.saturating_sub(denominator);
+        quotient = quotient.saturating_add(1);
+    }
+    Some((quotient, remainder))
+}

--- a/crates/whitaker_clones_core/src/run0/span.rs
+++ b/crates/whitaker_clones_core/src/run0/span.rs
@@ -61,8 +61,8 @@ fn line_and_column(source_text: &str, starts: &[usize], offset: usize) -> (usize
         .partition_point(|start| *start <= offset)
         .saturating_sub(1);
     let line_start = starts[line_index];
-    let line_text = &source_text[line_start..];
-    let byte_offset = offset.saturating_sub(line_start);
-    let char_count = line_text[..byte_offset].chars().count();
-    (line_index.saturating_add(1), char_count.saturating_add(1))
+    let clamped_offset = offset.min(source_text.len());
+    let line_slice = &source_text[line_start..clamped_offset];
+    let utf16_count = line_slice.encode_utf16().count();
+    (line_index.saturating_add(1), utf16_count.saturating_add(1))
 }

--- a/crates/whitaker_clones_core/src/run0/span.rs
+++ b/crates/whitaker_clones_core/src/run0/span.rs
@@ -11,9 +11,9 @@ pub(crate) fn region_for_range(
 ) -> Run0Result<Region> {
     validate_range(fragment_id, source_text, &range)?;
     let starts = line_starts(source_text);
-    let (start_line, start_column) = line_and_column(&starts, range.start);
+    let (start_line, start_column) = line_and_column(source_text, &starts, range.start);
     let end_position = range.end.saturating_sub(1);
-    let (end_line, end_column) = line_and_column(&starts, end_position);
+    let (end_line, end_column) = line_and_column(source_text, &starts, end_position);
 
     RegionBuilder::new(start_line)
         .with_start_column(start_column)
@@ -56,11 +56,13 @@ fn line_starts(source_text: &str) -> Vec<usize> {
     starts
 }
 
-fn line_and_column(starts: &[usize], offset: usize) -> (usize, usize) {
+fn line_and_column(source_text: &str, starts: &[usize], offset: usize) -> (usize, usize) {
     let line_index = starts
         .partition_point(|start| *start <= offset)
         .saturating_sub(1);
     let line_start = starts[line_index];
-    let column = offset.saturating_sub(line_start).saturating_add(1);
-    (line_index.saturating_add(1), column)
+    let line_text = &source_text[line_start..];
+    let byte_offset = offset.saturating_sub(line_start);
+    let char_count = line_text[..byte_offset].chars().count();
+    (line_index.saturating_add(1), char_count.saturating_add(1))
 }

--- a/crates/whitaker_clones_core/src/run0/span.rs
+++ b/crates/whitaker_clones_core/src/run0/span.rs
@@ -1,0 +1,66 @@
+//! Byte-range to SARIF-region conversion helpers.
+
+use whitaker_sarif::{Region, RegionBuilder};
+
+use super::error::{Run0Error, Run0Result};
+
+pub(crate) fn region_for_range(
+    fragment_id: &str,
+    source_text: &str,
+    range: std::ops::Range<usize>,
+) -> Run0Result<Region> {
+    validate_range(fragment_id, source_text, &range)?;
+    let starts = line_starts(source_text);
+    let (start_line, start_column) = line_and_column(&starts, range.start);
+    let end_position = range.end.saturating_sub(1);
+    let (end_line, end_column) = line_and_column(&starts, end_position);
+
+    RegionBuilder::new(start_line)
+        .with_start_column(start_column)
+        .with_end_line(end_line)
+        .with_end_column(end_column)
+        .with_byte_offset(range.start)
+        .with_byte_length(range.end.saturating_sub(range.start))
+        .build()
+        .map_err(Run0Error::from)
+}
+
+fn validate_range(
+    fragment_id: &str,
+    source_text: &str,
+    range: &std::ops::Range<usize>,
+) -> Run0Result<()> {
+    if range.start >= range.end || range.end > source_text.len() {
+        return Err(Run0Error::InvalidFingerprintRange {
+            fragment_id: fragment_id.to_owned(),
+            start: range.start,
+            end: range.end,
+            source_len: source_text.len(),
+        });
+    }
+    if !source_text.is_char_boundary(range.start) || !source_text.is_char_boundary(range.end) {
+        return Err(Run0Error::InvalidUtf8Boundary {
+            fragment_id: fragment_id.to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn line_starts(source_text: &str) -> Vec<usize> {
+    let mut starts = vec![0];
+    for (index, ch) in source_text.char_indices() {
+        if ch == '\n' {
+            starts.push(index.saturating_add(ch.len_utf8()));
+        }
+    }
+    starts
+}
+
+fn line_and_column(starts: &[usize], offset: usize) -> (usize, usize) {
+    let line_index = starts
+        .partition_point(|start| *start <= offset)
+        .saturating_sub(1);
+    let line_start = starts[line_index];
+    let column = offset.saturating_sub(line_start).saturating_add(1);
+    (line_index.saturating_add(1), column)
+}

--- a/crates/whitaker_clones_core/src/run0/span.rs
+++ b/crates/whitaker_clones_core/src/run0/span.rs
@@ -12,7 +12,11 @@ pub(crate) fn region_for_range(
     validate_range(fragment_id, source_text, &range)?;
     let starts = line_starts(source_text);
     let (start_line, start_column) = line_and_column(source_text, &starts, range.start);
-    let end_position = range.end.saturating_sub(1);
+    let end_position = source_text[..range.end]
+        .char_indices()
+        .next_back()
+        .map(|(i, _)| i)
+        .unwrap_or(range.start);
     let (end_line, end_column) = line_and_column(source_text, &starts, end_position);
 
     RegionBuilder::new(start_line)

--- a/crates/whitaker_clones_core/src/run0/test_helpers.rs
+++ b/crates/whitaker_clones_core/src/run0/test_helpers.rs
@@ -1,0 +1,42 @@
+//! Shared test helpers for Run 0 acceptance and emission tests.
+
+use crate::{CandidatePair, Fingerprint, FragmentId, NormProfile};
+
+use super::{TokenFragment, TokenPassConfig};
+
+pub(super) struct FragmentInput<'a> {
+    pub(super) id: &'a str,
+    pub(super) profile: NormProfile,
+    pub(super) file_uri: &'a str,
+    pub(super) source_text: &'a str,
+    pub(super) hashes: &'a [(u64, std::ops::Range<usize>)],
+}
+
+pub(super) fn fingerprint(hash: u64, range: std::ops::Range<usize>) -> Fingerprint {
+    Fingerprint::new(hash, range)
+}
+
+pub(super) fn fragment(input: FragmentInput<'_>) -> TokenFragment {
+    TokenFragment::new(
+        FragmentId::from(input.id),
+        input.profile,
+        input.file_uri,
+        input.source_text,
+    )
+    .with_retained_fingerprints(
+        input
+            .hashes
+            .iter()
+            .map(|(hash, range)| fingerprint(*hash, range.clone()))
+            .collect(),
+    )
+}
+
+pub(super) fn pair(left: &str, right: &str) -> CandidatePair {
+    CandidatePair::new(FragmentId::from(left), FragmentId::from(right))
+        .unwrap_or_else(|| panic!("pair `{left}` and `{right}` must be distinct"))
+}
+
+pub(super) fn config() -> TokenPassConfig {
+    TokenPassConfig::new("whitaker_clones_cli@token", env!("CARGO_PKG_VERSION"))
+}

--- a/crates/whitaker_clones_core/src/run0/tests.rs
+++ b/crates/whitaker_clones_core/src/run0/tests.rs
@@ -39,11 +39,11 @@ fn fragment(input: FragmentInput<'_>) -> TokenFragment {
 
 fn pair(left: &str, right: &str) -> CandidatePair {
     CandidatePair::new(FragmentId::from(left), FragmentId::from(right))
-        .expect("pair `{left}` and `{right}` must be distinct")
+        .unwrap_or_else(|| panic!("pair `{left}` and `{right}` must be distinct"))
 }
 
 fn config() -> TokenPassConfig {
-    TokenPassConfig::new("whitaker_clones_cli@token", "0.2.1")
+    TokenPassConfig::new("whitaker_clones_cli@token", env!("CARGO_PKG_VERSION"))
 }
 
 fn build_pair_and_accept(

--- a/crates/whitaker_clones_core/src/run0/tests.rs
+++ b/crates/whitaker_clones_core/src/run0/tests.rs
@@ -2,49 +2,15 @@
 
 use whitaker_sarif::{Region, WHK001_ID, WHK002_ID};
 
-use crate::{CandidatePair, Fingerprint, FragmentId, NormProfile};
+use crate::NormProfile;
 
 use super::{
-    AcceptedPair, Run0Error, SimilarityThreshold, TokenFragment, TokenPassConfig,
-    accept_candidate_pairs, emit_run0, score::SimilarityRatio, span::region_for_range,
+    AcceptedPair, Run0Error, SimilarityThreshold, TokenPassConfig, accept_candidate_pairs,
+    emit_run0,
+    score::SimilarityRatio,
+    span::region_for_range,
+    test_helpers::{FragmentInput, config, fragment, pair},
 };
-
-fn fingerprint(hash: u64, range: std::ops::Range<usize>) -> Fingerprint {
-    Fingerprint::new(hash, range)
-}
-
-struct FragmentInput<'a> {
-    id: &'a str,
-    profile: NormProfile,
-    file_uri: &'a str,
-    source_text: &'a str,
-    hashes: &'a [(u64, std::ops::Range<usize>)],
-}
-
-fn fragment(input: FragmentInput<'_>) -> TokenFragment {
-    TokenFragment::new(
-        FragmentId::from(input.id),
-        input.profile,
-        input.file_uri,
-        input.source_text,
-    )
-    .with_retained_fingerprints(
-        input
-            .hashes
-            .iter()
-            .map(|(hash, range)| fingerprint(*hash, range.clone()))
-            .collect(),
-    )
-}
-
-fn pair(left: &str, right: &str) -> CandidatePair {
-    CandidatePair::new(FragmentId::from(left), FragmentId::from(right))
-        .unwrap_or_else(|| panic!("pair `{left}` and `{right}` must be distinct"))
-}
-
-fn config() -> TokenPassConfig {
-    TokenPassConfig::new("whitaker_clones_cli@token", env!("CARGO_PKG_VERSION"))
-}
 
 fn build_pair_and_accept(
     left: FragmentInput<'_>,

--- a/crates/whitaker_clones_core/src/run0/tests.rs
+++ b/crates/whitaker_clones_core/src/run0/tests.rs
@@ -6,9 +6,7 @@ use crate::{CandidatePair, Fingerprint, FragmentId, NormProfile};
 
 use super::{
     AcceptedPair, Run0Error, SimilarityThreshold, TokenFragment, TokenPassConfig,
-    accept_candidate_pairs, emit_run0,
-    score::SimilarityRatio,
-    span::region_for_range,
+    accept_candidate_pairs, emit_run0, score::SimilarityRatio, span::region_for_range,
 };
 
 fn fingerprint(hash: u64, range: std::ops::Range<usize>) -> Fingerprint {

--- a/crates/whitaker_clones_core/src/run0/tests.rs
+++ b/crates/whitaker_clones_core/src/run0/tests.rs
@@ -1,6 +1,6 @@
 //! Unit coverage for token-pass acceptance and Run 0 emission.
 
-use whitaker_sarif::{WHITAKER_FRAGMENT_KEY, WHK001_ID, WHK002_ID, WhitakerProperties};
+use whitaker_sarif::{Region, WHITAKER_FRAGMENT_KEY, WHK001_ID, WHK002_ID, WhitakerProperties};
 
 use crate::{CandidatePair, Fingerprint, FragmentId, NormProfile};
 
@@ -157,12 +157,17 @@ fn single_line_region_uses_one_based_columns() {
     let region = region_for_range("alpha", "fn a() {}\n", 0..8)
         .unwrap_or_else(|error| panic!("unexpected region error: {error}"));
 
-    assert_eq!(region.start_line, 1);
-    assert_eq!(region.start_column, Some(1));
-    assert_eq!(region.end_line, Some(1));
-    assert_eq!(region.end_column, Some(8));
-    assert_eq!(region.byte_offset, Some(0));
-    assert_eq!(region.byte_length, Some(8));
+    assert_eq!(
+        region,
+        Region {
+            start_line: 1,
+            start_column: Some(1),
+            end_line: Some(1),
+            end_column: Some(8),
+            byte_offset: Some(0),
+            byte_length: Some(8),
+        }
+    );
 }
 
 #[test]
@@ -171,10 +176,17 @@ fn multi_line_region_tracks_trailing_newline() {
     let region = region_for_range("alpha", source, 13..27)
         .unwrap_or_else(|error| panic!("unexpected region error: {error}"));
 
-    assert_eq!(region.start_line, 2);
-    assert_eq!(region.start_column, Some(1));
-    assert_eq!(region.end_line, Some(3));
-    assert_eq!(region.end_column, Some(1));
+    assert_eq!(
+        region,
+        Region {
+            start_line: 2,
+            start_column: Some(1),
+            end_line: Some(3),
+            end_column: Some(1),
+            byte_offset: Some(13),
+            byte_length: Some(14),
+        }
+    );
 }
 
 #[test]

--- a/crates/whitaker_clones_core/src/run0/tests.rs
+++ b/crates/whitaker_clones_core/src/run0/tests.rs
@@ -1,0 +1,347 @@
+//! Unit coverage for token-pass acceptance and Run 0 emission.
+
+use whitaker_sarif::{WHITAKER_FRAGMENT_KEY, WHK001_ID, WHK002_ID, WhitakerProperties};
+
+use crate::{CandidatePair, Fingerprint, FragmentId, NormProfile};
+
+use super::{
+    AcceptedPair, Run0Error, SimilarityThreshold, TokenFragment, TokenPassConfig,
+    accept_candidate_pairs, emit_run0,
+    score::{SimilarityRatio, jaccard_similarity},
+    span::region_for_range,
+};
+
+fn fingerprint(hash: u64, range: std::ops::Range<usize>) -> Fingerprint {
+    Fingerprint::new(hash, range)
+}
+
+struct FragmentInput<'a> {
+    id: &'a str,
+    profile: NormProfile,
+    file_uri: &'a str,
+    source_text: &'a str,
+    hashes: &'a [(u64, std::ops::Range<usize>)],
+}
+
+fn fragment(input: FragmentInput<'_>) -> TokenFragment {
+    TokenFragment::new(
+        FragmentId::from(input.id),
+        input.profile,
+        input.file_uri,
+        input.source_text,
+    )
+    .with_retained_fingerprints(
+        input
+            .hashes
+            .iter()
+            .map(|(hash, range)| fingerprint(*hash, range.clone()))
+            .collect(),
+    )
+}
+
+fn pair(left: &str, right: &str) -> CandidatePair {
+    CandidatePair::new(FragmentId::from(left), FragmentId::from(right))
+        .unwrap_or_else(|| panic!("pair `{left}` and `{right}` must be distinct"))
+}
+
+fn config() -> TokenPassConfig {
+    TokenPassConfig::new("whitaker_clones_cli@token", "0.2.1")
+}
+
+#[test]
+fn boundary_threshold_accepts_type1_pair() {
+    let fragments = vec![
+        fragment(FragmentInput {
+            id: "alpha",
+            profile: NormProfile::T1,
+            file_uri: "src/a.rs",
+            source_text: "fn a() {}\n",
+            hashes: &[(1, 0..8), (2, 0..8)],
+        }),
+        fragment(FragmentInput {
+            id: "beta",
+            profile: NormProfile::T1,
+            file_uri: "src/b.rs",
+            source_text: "fn b() {}\n",
+            hashes: &[(1, 0..8), (2, 0..8)],
+        }),
+    ];
+
+    let accepted = accept_candidate_pairs(&fragments, &[pair("alpha", "beta")], &config())
+        .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
+
+    assert_eq!(accepted.len(), 1);
+    assert_eq!(accepted[0].profile(), NormProfile::T1);
+    assert_eq!(accepted[0].score(), SimilarityRatio::new(2, 2));
+}
+
+#[test]
+fn boundary_threshold_accepts_type2_pair() {
+    let fragments = vec![
+        fragment(FragmentInput {
+            id: "alpha",
+            profile: NormProfile::T2,
+            file_uri: "src/a.rs",
+            source_text: "fn a(x: i32) {}\n",
+            hashes: &[(1, 0..15), (2, 0..15)],
+        }),
+        fragment(FragmentInput {
+            id: "beta",
+            profile: NormProfile::T2,
+            file_uri: "src/b.rs",
+            source_text: "fn b(y: i32) {}\n",
+            hashes: &[(1, 0..15), (3, 0..15)],
+        }),
+    ];
+
+    let config = config().with_type2_threshold(
+        SimilarityThreshold::new("type2", 1, 3)
+            .unwrap_or_else(|error| panic!("unexpected threshold error: {error}")),
+    );
+    let accepted = accept_candidate_pairs(&fragments, &[pair("alpha", "beta")], &config)
+        .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
+
+    assert_eq!(accepted.len(), 1);
+    assert_eq!(accepted[0].profile(), NormProfile::T2);
+    assert_eq!(accepted[0].score(), SimilarityRatio::new(1, 3));
+}
+
+#[test]
+fn just_below_threshold_is_rejected() {
+    let fragments = vec![
+        fragment(FragmentInput {
+            id: "alpha",
+            profile: NormProfile::T2,
+            file_uri: "src/a.rs",
+            source_text: "fn a(x: i32) {}\n",
+            hashes: &[(1, 0..15), (2, 0..15)],
+        }),
+        fragment(FragmentInput {
+            id: "beta",
+            profile: NormProfile::T2,
+            file_uri: "src/b.rs",
+            source_text: "fn b(y: i32) {}\n",
+            hashes: &[(1, 0..15), (3, 0..15)],
+        }),
+    ];
+
+    let accepted = accept_candidate_pairs(&fragments, &[pair("alpha", "beta")], &config())
+        .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
+
+    assert!(accepted.is_empty());
+}
+
+#[test]
+fn duplicate_hashes_do_not_inflate_jaccard_score() {
+    let left = [
+        fingerprint(1, 0..3),
+        fingerprint(1, 3..6),
+        fingerprint(2, 6..9),
+    ];
+    let right = [fingerprint(1, 0..3), fingerprint(2, 3..6)];
+
+    let score = jaccard_similarity(&left, &right)
+        .unwrap_or_else(|| panic!("score should be present for non-empty fragments"));
+
+    assert_eq!(score, SimilarityRatio::new(2, 2));
+}
+
+#[test]
+fn single_line_region_uses_one_based_columns() {
+    let region = region_for_range("alpha", "fn a() {}\n", 0..8)
+        .unwrap_or_else(|error| panic!("unexpected region error: {error}"));
+
+    assert_eq!(region.start_line, 1);
+    assert_eq!(region.start_column, Some(1));
+    assert_eq!(region.end_line, Some(1));
+    assert_eq!(region.end_column, Some(8));
+    assert_eq!(region.byte_offset, Some(0));
+    assert_eq!(region.byte_length, Some(8));
+}
+
+#[test]
+fn multi_line_region_tracks_trailing_newline() {
+    let source = "fn alpha() {\n    value();\n}\n";
+    let region = region_for_range("alpha", source, 13..27)
+        .unwrap_or_else(|error| panic!("unexpected region error: {error}"));
+
+    assert_eq!(region.start_line, 2);
+    assert_eq!(region.start_column, Some(1));
+    assert_eq!(region.end_line, Some(3));
+    assert_eq!(region.end_column, Some(1));
+}
+
+#[test]
+fn emit_run0_uses_primary_and_related_locations() {
+    let fragments = vec![
+        fragment(FragmentInput {
+            id: "alpha",
+            profile: NormProfile::T1,
+            file_uri: "src/a.rs",
+            source_text: "fn a() {}\n",
+            hashes: &[(11, 0..8)],
+        }),
+        fragment(FragmentInput {
+            id: "beta",
+            profile: NormProfile::T1,
+            file_uri: "src/b.rs",
+            source_text: "fn b() {}\n",
+            hashes: &[(11, 0..8)],
+        }),
+    ];
+    let accepted = vec![AcceptedPair::new(
+        pair("alpha", "beta"),
+        NormProfile::T1,
+        SimilarityRatio::new(1, 1),
+    )];
+
+    let run = emit_run0(&fragments, &accepted, &config())
+        .unwrap_or_else(|error| panic!("unexpected emit error: {error}"));
+
+    let [result] = run.results.as_slice() else {
+        panic!("expected exactly one result");
+    };
+    assert_eq!(result.rule_id, WHK001_ID);
+    assert_eq!(result.locations.len(), 1);
+    assert_eq!(result.related_locations.len(), 1);
+    assert_eq!(
+        result.locations[0].physical_location.artifact_location.uri,
+        "src/a.rs"
+    );
+    assert_eq!(
+        result.related_locations[0]
+            .physical_location
+            .artifact_location
+            .uri,
+        "src/b.rs"
+    );
+}
+
+#[test]
+fn emit_run0_sorts_and_deduplicates_results() {
+    let fragments = vec![
+        fragment(FragmentInput {
+            id: "alpha",
+            profile: NormProfile::T1,
+            file_uri: "src/a.rs",
+            source_text: "fn a() {}\n",
+            hashes: &[(11, 0..8)],
+        }),
+        fragment(FragmentInput {
+            id: "beta",
+            profile: NormProfile::T1,
+            file_uri: "src/b.rs",
+            source_text: "fn b() {}\n",
+            hashes: &[(11, 0..8)],
+        }),
+        fragment(FragmentInput {
+            id: "gamma",
+            profile: NormProfile::T2,
+            file_uri: "src/c.rs",
+            source_text: "fn c(x: i32) {}\n",
+            hashes: &[(1, 0..15), (2, 0..15)],
+        }),
+        fragment(FragmentInput {
+            id: "delta",
+            profile: NormProfile::T2,
+            file_uri: "src/d.rs",
+            source_text: "fn d(y: i32) {}\n",
+            hashes: &[(1, 0..15), (2, 0..15)],
+        }),
+    ];
+    let accepted = vec![
+        AcceptedPair::new(
+            pair("gamma", "delta"),
+            NormProfile::T2,
+            SimilarityRatio::new(2, 2),
+        ),
+        AcceptedPair::new(
+            pair("beta", "alpha"),
+            NormProfile::T1,
+            SimilarityRatio::new(1, 1),
+        ),
+        AcceptedPair::new(
+            pair("alpha", "beta"),
+            NormProfile::T1,
+            SimilarityRatio::new(1, 1),
+        ),
+    ];
+
+    let run = emit_run0(&fragments, &accepted, &config())
+        .unwrap_or_else(|error| panic!("unexpected emit error: {error}"));
+
+    assert_eq!(run.results.len(), 2);
+    assert_eq!(run.results[0].rule_id, WHK001_ID);
+    assert_eq!(run.results[1].rule_id, WHK002_ID);
+}
+
+#[test]
+fn invalid_range_produces_typed_error() {
+    let error = region_for_range("alpha", "fn a() {}\n", 9..12)
+        .err()
+        .unwrap_or_else(|| panic!("invalid range must error"));
+
+    match error {
+        Run0Error::InvalidFingerprintRange {
+            fragment_id,
+            start,
+            end,
+            source_len,
+        } => {
+            assert_eq!(fragment_id, "alpha");
+            assert_eq!(start, 9);
+            assert_eq!(end, 12);
+            assert_eq!(source_len, 10);
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
+#[test]
+fn emitted_result_contains_fingerprints_and_properties() {
+    let fragments = vec![
+        fragment(FragmentInput {
+            id: "alpha",
+            profile: NormProfile::T2,
+            file_uri: "src/a.rs",
+            source_text: "fn a(x: i32) {}\n",
+            hashes: &[(1, 0..15), (2, 0..15)],
+        }),
+        fragment(FragmentInput {
+            id: "beta",
+            profile: NormProfile::T2,
+            file_uri: "src/b.rs",
+            source_text: "fn b(y: i32) {}\n",
+            hashes: &[(1, 0..15), (2, 0..15)],
+        }),
+    ];
+    let accepted = vec![AcceptedPair::new(
+        pair("alpha", "beta"),
+        NormProfile::T2,
+        SimilarityRatio::new(2, 2),
+    )];
+
+    let run = emit_run0(&fragments, &accepted, &config())
+        .unwrap_or_else(|error| panic!("unexpected emit error: {error}"));
+    let [result] = run.results.as_slice() else {
+        panic!("expected one result");
+    };
+    let properties = result
+        .properties
+        .as_ref()
+        .unwrap_or_else(|| panic!("Whitaker properties must be present"));
+    let extracted = WhitakerProperties::try_from(properties)
+        .unwrap_or_else(|error| panic!("unexpected property extraction error: {error}"));
+
+    assert_eq!(result.rule_id, WHK002_ID);
+    assert!(
+        result
+            .partial_fingerprints
+            .contains_key(WHITAKER_FRAGMENT_KEY)
+    );
+    assert!(result.partial_fingerprints.contains_key("tokenHash"));
+    assert_eq!(extracted.profile, "T2");
+    assert_eq!(extracted.k, 25);
+    assert_eq!(extracted.window, 16);
+    assert_eq!(extracted.class_size, 2);
+}

--- a/crates/whitaker_clones_core/src/run0/tests.rs
+++ b/crates/whitaker_clones_core/src/run0/tests.rs
@@ -57,6 +57,22 @@ fn build_pair_and_accept(
     accept_candidate_pairs(&fragments, &[pair("alpha", "beta")], cfg)
 }
 
+fn assert_single_accepted(
+    accepted: &[AcceptedPair],
+    expected_profile: NormProfile,
+    expected_score: SimilarityRatio,
+) {
+    assert_eq!(accepted.len(), 1);
+    assert_eq!(accepted[0].profile(), expected_profile);
+    assert_eq!(accepted[0].score(), expected_score);
+}
+
+fn assert_region(id: &str, source: &str, range: std::ops::Range<usize>, expected: Region) {
+    let region = region_for_range(id, source, range)
+        .unwrap_or_else(|error| panic!("unexpected region error: {error}"));
+    assert_eq!(region, expected);
+}
+
 #[test]
 fn boundary_threshold_accepts_type1_pair() {
     let accepted = build_pair_and_accept(
@@ -78,9 +94,7 @@ fn boundary_threshold_accepts_type1_pair() {
     )
     .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
 
-    assert_eq!(accepted.len(), 1);
-    assert_eq!(accepted[0].profile(), NormProfile::T1);
-    assert_eq!(accepted[0].score(), SimilarityRatio::new(2, 2));
+    assert_single_accepted(&accepted, NormProfile::T1, SimilarityRatio::new(2, 2));
 }
 
 #[test]
@@ -108,9 +122,7 @@ fn boundary_threshold_accepts_type2_pair() {
     )
     .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
 
-    assert_eq!(accepted.len(), 1);
-    assert_eq!(accepted[0].profile(), NormProfile::T2);
-    assert_eq!(accepted[0].score(), SimilarityRatio::new(1, 3));
+    assert_single_accepted(&accepted, NormProfile::T2, SimilarityRatio::new(1, 3));
 }
 
 #[test]
@@ -154,11 +166,10 @@ fn duplicate_hashes_do_not_inflate_jaccard_score() {
 
 #[test]
 fn single_line_region_uses_one_based_columns() {
-    let region = region_for_range("alpha", "fn a() {}\n", 0..8)
-        .unwrap_or_else(|error| panic!("unexpected region error: {error}"));
-
-    assert_eq!(
-        region,
+    assert_region(
+        "alpha",
+        "fn a() {}\n",
+        0..8,
         Region {
             start_line: 1,
             start_column: Some(1),
@@ -166,18 +177,16 @@ fn single_line_region_uses_one_based_columns() {
             end_column: Some(8),
             byte_offset: Some(0),
             byte_length: Some(8),
-        }
+        },
     );
 }
 
 #[test]
 fn multi_line_region_tracks_trailing_newline() {
-    let source = "fn alpha() {\n    value();\n}\n";
-    let region = region_for_range("alpha", source, 13..27)
-        .unwrap_or_else(|error| panic!("unexpected region error: {error}"));
-
-    assert_eq!(
-        region,
+    assert_region(
+        "alpha",
+        "fn alpha() {\n    value();\n}\n",
+        13..27,
         Region {
             start_line: 2,
             start_column: Some(1),
@@ -185,7 +194,7 @@ fn multi_line_region_tracks_trailing_newline() {
             end_column: Some(1),
             byte_offset: Some(13),
             byte_length: Some(14),
-        }
+        },
     );
 }
 

--- a/crates/whitaker_clones_core/src/run0/tests.rs
+++ b/crates/whitaker_clones_core/src/run0/tests.rs
@@ -165,6 +165,15 @@ fn duplicate_hashes_do_not_inflate_jaccard_score() {
 }
 
 #[test]
+fn jaccard_returns_none_for_empty_fragments() {
+    let non_empty = [fingerprint(1, 0..3)];
+    let empty: [Fingerprint; 0] = [];
+
+    assert!(jaccard_similarity(&empty, &non_empty).is_none());
+    assert!(jaccard_similarity(&non_empty, &empty).is_none());
+}
+
+#[test]
 fn single_line_region_uses_one_based_columns() {
     assert_region(
         "alpha",
@@ -319,6 +328,82 @@ fn invalid_range_produces_typed_error() {
             assert_eq!(start, 9);
             assert_eq!(end, 12);
             assert_eq!(source_len, 10);
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
+#[test]
+fn invalid_utf8_boundary_produces_typed_error() {
+    // "á" = 2 bytes in UTF-8; index 2 is in the middle of that code point
+    let source = "aáb";
+    let mid = 2; // inside "á" byte sequence
+    let error = region_for_range("alpha", source, 0..mid)
+        .err()
+        .unwrap_or_else(|| panic!("invalid utf-8 boundary must error"));
+
+    match error {
+        Run0Error::InvalidUtf8Boundary { fragment_id } => {
+            assert_eq!(fragment_id, "alpha");
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
+#[test]
+fn missing_fragment_produces_typed_error() {
+    let fragments = vec![fragment(FragmentInput {
+        id: "alpha",
+        profile: NormProfile::T1,
+        file_uri: "src/a.rs",
+        source_text: "fn a() {}\n",
+        hashes: &[(1, 0..8), (2, 0..8)],
+    })];
+    let candidates = vec![pair("alpha", "beta")];
+
+    let error = accept_candidate_pairs(&fragments, &candidates, &config())
+        .err()
+        .unwrap_or_else(|| panic!("missing fragment must error"));
+
+    match error {
+        Run0Error::MissingFragment { fragment_id } => {
+            assert_eq!(fragment_id, "beta");
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
+#[test]
+fn mixed_profiles_produces_typed_error() {
+    let fragments = vec![
+        fragment(FragmentInput {
+            id: "alpha",
+            profile: NormProfile::T1,
+            file_uri: "src/a.rs",
+            source_text: "fn a() {}\n",
+            hashes: &[(1, 0..8), (2, 0..8)],
+        }),
+        fragment(FragmentInput {
+            id: "beta",
+            profile: NormProfile::T2,
+            file_uri: "src/b.rs",
+            source_text: "fn b() {}\n",
+            hashes: &[(1, 0..8), (2, 0..8)],
+        }),
+    ];
+    let candidates = vec![pair("alpha", "beta")];
+
+    let error = accept_candidate_pairs(&fragments, &candidates, &config())
+        .err()
+        .unwrap_or_else(|| panic!("mixed profiles must error"));
+
+    match error {
+        Run0Error::MixedProfiles {
+            left_fragment,
+            right_fragment,
+        } => {
+            assert_eq!(left_fragment, "alpha");
+            assert_eq!(right_fragment, "beta");
         }
         other => panic!("unexpected error: {other}"),
     }

--- a/crates/whitaker_clones_core/src/run0/tests.rs
+++ b/crates/whitaker_clones_core/src/run0/tests.rs
@@ -48,27 +48,35 @@ fn config() -> TokenPassConfig {
     TokenPassConfig::new("whitaker_clones_cli@token", "0.2.1")
 }
 
+fn build_pair_and_accept(
+    left: FragmentInput<'_>,
+    right: FragmentInput<'_>,
+    cfg: &TokenPassConfig,
+) -> Result<Vec<AcceptedPair>, Run0Error> {
+    let fragments = vec![fragment(left), fragment(right)];
+    accept_candidate_pairs(&fragments, &[pair("alpha", "beta")], cfg)
+}
+
 #[test]
 fn boundary_threshold_accepts_type1_pair() {
-    let fragments = vec![
-        fragment(FragmentInput {
+    let accepted = build_pair_and_accept(
+        FragmentInput {
             id: "alpha",
             profile: NormProfile::T1,
             file_uri: "src/a.rs",
             source_text: "fn a() {}\n",
             hashes: &[(1, 0..8), (2, 0..8)],
-        }),
-        fragment(FragmentInput {
+        },
+        FragmentInput {
             id: "beta",
             profile: NormProfile::T1,
             file_uri: "src/b.rs",
             source_text: "fn b() {}\n",
             hashes: &[(1, 0..8), (2, 0..8)],
-        }),
-    ];
-
-    let accepted = accept_candidate_pairs(&fragments, &[pair("alpha", "beta")], &config())
-        .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
+        },
+        &config(),
+    )
+    .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
 
     assert_eq!(accepted.len(), 1);
     assert_eq!(accepted[0].profile(), NormProfile::T1);
@@ -77,29 +85,28 @@ fn boundary_threshold_accepts_type1_pair() {
 
 #[test]
 fn boundary_threshold_accepts_type2_pair() {
-    let fragments = vec![
-        fragment(FragmentInput {
+    let config = config().with_type2_threshold(
+        SimilarityThreshold::new("type2", 1, 3)
+            .unwrap_or_else(|error| panic!("unexpected threshold error: {error}")),
+    );
+    let accepted = build_pair_and_accept(
+        FragmentInput {
             id: "alpha",
             profile: NormProfile::T2,
             file_uri: "src/a.rs",
             source_text: "fn a(x: i32) {}\n",
             hashes: &[(1, 0..15), (2, 0..15)],
-        }),
-        fragment(FragmentInput {
+        },
+        FragmentInput {
             id: "beta",
             profile: NormProfile::T2,
             file_uri: "src/b.rs",
             source_text: "fn b(y: i32) {}\n",
             hashes: &[(1, 0..15), (3, 0..15)],
-        }),
-    ];
-
-    let config = config().with_type2_threshold(
-        SimilarityThreshold::new("type2", 1, 3)
-            .unwrap_or_else(|error| panic!("unexpected threshold error: {error}")),
-    );
-    let accepted = accept_candidate_pairs(&fragments, &[pair("alpha", "beta")], &config)
-        .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
+        },
+        &config,
+    )
+    .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
 
     assert_eq!(accepted.len(), 1);
     assert_eq!(accepted[0].profile(), NormProfile::T2);
@@ -108,25 +115,24 @@ fn boundary_threshold_accepts_type2_pair() {
 
 #[test]
 fn just_below_threshold_is_rejected() {
-    let fragments = vec![
-        fragment(FragmentInput {
+    let accepted = build_pair_and_accept(
+        FragmentInput {
             id: "alpha",
             profile: NormProfile::T2,
             file_uri: "src/a.rs",
             source_text: "fn a(x: i32) {}\n",
             hashes: &[(1, 0..15), (2, 0..15)],
-        }),
-        fragment(FragmentInput {
+        },
+        FragmentInput {
             id: "beta",
             profile: NormProfile::T2,
             file_uri: "src/b.rs",
             source_text: "fn b(y: i32) {}\n",
             hashes: &[(1, 0..15), (3, 0..15)],
-        }),
-    ];
-
-    let accepted = accept_candidate_pairs(&fragments, &[pair("alpha", "beta")], &config())
-        .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
+        },
+        &config(),
+    )
+    .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
 
     assert!(accepted.is_empty());
 }
@@ -297,8 +303,7 @@ fn invalid_range_produces_typed_error() {
     }
 }
 
-#[test]
-fn emitted_result_contains_fingerprints_and_properties() {
+fn make_t2_emission_run() -> whitaker_sarif::Run {
     let fragments = vec![
         fragment(FragmentInput {
             id: "alpha",
@@ -321,8 +326,38 @@ fn emitted_result_contains_fingerprints_and_properties() {
         SimilarityRatio::new(2, 2),
     )];
 
-    let run = emit_run0(&fragments, &accepted, &config())
-        .unwrap_or_else(|error| panic!("unexpected emit error: {error}"));
+    emit_run0(&fragments, &accepted, &config())
+        .unwrap_or_else(|error| panic!("unexpected emit error: {error}"))
+}
+
+#[test]
+fn emitted_t2_result_has_correct_rule_id() {
+    let run = make_t2_emission_run();
+    let [result] = run.results.as_slice() else {
+        panic!("expected one result");
+    };
+
+    assert_eq!(result.rule_id, WHK002_ID);
+}
+
+#[test]
+fn emitted_t2_result_contains_required_fingerprint_keys() {
+    let run = make_t2_emission_run();
+    let [result] = run.results.as_slice() else {
+        panic!("expected one result");
+    };
+
+    assert!(
+        result
+            .partial_fingerprints
+            .contains_key(WHITAKER_FRAGMENT_KEY)
+    );
+    assert!(result.partial_fingerprints.contains_key("tokenHash"));
+}
+
+#[test]
+fn emitted_t2_result_properties_match_config() {
+    let run = make_t2_emission_run();
     let [result] = run.results.as_slice() else {
         panic!("expected one result");
     };
@@ -333,15 +368,13 @@ fn emitted_result_contains_fingerprints_and_properties() {
     let extracted = WhitakerProperties::try_from(properties)
         .unwrap_or_else(|error| panic!("unexpected property extraction error: {error}"));
 
-    assert_eq!(result.rule_id, WHK002_ID);
-    assert!(
-        result
-            .partial_fingerprints
-            .contains_key(WHITAKER_FRAGMENT_KEY)
+    assert_eq!(
+        (
+            extracted.profile.as_str(),
+            extracted.k,
+            extracted.window,
+            extracted.class_size,
+        ),
+        ("T2", 25, 16, 2),
     );
-    assert!(result.partial_fingerprints.contains_key("tokenHash"));
-    assert_eq!(extracted.profile, "T2");
-    assert_eq!(extracted.k, 25);
-    assert_eq!(extracted.window, 16);
-    assert_eq!(extracted.class_size, 2);
 }

--- a/crates/whitaker_clones_core/src/run0/tests.rs
+++ b/crates/whitaker_clones_core/src/run0/tests.rs
@@ -1,13 +1,13 @@
 //! Unit coverage for token-pass acceptance and Run 0 emission.
 
-use whitaker_sarif::{Region, WHITAKER_FRAGMENT_KEY, WHK001_ID, WHK002_ID, WhitakerProperties};
+use whitaker_sarif::{Region, WHK001_ID, WHK002_ID};
 
 use crate::{CandidatePair, Fingerprint, FragmentId, NormProfile};
 
 use super::{
     AcceptedPair, Run0Error, SimilarityThreshold, TokenFragment, TokenPassConfig,
     accept_candidate_pairs, emit_run0,
-    score::{SimilarityRatio, jaccard_similarity},
+    score::SimilarityRatio,
     span::region_for_range,
 };
 
@@ -41,7 +41,7 @@ fn fragment(input: FragmentInput<'_>) -> TokenFragment {
 
 fn pair(left: &str, right: &str) -> CandidatePair {
     CandidatePair::new(FragmentId::from(left), FragmentId::from(right))
-        .unwrap_or_else(|| panic!("pair `{left}` and `{right}` must be distinct"))
+        .expect("pair `{left}` and `{right}` must be distinct")
 }
 
 fn config() -> TokenPassConfig {
@@ -147,30 +147,6 @@ fn just_below_threshold_is_rejected() {
     .unwrap_or_else(|error| panic!("unexpected acceptance error: {error}"));
 
     assert!(accepted.is_empty());
-}
-
-#[test]
-fn duplicate_hashes_do_not_inflate_jaccard_score() {
-    let left = [
-        fingerprint(1, 0..3),
-        fingerprint(1, 3..6),
-        fingerprint(2, 6..9),
-    ];
-    let right = [fingerprint(1, 0..3), fingerprint(2, 3..6)];
-
-    let score = jaccard_similarity(&left, &right)
-        .unwrap_or_else(|| panic!("score should be present for non-empty fragments"));
-
-    assert_eq!(score, SimilarityRatio::new(2, 2));
-}
-
-#[test]
-fn jaccard_returns_none_for_empty_fragments() {
-    let non_empty = [fingerprint(1, 0..3)];
-    let empty: [Fingerprint; 0] = [];
-
-    assert!(jaccard_similarity(&empty, &non_empty).is_none());
-    assert!(jaccard_similarity(&non_empty, &empty).is_none());
 }
 
 #[test]
@@ -407,80 +383,4 @@ fn mixed_profiles_produces_typed_error() {
         }
         other => panic!("unexpected error: {other}"),
     }
-}
-
-fn make_t2_emission_run() -> whitaker_sarif::Run {
-    let fragments = vec![
-        fragment(FragmentInput {
-            id: "alpha",
-            profile: NormProfile::T2,
-            file_uri: "src/a.rs",
-            source_text: "fn a(x: i32) {}\n",
-            hashes: &[(1, 0..15), (2, 0..15)],
-        }),
-        fragment(FragmentInput {
-            id: "beta",
-            profile: NormProfile::T2,
-            file_uri: "src/b.rs",
-            source_text: "fn b(y: i32) {}\n",
-            hashes: &[(1, 0..15), (2, 0..15)],
-        }),
-    ];
-    let accepted = vec![AcceptedPair::new(
-        pair("alpha", "beta"),
-        NormProfile::T2,
-        SimilarityRatio::new(2, 2),
-    )];
-
-    emit_run0(&fragments, &accepted, &config())
-        .unwrap_or_else(|error| panic!("unexpected emit error: {error}"))
-}
-
-#[test]
-fn emitted_t2_result_has_correct_rule_id() {
-    let run = make_t2_emission_run();
-    let [result] = run.results.as_slice() else {
-        panic!("expected one result");
-    };
-
-    assert_eq!(result.rule_id, WHK002_ID);
-}
-
-#[test]
-fn emitted_t2_result_contains_required_fingerprint_keys() {
-    let run = make_t2_emission_run();
-    let [result] = run.results.as_slice() else {
-        panic!("expected one result");
-    };
-
-    assert!(
-        result
-            .partial_fingerprints
-            .contains_key(WHITAKER_FRAGMENT_KEY)
-    );
-    assert!(result.partial_fingerprints.contains_key("tokenHash"));
-}
-
-#[test]
-fn emitted_t2_result_properties_match_config() {
-    let run = make_t2_emission_run();
-    let [result] = run.results.as_slice() else {
-        panic!("expected one result");
-    };
-    let properties = result
-        .properties
-        .as_ref()
-        .unwrap_or_else(|| panic!("Whitaker properties must be present"));
-    let extracted = WhitakerProperties::try_from(properties)
-        .unwrap_or_else(|error| panic!("unexpected property extraction error: {error}"));
-
-    assert_eq!(
-        (
-            extracted.profile.as_str(),
-            extracted.k,
-            extracted.window,
-            extracted.class_size,
-        ),
-        ("T2", 25, 16, 2),
-    );
 }

--- a/crates/whitaker_clones_core/src/run0/tests_emit.rs
+++ b/crates/whitaker_clones_core/src/run0/tests_emit.rs
@@ -2,49 +2,13 @@
 
 use whitaker_sarif::{WHITAKER_FRAGMENT_KEY, WHK002_ID, WhitakerProperties};
 
-use crate::{Fingerprint, FragmentId, NormProfile};
+use crate::{Fingerprint, NormProfile};
 
 use super::{
-    AcceptedPair, SimilarityRatio, TokenFragment, TokenPassConfig, emit_run0,
+    AcceptedPair, SimilarityRatio, emit_run0,
     score::jaccard_similarity,
+    test_helpers::{FragmentInput, config, fingerprint, fragment, pair},
 };
-
-struct FragmentInput<'a> {
-    id: &'a str,
-    profile: NormProfile,
-    file_uri: &'a str,
-    source_text: &'a str,
-    hashes: &'a [(u64, std::ops::Range<usize>)],
-}
-
-fn fingerprint(hash: u64, range: std::ops::Range<usize>) -> Fingerprint {
-    Fingerprint::new(hash, range)
-}
-
-fn fragment(input: FragmentInput<'_>) -> TokenFragment {
-    TokenFragment::new(
-        FragmentId::from(input.id),
-        input.profile,
-        input.file_uri,
-        input.source_text,
-    )
-    .with_retained_fingerprints(
-        input
-            .hashes
-            .iter()
-            .map(|(hash, range)| fingerprint(*hash, range.clone()))
-            .collect(),
-    )
-}
-
-fn pair(left: &str, right: &str) -> crate::CandidatePair {
-    crate::CandidatePair::new(FragmentId::from(left), FragmentId::from(right))
-        .unwrap_or_else(|| panic!("pair `{left}` and `{right}` must be distinct"))
-}
-
-fn config() -> TokenPassConfig {
-    TokenPassConfig::new("whitaker_clones_cli@token", env!("CARGO_PKG_VERSION"))
-}
 
 #[test]
 fn duplicate_hashes_do_not_inflate_jaccard_score() {

--- a/crates/whitaker_clones_core/src/run0/tests_emit.rs
+++ b/crates/whitaker_clones_core/src/run0/tests_emit.rs
@@ -1,0 +1,147 @@
+//! Tests for SARIF Run 0 emission specifics.
+
+use whitaker_sarif::{WHITAKER_FRAGMENT_KEY, WHK002_ID, WhitakerProperties};
+
+use crate::{Fingerprint, FragmentId, NormProfile};
+
+use super::{
+    AcceptedPair, SimilarityRatio, TokenFragment, TokenPassConfig, emit_run0,
+    score::jaccard_similarity,
+};
+
+struct FragmentInput<'a> {
+    id: &'a str,
+    profile: NormProfile,
+    file_uri: &'a str,
+    source_text: &'a str,
+    hashes: &'a [(u64, std::ops::Range<usize>)],
+}
+
+fn fingerprint(hash: u64, range: std::ops::Range<usize>) -> Fingerprint {
+    Fingerprint::new(hash, range)
+}
+
+fn fragment(input: FragmentInput<'_>) -> TokenFragment {
+    TokenFragment::new(
+        FragmentId::from(input.id),
+        input.profile,
+        input.file_uri,
+        input.source_text,
+    )
+    .with_retained_fingerprints(
+        input
+            .hashes
+            .iter()
+            .map(|(hash, range)| fingerprint(*hash, range.clone()))
+            .collect(),
+    )
+}
+
+fn pair(left: &str, right: &str) -> crate::CandidatePair {
+    crate::CandidatePair::new(FragmentId::from(left), FragmentId::from(right))
+        .expect("pair `{left}` and `{right}` must be distinct")
+}
+
+fn config() -> TokenPassConfig {
+    TokenPassConfig::new("whitaker_clones_cli@token", "0.2.1")
+}
+
+#[test]
+fn duplicate_hashes_do_not_inflate_jaccard_score() {
+    let left = [
+        fingerprint(1, 0..3),
+        fingerprint(1, 3..6),
+        fingerprint(2, 6..9),
+    ];
+    let right = [fingerprint(1, 0..3), fingerprint(2, 3..6)];
+
+    let score = jaccard_similarity(&left, &right)
+        .unwrap_or_else(|| panic!("score should be present for non-empty fragments"));
+
+    assert_eq!(score, SimilarityRatio::new(2, 2));
+}
+
+#[test]
+fn jaccard_returns_none_for_empty_fragments() {
+    let non_empty = [fingerprint(1, 0..3)];
+    let empty: [Fingerprint; 0] = [];
+
+    assert!(jaccard_similarity(&empty, &non_empty).is_none());
+    assert!(jaccard_similarity(&non_empty, &empty).is_none());
+}
+
+fn make_t2_emission_run() -> whitaker_sarif::Run {
+    let fragments = vec![
+        fragment(FragmentInput {
+            id: "alpha",
+            profile: NormProfile::T2,
+            file_uri: "src/a.rs",
+            source_text: "fn a(x: i32) {}\n",
+            hashes: &[(1, 0..15), (2, 0..15)],
+        }),
+        fragment(FragmentInput {
+            id: "beta",
+            profile: NormProfile::T2,
+            file_uri: "src/b.rs",
+            source_text: "fn b(y: i32) {}\n",
+            hashes: &[(1, 0..15), (2, 0..15)],
+        }),
+    ];
+    let accepted = vec![AcceptedPair::new(
+        pair("alpha", "beta"),
+        NormProfile::T2,
+        SimilarityRatio::new(2, 2),
+    )];
+
+    emit_run0(&fragments, &accepted, &config())
+        .unwrap_or_else(|error| panic!("unexpected emit error: {error}"))
+}
+
+#[test]
+fn emitted_t2_result_has_correct_rule_id() {
+    let run = make_t2_emission_run();
+    let [result] = run.results.as_slice() else {
+        panic!("expected one result");
+    };
+
+    assert_eq!(result.rule_id, WHK002_ID);
+}
+
+#[test]
+fn emitted_t2_result_contains_required_fingerprint_keys() {
+    let run = make_t2_emission_run();
+    let [result] = run.results.as_slice() else {
+        panic!("expected one result");
+    };
+
+    assert!(
+        result
+            .partial_fingerprints
+            .contains_key(WHITAKER_FRAGMENT_KEY)
+    );
+    assert!(result.partial_fingerprints.contains_key("tokenHash"));
+}
+
+#[test]
+fn emitted_t2_result_properties_match_config() {
+    let run = make_t2_emission_run();
+    let [result] = run.results.as_slice() else {
+        panic!("expected one result");
+    };
+    let properties = result
+        .properties
+        .as_ref()
+        .unwrap_or_else(|| panic!("Whitaker properties must be present"));
+    let extracted = WhitakerProperties::try_from(properties)
+        .unwrap_or_else(|error| panic!("unexpected property extraction error: {error}"));
+
+    assert_eq!(
+        (
+            extracted.profile.as_str(),
+            extracted.k,
+            extracted.window,
+            extracted.class_size,
+        ),
+        ("T2", 25, 16, 2),
+    );
+}

--- a/crates/whitaker_clones_core/src/run0/tests_emit.rs
+++ b/crates/whitaker_clones_core/src/run0/tests_emit.rs
@@ -39,7 +39,7 @@ fn fragment(input: FragmentInput<'_>) -> TokenFragment {
 
 fn pair(left: &str, right: &str) -> crate::CandidatePair {
     crate::CandidatePair::new(FragmentId::from(left), FragmentId::from(right))
-        .expect("pair `{left}` and `{right}` must be distinct")
+        .unwrap_or_else(|| panic!("pair `{left}` and `{right}` must be distinct"))
 }
 
 fn config() -> TokenPassConfig {

--- a/crates/whitaker_clones_core/src/run0/tests_emit.rs
+++ b/crates/whitaker_clones_core/src/run0/tests_emit.rs
@@ -43,7 +43,7 @@ fn pair(left: &str, right: &str) -> crate::CandidatePair {
 }
 
 fn config() -> TokenPassConfig {
-    TokenPassConfig::new("whitaker_clones_cli@token", "0.2.1")
+    TokenPassConfig::new("whitaker_clones_cli@token", env!("CARGO_PKG_VERSION"))
 }
 
 #[test]

--- a/crates/whitaker_clones_core/src/run0/types.rs
+++ b/crates/whitaker_clones_core/src/run0/types.rs
@@ -1,0 +1,256 @@
+//! Public input and output types for token-pass Run 0 emission.
+
+use crate::{CandidatePair, Fingerprint, FragmentId, NormProfile};
+
+use super::score::SimilarityThreshold;
+
+const DEFAULT_SHINGLE_SIZE: usize = 25;
+const DEFAULT_WINNOW_WINDOW: usize = 16;
+
+/// A token-pass fragment ready for acceptance scoring and SARIF emission.
+///
+/// # Examples
+///
+/// ```
+/// use whitaker_clones_core::{Fingerprint, FragmentId, NormProfile, TokenFragment};
+///
+/// let fragment = TokenFragment::new(
+///     FragmentId::from("src/lib.rs:0..12:T1"),
+///     NormProfile::T1,
+///     "src/lib.rs",
+///     "fn demo() {}\n",
+/// )
+/// .with_retained_fingerprints(vec![Fingerprint::new(7, 0..11)]);
+///
+/// assert_eq!(fragment.profile(), NormProfile::T1);
+/// assert_eq!(fragment.file_uri(), "src/lib.rs");
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TokenFragment {
+    id: FragmentId,
+    profile: NormProfile,
+    file_uri: String,
+    source_text: String,
+    retained_fingerprints: Vec<Fingerprint>,
+}
+
+impl TokenFragment {
+    /// Creates a token fragment from stable identity and source text.
+    #[must_use]
+    pub fn new(
+        id: FragmentId,
+        profile: NormProfile,
+        file_uri: impl Into<String>,
+        source_text: impl Into<String>,
+    ) -> Self {
+        Self {
+            id,
+            profile,
+            file_uri: file_uri.into(),
+            source_text: source_text.into(),
+            retained_fingerprints: Vec::new(),
+        }
+    }
+
+    /// Replaces the retained fingerprints stored for this fragment.
+    #[must_use]
+    pub fn with_retained_fingerprints(mut self, retained_fingerprints: Vec<Fingerprint>) -> Self {
+        self.retained_fingerprints = retained_fingerprints;
+        self
+    }
+
+    /// Returns the stable fragment identifier.
+    #[must_use]
+    pub const fn id(&self) -> &FragmentId {
+        &self.id
+    }
+
+    /// Returns the normalization profile used to produce this fragment.
+    #[must_use]
+    pub const fn profile(&self) -> NormProfile {
+        self.profile
+    }
+
+    /// Returns the source artifact URI used in SARIF output.
+    #[must_use]
+    pub fn file_uri(&self) -> &str {
+        self.file_uri.as_str()
+    }
+
+    /// Returns the original source text used for byte-range mapping.
+    #[must_use]
+    pub fn source_text(&self) -> &str {
+        self.source_text.as_str()
+    }
+
+    /// Returns the retained token fingerprints for this fragment.
+    #[must_use]
+    pub fn retained_fingerprints(&self) -> &[Fingerprint] {
+        self.retained_fingerprints.as_slice()
+    }
+}
+
+/// Immutable configuration for token-pass acceptance and Run 0 emission.
+///
+/// Defaults follow the design document: `k = 25`, `window = 16`,
+/// `type1 = 19/20`, and `type2 = 9/10`.
+///
+/// # Examples
+///
+/// ```
+/// use whitaker_clones_core::{SimilarityThreshold, TokenPassConfig};
+///
+/// let config = TokenPassConfig::new("whitaker_clones_cli@token", "0.2.1")
+///     .with_type1_threshold(SimilarityThreshold::new("type1", 1, 1).expect("valid threshold"));
+///
+/// assert_eq!(config.shingle_size(), 25);
+/// assert_eq!(config.tool_name(), "whitaker_clones_cli@token");
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TokenPassConfig {
+    tool_name: String,
+    tool_version: String,
+    shingle_size: usize,
+    winnow_window: usize,
+    type1_threshold: SimilarityThreshold,
+    type2_threshold: SimilarityThreshold,
+}
+
+impl TokenPassConfig {
+    /// Creates a configuration with the design-document defaults.
+    #[must_use]
+    pub fn new(tool_name: impl Into<String>, tool_version: impl Into<String>) -> Self {
+        Self {
+            tool_name: tool_name.into(),
+            tool_version: tool_version.into(),
+            shingle_size: DEFAULT_SHINGLE_SIZE,
+            winnow_window: DEFAULT_WINNOW_WINDOW,
+            type1_threshold: SimilarityThreshold::new_unchecked("type1", 19, 20),
+            type2_threshold: SimilarityThreshold::new_unchecked("type2", 9, 10),
+        }
+    }
+
+    /// Overrides the configured shingle size recorded in Whitaker properties.
+    #[must_use]
+    pub const fn with_shingle_size(mut self, shingle_size: usize) -> Self {
+        self.shingle_size = shingle_size;
+        self
+    }
+
+    /// Overrides the configured winnow window recorded in Whitaker properties.
+    #[must_use]
+    pub const fn with_winnow_window(mut self, winnow_window: usize) -> Self {
+        self.winnow_window = winnow_window;
+        self
+    }
+
+    /// Overrides the Type-1 Jaccard acceptance threshold.
+    #[must_use]
+    pub const fn with_type1_threshold(mut self, threshold: SimilarityThreshold) -> Self {
+        self.type1_threshold = threshold;
+        self
+    }
+
+    /// Overrides the Type-2 Jaccard acceptance threshold.
+    #[must_use]
+    pub const fn with_type2_threshold(mut self, threshold: SimilarityThreshold) -> Self {
+        self.type2_threshold = threshold;
+        self
+    }
+
+    /// Returns the SARIF producer name.
+    #[must_use]
+    pub fn tool_name(&self) -> &str {
+        self.tool_name.as_str()
+    }
+
+    /// Returns the SARIF producer version.
+    #[must_use]
+    pub fn tool_version(&self) -> &str {
+        self.tool_version.as_str()
+    }
+
+    /// Returns the configured shingle size.
+    #[must_use]
+    pub const fn shingle_size(&self) -> usize {
+        self.shingle_size
+    }
+
+    /// Returns the configured winnow window.
+    #[must_use]
+    pub const fn winnow_window(&self) -> usize {
+        self.winnow_window
+    }
+
+    /// Returns the Type-1 acceptance threshold.
+    #[must_use]
+    pub const fn type1_threshold(&self) -> SimilarityThreshold {
+        self.type1_threshold
+    }
+
+    /// Returns the Type-2 acceptance threshold.
+    #[must_use]
+    pub const fn type2_threshold(&self) -> SimilarityThreshold {
+        self.type2_threshold
+    }
+}
+
+/// An accepted token-pass candidate pair and its final rule classification.
+///
+/// # Examples
+///
+/// ```
+/// use whitaker_clones_core::{
+///     AcceptedPair, CandidatePair, FragmentId, NormProfile, SimilarityRatio,
+/// };
+///
+/// let pair = CandidatePair::new(FragmentId::from("alpha"), FragmentId::from("beta"))
+///     .expect("distinct fragments");
+/// let accepted = AcceptedPair::new(
+///     pair,
+///     NormProfile::T1,
+///     SimilarityRatio::new(4, 4),
+/// );
+///
+/// assert_eq!(accepted.profile(), NormProfile::T1);
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AcceptedPair {
+    pair: CandidatePair,
+    profile: NormProfile,
+    score: super::score::SimilarityRatio,
+}
+
+impl AcceptedPair {
+    /// Creates an accepted pair with its resolved rule profile and score.
+    #[must_use]
+    pub const fn new(
+        pair: CandidatePair,
+        profile: NormProfile,
+        score: super::score::SimilarityRatio,
+    ) -> Self {
+        Self {
+            pair,
+            profile,
+            score,
+        }
+    }
+
+    /// Returns the canonical fragment pair.
+    #[must_use]
+    pub const fn pair(&self) -> &CandidatePair {
+        &self.pair
+    }
+
+    /// Returns the rule profile to emit for this pair.
+    #[must_use]
+    pub const fn profile(&self) -> NormProfile {
+        self.profile
+    }
+
+    /// Returns the accepted Jaccard score.
+    #[must_use]
+    pub const fn score(&self) -> super::score::SimilarityRatio {
+        self.score
+    }
+}

--- a/crates/whitaker_clones_core/src/run0/types.rs
+++ b/crates/whitaker_clones_core/src/run0/types.rs
@@ -2,7 +2,7 @@
 
 use crate::{CandidatePair, Fingerprint, FragmentId, NormProfile};
 
-use super::score::SimilarityThreshold;
+use super::score::{SimilarityRatio, SimilarityThreshold};
 
 const DEFAULT_SHINGLE_SIZE: usize = 25;
 const DEFAULT_WINNOW_WINDOW: usize = 16;
@@ -218,17 +218,13 @@ impl TokenPassConfig {
 pub struct AcceptedPair {
     pair: CandidatePair,
     profile: NormProfile,
-    score: super::score::SimilarityRatio,
+    score: SimilarityRatio,
 }
 
 impl AcceptedPair {
     /// Creates an accepted pair with its resolved rule profile and score.
     #[must_use]
-    pub const fn new(
-        pair: CandidatePair,
-        profile: NormProfile,
-        score: super::score::SimilarityRatio,
-    ) -> Self {
+    pub const fn new(pair: CandidatePair, profile: NormProfile, score: SimilarityRatio) -> Self {
         Self {
             pair,
             profile,
@@ -250,7 +246,7 @@ impl AcceptedPair {
 
     /// Returns the accepted Jaccard score.
     #[must_use]
-    pub const fn score(&self) -> super::score::SimilarityRatio {
+    pub const fn score(&self) -> SimilarityRatio {
         self.score
     }
 }

--- a/crates/whitaker_clones_core/tests/features/run0_sarif.feature
+++ b/crates/whitaker_clones_core/tests/features/run0_sarif.feature
@@ -1,0 +1,53 @@
+Feature: Token-pass Run 0 SARIF emission
+  Accepted token-pass pairs should emit deterministic SARIF Run 0 results for
+  Type-1 and Type-2 clones, while rejected or malformed inputs should stay
+  explicit.
+
+  Scenario: Accepted Type-1 pair emits one WHK001 result
+    Given token fragment alpha_t1 is loaded
+    And token fragment beta_t1 is loaded
+    And candidate pair alpha_t1 and beta_t1 is queued
+    When Run 0 is emitted
+    Then exactly 1 result is emitted
+    And the emitted rule is WHK001
+    And the result has 1 primary location and 1 related location
+
+  Scenario: Accepted Type-2 pair emits Whitaker Type-2 properties
+    Given token fragment alpha_t2 is loaded
+    And token fragment beta_t2 is loaded
+    And candidate pair alpha_t2 and beta_t2 is queued
+    When Run 0 is emitted
+    Then exactly 1 result is emitted
+    And the emitted rule is WHK002
+    And the Whitaker profile is T2
+    And the Whitaker k is 25
+    And the Whitaker window is 16
+
+  Scenario: Below-threshold pair emits no results
+    Given token fragment alpha_t2 is loaded
+    And token fragment beta_t2_partial is loaded
+    And candidate pair alpha_t2 and beta_t2_partial is queued
+    When Run 0 is emitted
+    Then no results are emitted
+
+  Scenario: Empty retained fingerprints fail before emission
+    Given token fragment alpha_empty is loaded
+    And token fragment beta_t1 is loaded
+    And candidate pair alpha_empty and beta_t1 is queued
+    When Run 0 is emitted
+    Then the emission error is token fragment `alpha_empty` must retain at least one fingerprint
+
+  Scenario: Multi-line ranges become 1-based SARIF regions
+    Given token fragment alpha_multiline is loaded
+    And token fragment beta_multiline is loaded
+    And candidate pair alpha_multiline and beta_multiline is queued
+    When Run 0 is emitted
+    Then the primary region is 2:1-3:1
+
+  Scenario: Reversed pair input still emits one deterministic result
+    Given token fragment alpha_t1 is loaded
+    And token fragment beta_t1 is loaded
+    And candidate pair beta_t1 and alpha_t1 is queued
+    When Run 0 is emitted
+    Then exactly 1 result is emitted
+    And the primary file is src/a.rs

--- a/crates/whitaker_clones_core/tests/run0_sarif_behaviour.rs
+++ b/crates/whitaker_clones_core/tests/run0_sarif_behaviour.rs
@@ -1,0 +1,326 @@
+//! Behaviour-driven coverage for token-pass Run 0 SARIF emission.
+//!
+//! Keep this harness in sync with `tests/features/run0_sarif.feature`.
+
+use std::{cell::RefCell, collections::BTreeMap};
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use whitaker_clones_core::{
+    CandidatePair, FragmentId, Run0Error, TokenFragment, TokenPassConfig, accept_candidate_pairs,
+    emit_run0,
+};
+use whitaker_sarif::{Run, SarifResult, WhitakerProperties};
+
+#[derive(Debug)]
+struct Run0World {
+    fragments: RefCell<BTreeMap<String, TokenFragment>>,
+    candidates: RefCell<Vec<CandidatePair>>,
+    run: RefCell<Option<Run>>,
+    error: RefCell<Option<Run0Error>>,
+    config: TokenPassConfig,
+}
+
+impl Default for Run0World {
+    fn default() -> Self {
+        Self {
+            fragments: RefCell::new(BTreeMap::new()),
+            candidates: RefCell::new(Vec::new()),
+            run: RefCell::new(None),
+            error: RefCell::new(None),
+            config: TokenPassConfig::new("whitaker_clones_cli@token", "0.2.1"),
+        }
+    }
+}
+
+#[fixture]
+fn world() -> Run0World {
+    Run0World::default()
+}
+
+fn with_results(world: &Run0World, assert_fn: impl FnOnce(&[SarifResult])) {
+    let run = world.run.borrow();
+    match run.as_ref() {
+        Some(run) => assert_fn(&run.results),
+        None => panic!("run must be emitted before checking results"),
+    }
+}
+
+fn fragment_fixture(name: &str) -> Result<TokenFragment, String> {
+    match name {
+        "alpha_t1" => Ok(TokenFragment::new(
+            FragmentId::from("alpha_t1"),
+            whitaker_clones_core::NormProfile::T1,
+            "src/a.rs",
+            "fn a() {}\n",
+        )
+        .with_retained_fingerprints(vec![whitaker_clones_core::Fingerprint::new(11, 0..8)])),
+        "beta_t1" => Ok(TokenFragment::new(
+            FragmentId::from("beta_t1"),
+            whitaker_clones_core::NormProfile::T1,
+            "src/b.rs",
+            "fn b() {}\n",
+        )
+        .with_retained_fingerprints(vec![whitaker_clones_core::Fingerprint::new(11, 0..8)])),
+        "alpha_t2" => Ok(TokenFragment::new(
+            FragmentId::from("alpha_t2"),
+            whitaker_clones_core::NormProfile::T2,
+            "src/a.rs",
+            "fn a(x: i32) {}\n",
+        )
+        .with_retained_fingerprints(vec![
+            whitaker_clones_core::Fingerprint::new(1, 0..15),
+            whitaker_clones_core::Fingerprint::new(2, 0..15),
+        ])),
+        "beta_t2" => Ok(TokenFragment::new(
+            FragmentId::from("beta_t2"),
+            whitaker_clones_core::NormProfile::T2,
+            "src/b.rs",
+            "fn b(y: i32) {}\n",
+        )
+        .with_retained_fingerprints(vec![
+            whitaker_clones_core::Fingerprint::new(1, 0..15),
+            whitaker_clones_core::Fingerprint::new(2, 0..15),
+        ])),
+        "beta_t2_partial" => Ok(TokenFragment::new(
+            FragmentId::from("beta_t2_partial"),
+            whitaker_clones_core::NormProfile::T2,
+            "src/b.rs",
+            "fn b(y: i32) {}\n",
+        )
+        .with_retained_fingerprints(vec![
+            whitaker_clones_core::Fingerprint::new(1, 0..15),
+            whitaker_clones_core::Fingerprint::new(3, 0..15),
+        ])),
+        "alpha_empty" => Ok(TokenFragment::new(
+            FragmentId::from("alpha_empty"),
+            whitaker_clones_core::NormProfile::T1,
+            "src/a.rs",
+            "fn a() {}\n",
+        )),
+        "alpha_multiline" => Ok(TokenFragment::new(
+            FragmentId::from("alpha_multiline"),
+            whitaker_clones_core::NormProfile::T1,
+            "src/a.rs",
+            "fn alpha() {\n    value();\n}\n",
+        )
+        .with_retained_fingerprints(vec![whitaker_clones_core::Fingerprint::new(21, 13..27)])),
+        "beta_multiline" => Ok(TokenFragment::new(
+            FragmentId::from("beta_multiline"),
+            whitaker_clones_core::NormProfile::T1,
+            "src/b.rs",
+            "fn beta() {\n    value();\n}\n",
+        )
+        .with_retained_fingerprints(vec![whitaker_clones_core::Fingerprint::new(21, 12..26)])),
+        other => Err(format!("unknown fragment fixture `{other}`")),
+    }
+}
+
+#[given("token fragment {name} is loaded")]
+fn given_token_fragment(world: &Run0World, name: String) -> Result<(), String> {
+    let fragment = fragment_fixture(&name)?;
+    world.fragments.borrow_mut().insert(name, fragment);
+    Ok(())
+}
+
+#[given("candidate pair {left} and {right} is queued")]
+fn given_candidate_pair(world: &Run0World, left: String, right: String) -> Result<(), String> {
+    let pair = CandidatePair::new(FragmentId::from(left), FragmentId::from(right))
+        .ok_or_else(|| "candidate pairs must use distinct fragment IDs".to_owned())?;
+    world.candidates.borrow_mut().push(pair);
+    Ok(())
+}
+
+#[when("Run 0 is emitted")]
+fn when_run_zero_is_emitted(world: &Run0World) {
+    let fragments = world
+        .fragments
+        .borrow()
+        .values()
+        .cloned()
+        .collect::<Vec<_>>();
+    let accepted =
+        match accept_candidate_pairs(&fragments, &world.candidates.borrow(), &world.config) {
+            Ok(accepted) => accepted,
+            Err(error) => {
+                *world.error.borrow_mut() = Some(error);
+                *world.run.borrow_mut() = None;
+                return;
+            }
+        };
+
+    match emit_run0(&fragments, &accepted, &world.config) {
+        Ok(run) => {
+            *world.run.borrow_mut() = Some(run);
+            *world.error.borrow_mut() = None;
+        }
+        Err(error) => {
+            *world.run.borrow_mut() = None;
+            *world.error.borrow_mut() = Some(error);
+        }
+    }
+}
+
+#[then("exactly {count} result is emitted")]
+fn then_exactly_one_result_is_emitted(world: &Run0World, count: usize) {
+    with_results(world, |results| assert_eq!(results.len(), count));
+}
+
+#[then("the emitted rule is {rule_id}")]
+fn then_emitted_rule_is(world: &Run0World, rule_id: String) {
+    with_results(world, |results| {
+        let [result] = results else {
+            panic!("exactly one result must exist before checking the rule");
+        };
+        assert_eq!(result.rule_id, rule_id);
+    });
+}
+
+#[then("the result has {primary_count} primary location and {related_count} related location")]
+fn then_result_has_locations(world: &Run0World, primary_count: usize, related_count: usize) {
+    with_results(world, |results| {
+        let [result] = results else {
+            panic!("exactly one result must exist before checking locations");
+        };
+        assert_eq!(result.locations.len(), primary_count);
+        assert_eq!(result.related_locations.len(), related_count);
+    });
+}
+
+#[then("the Whitaker profile is {profile}")]
+fn then_whitaker_profile_is(world: &Run0World, profile: String) {
+    with_results(world, |results| {
+        let [result] = results else {
+            panic!("exactly one result must exist before checking Whitaker properties");
+        };
+        let properties = match result.properties.as_ref() {
+            Some(properties) => properties,
+            None => panic!("Whitaker properties must be present"),
+        };
+        match WhitakerProperties::try_from(properties) {
+            Ok(extracted) => assert_eq!(extracted.profile, profile),
+            Err(error) => panic!("unexpected property extraction error: {error}"),
+        }
+    });
+}
+
+#[then("the Whitaker k is {k}")]
+fn then_whitaker_k_is(world: &Run0World, k: usize) {
+    with_results(world, |results| {
+        let [result] = results else {
+            panic!("exactly one result must exist before checking Whitaker properties");
+        };
+        let properties = match result.properties.as_ref() {
+            Some(properties) => properties,
+            None => panic!("Whitaker properties must be present"),
+        };
+        match WhitakerProperties::try_from(properties) {
+            Ok(extracted) => assert_eq!(extracted.k, k),
+            Err(error) => panic!("unexpected property extraction error: {error}"),
+        }
+    });
+}
+
+#[then("the Whitaker window is {window}")]
+fn then_whitaker_window_is(world: &Run0World, window: usize) {
+    with_results(world, |results| {
+        let [result] = results else {
+            panic!("exactly one result must exist before checking Whitaker properties");
+        };
+        let properties = match result.properties.as_ref() {
+            Some(properties) => properties,
+            None => panic!("Whitaker properties must be present"),
+        };
+        match WhitakerProperties::try_from(properties) {
+            Ok(extracted) => assert_eq!(extracted.window, window),
+            Err(error) => panic!("unexpected property extraction error: {error}"),
+        }
+    });
+}
+
+#[then("no results are emitted")]
+fn then_no_results_are_emitted(world: &Run0World) {
+    with_results(world, |results| assert!(results.is_empty()));
+}
+
+#[then("the emission error is {message}")]
+fn then_emission_error_is(world: &Run0World, message: String) -> Result<(), String> {
+    match world.error.borrow().as_ref() {
+        Some(error) => {
+            assert_eq!(error.to_string(), message);
+            Ok(())
+        }
+        None => Err("an emission error must be present".to_owned()),
+    }
+}
+
+#[then("the primary region is {region}")]
+fn then_primary_region_is(world: &Run0World, region: String) {
+    with_results(world, |results| {
+        let [result] = results else {
+            panic!("exactly one result must exist before checking the primary region");
+        };
+        let location = match result.locations.first() {
+            Some(location) => location,
+            None => panic!("a primary location must be present"),
+        };
+        let region_value = match location.physical_location.region.as_ref() {
+            Some(region_value) => region_value,
+            None => panic!("a primary region must be present"),
+        };
+        let actual = format!(
+            "{}:{}-{}:{}",
+            region_value.start_line,
+            region_value.start_column.unwrap_or(1),
+            region_value.end_line.unwrap_or(region_value.start_line),
+            region_value
+                .end_column
+                .unwrap_or(region_value.start_column.unwrap_or(1))
+        );
+        assert_eq!(actual, region);
+    });
+}
+
+#[then("the primary file is {file_uri}")]
+fn then_primary_file_is(world: &Run0World, file_uri: String) {
+    with_results(world, |results| {
+        let [result] = results else {
+            panic!("exactly one result must exist before checking the primary file");
+        };
+        let location = match result.locations.first() {
+            Some(location) => location,
+            None => panic!("a primary location must be present"),
+        };
+        assert_eq!(location.physical_location.artifact_location.uri, file_uri);
+    });
+}
+
+#[scenario(path = "tests/features/run0_sarif.feature", index = 0)]
+fn scenario_type1_pair(world: Run0World) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/run0_sarif.feature", index = 1)]
+fn scenario_type2_pair(world: Run0World) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/run0_sarif.feature", index = 2)]
+fn scenario_below_threshold(world: Run0World) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/run0_sarif.feature", index = 3)]
+fn scenario_empty_fingerprints(world: Run0World) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/run0_sarif.feature", index = 4)]
+fn scenario_multiline_region(world: Run0World) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/run0_sarif.feature", index = 5)]
+fn scenario_reversed_pair(world: Run0World) {
+    let _ = world;
+}

--- a/crates/whitaker_clones_core/tests/run0_sarif_behaviour.rs
+++ b/crates/whitaker_clones_core/tests/run0_sarif_behaviour.rs
@@ -28,7 +28,7 @@ impl Default for Run0World {
             candidates: RefCell::new(Vec::new()),
             run: RefCell::new(None),
             error: RefCell::new(None),
-            config: TokenPassConfig::new("whitaker_clones_cli@token", "0.2.1"),
+            config: TokenPassConfig::new("whitaker_clones_cli@token", env!("CARGO_PKG_VERSION")),
         }
     }
 }

--- a/crates/whitaker_clones_core/tests/run0_sarif_behaviour.rs
+++ b/crates/whitaker_clones_core/tests/run0_sarif_behaviour.rs
@@ -46,6 +46,21 @@ fn with_results(world: &Run0World, assert_fn: impl FnOnce(&[SarifResult])) {
     }
 }
 
+fn with_whitaker_properties(world: &Run0World, assert_fn: impl FnOnce(&WhitakerProperties)) {
+    with_results(world, |results| {
+        let [result] = results else {
+            panic!("exactly one result must exist before checking Whitaker properties");
+        };
+        let properties = result
+            .properties
+            .as_ref()
+            .unwrap_or_else(|| panic!("Whitaker properties must be present"));
+        let extracted = WhitakerProperties::try_from(properties)
+            .unwrap_or_else(|error| panic!("unexpected property extraction error: {error}"));
+        assert_fn(&extracted);
+    });
+}
+
 fn fragment_fixture(name: &str) -> Result<TokenFragment, String> {
     match name {
         "alpha_t1" => Ok(TokenFragment::new(
@@ -189,53 +204,17 @@ fn then_result_has_locations(world: &Run0World, primary_count: usize, related_co
 
 #[then("the Whitaker profile is {profile}")]
 fn then_whitaker_profile_is(world: &Run0World, profile: String) {
-    with_results(world, |results| {
-        let [result] = results else {
-            panic!("exactly one result must exist before checking Whitaker properties");
-        };
-        let properties = match result.properties.as_ref() {
-            Some(properties) => properties,
-            None => panic!("Whitaker properties must be present"),
-        };
-        match WhitakerProperties::try_from(properties) {
-            Ok(extracted) => assert_eq!(extracted.profile, profile),
-            Err(error) => panic!("unexpected property extraction error: {error}"),
-        }
-    });
+    with_whitaker_properties(world, |props| assert_eq!(props.profile, profile));
 }
 
 #[then("the Whitaker k is {k}")]
 fn then_whitaker_k_is(world: &Run0World, k: usize) {
-    with_results(world, |results| {
-        let [result] = results else {
-            panic!("exactly one result must exist before checking Whitaker properties");
-        };
-        let properties = match result.properties.as_ref() {
-            Some(properties) => properties,
-            None => panic!("Whitaker properties must be present"),
-        };
-        match WhitakerProperties::try_from(properties) {
-            Ok(extracted) => assert_eq!(extracted.k, k),
-            Err(error) => panic!("unexpected property extraction error: {error}"),
-        }
-    });
+    with_whitaker_properties(world, |props| assert_eq!(props.k, k));
 }
 
 #[then("the Whitaker window is {window}")]
 fn then_whitaker_window_is(world: &Run0World, window: usize) {
-    with_results(world, |results| {
-        let [result] = results else {
-            panic!("exactly one result must exist before checking Whitaker properties");
-        };
-        let properties = match result.properties.as_ref() {
-            Some(properties) => properties,
-            None => panic!("Whitaker properties must be present"),
-        };
-        match WhitakerProperties::try_from(properties) {
-            Ok(extracted) => assert_eq!(extracted.window, window),
-            Err(error) => panic!("unexpected property extraction error: {error}"),
-        }
-    });
+    with_whitaker_properties(world, |props| assert_eq!(props.window, window));
 }
 
 #[then("no results are emitted")]

--- a/docs/adr-002-dylint-expect-attribute-macro.md
+++ b/docs/adr-002-dylint-expect-attribute-macro.md
@@ -10,8 +10,9 @@ Proposed.
 
 ## Context and problem statement
 
-Whitaker enforces project-specific Rust conventions using Dylint lint libraries.
-These lints run outwith normal `cargo check` and `cargo test` workflows.
+Whitaker enforces project-specific Rust conventions using Dylint lint
+libraries. These lints run outwith normal `cargo check` and `cargo test`
+workflows.
 
 Occasionally, a lint must be suppressed for a narrow scope (for example, a
 legacy call-site that cannot be refactored immediately, or an intentional
@@ -26,8 +27,8 @@ noise in normal builds because:
 - `rustc` does not know Dylint-defined lint names during ordinary compilation,
   so it can emit `unknown_lints` diagnostics.
 - The recommended Dylint gating mechanism uses `cfg_attr(dylint_lib = "…", …)`,
-  but toolchains can emit `unexpected_cfgs` diagnostics for unknown cfg keys/values
-  when `check-cfg` validation is enabled.
+  but toolchains can emit `unexpected_cfgs` diagnostics for unknown cfg
+  keys/values when `check-cfg` validation is enabled.
 
 The project needs an ergonomic, consistent, and low-friction mechanism for
 annotating items with conditional Dylint `expect` semantics that:
@@ -194,8 +195,8 @@ time.
   area.
 - Pre-expansion lints can bypass `cfg_attr` gating. For example, a
   `#[derive(...)]` macro can raise lint diagnostics on generated code before
-  `dylint_expect` expansion is applied.
-  The macro cannot correct toolchain ordering constraints.
+  `dylint_expect` expansion is applied. The macro cannot correct toolchain
+  ordering constraints.
 - The `lib` value must match the identifier Dylint injects via `dylint_lib`.
   Mismatches silently disable the `expect` and can lead to missed enforcement.
 

--- a/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
+++ b/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
@@ -520,8 +520,11 @@ During implementation, use targeted commands for quick feedback before the full
 workspace gates:
 
 ```bash
-set -o pipefail && cargo test -p whitaker_clones_core 2>&1 | tee /tmp/7-2-3-core-test.log
-set -o pipefail && cargo clippy -p whitaker_clones_core --all-targets --all-features -- -D warnings 2>&1 | tee /tmp/7-2-3-core-lint.log
+set -o pipefail && \
+  cargo test -p whitaker_clones_core 2>&1 | tee /tmp/7-2-3-core-test.log
+set -o pipefail && \
+  cargo clippy -p whitaker_clones_core --all-targets --all-features -- \
+  -D warnings 2>&1 | tee /tmp/7-2-3-core-lint.log
 ```
 
 Expected end-state signals:

--- a/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
+++ b/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
@@ -1,8 +1,8 @@
 # Emit Static Analysis Results Interchange Format (SARIF) Run 0 for accepted Type-1 and Type-2 clone pairs (roadmap 7.2.3)
 
 This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
-`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
-`Outcomes & Retrospective` must be kept up to date as work proceeds.
+`Risks`, `Progress`, `Surprises and discoveries`, `Decision log`, and
+`Outcomes and retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -85,8 +85,8 @@ Observable outcome:
   fail after 3 targeted fix iterations, stop and escalate with the saved log
   paths.
 - SARIF tolerance: if local documentation is insufficient to resolve a SARIF
-  field-shape question, use the Firecrawl MCP to fetch the relevant SARIF spec
-  details before continuing rather than guessing.
+  field-shape question, use the Firecrawl MCP (Model Context Protocol) to fetch
+  the relevant SARIF spec details before continuing rather than guessing.
 
 ## Risks
 
@@ -138,7 +138,7 @@ Observable outcome:
 - [x] Stage I: Finalize the living sections in this ExecPlan after
   implementation.
 
-## Surprises & Discoveries
+## Surprises and discoveries
 
 - `whitaker_clones_core` already provides the exact 7.2.3 upstream inputs that
   matter: canonical `CandidatePair`, deterministic `FragmentId`, and retained
@@ -166,7 +166,7 @@ Observable outcome:
   `TokenFragment::new` now sets source identity only, while retained
   fingerprints are supplied via `.with_retained_fingerprints(...)`.
 
-## Decision Log
+## Decision log
 
 - Decision: keep 7.2.3 inside `crates/whitaker_clones_core/` and add a
   dependency on `whitaker_sarif` there. Rationale: the design assigns scoring
@@ -258,7 +258,7 @@ self-contained:
 - `docs/whitaker-dylint-suite-design.md` for workspace testing and quality-gate
   expectations.
 
-## Outcomes & Retrospective
+## Outcomes and retrospective
 
 - 7.2.3 now ships as a dedicated `run0/` module inside
   `crates/whitaker_clones_core/`, exposing acceptance and SARIF-emission APIs

--- a/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
+++ b/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
@@ -1,0 +1,521 @@
+# Emit SARIF Run 0 for accepted Type-1 and Type-2 clone pairs (roadmap 7.2.3)
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+This document must be maintained in accordance with `AGENTS.md`.
+
+## Purpose / big picture
+
+Roadmap item 7.2.3 turns the completed token-pass building blocks from 7.2.1
+and 7.2.2 into an observable token-pass output. After this change,
+`crates/whitaker_clones_core/` will be able to take stable candidate pairs,
+score them for Type-1 or Type-2 acceptance, and emit a SARIF Run 0 payload that
+downstream tooling can read immediately. The emitted run must use the existing
+`whitaker_sarif` crate, must carry stable partial fingerprints, and must
+convert retained token byte ranges into stable 1-based SARIF regions.
+
+Observable outcome:
+
+1. `whitaker_clones_core` exposes a documented API that accepts token-pass
+   fragment data plus candidate pairs and returns a SARIF `Run` for the token
+   pass.
+2. Accepted Type-1 pairs produce `WHK001` results and accepted Type-2 pairs
+   produce `WHK002` results.
+3. Each emitted result carries deterministic `message`, `locations`,
+   `related_locations`, `partial_fingerprints`, and Whitaker `properties`.
+4. Unit tests cover happy paths, unhappy paths, threshold boundaries,
+   multi-line span conversion, stable ordering, and duplicate suppression.
+5. Behaviour-driven development (BDD) tests using `rstest-bdd` v0.5.0 exercise
+   end-to-end Run 0 emission for accepted, rejected, and malformed inputs.
+6. `docs/whitaker-clone-detector-design.md` records the final 7.2.3
+   implementation decisions in a new `## Implementation decisions (7.2.3)`
+   section.
+7. `docs/roadmap.md` marks 7.2.3 done only after the implementation, tests,
+   and quality gates succeed.
+8. The implementation turn finishes with `make fmt`, `make markdownlint`,
+   `make nixie`, `make check-fmt`, `make lint`, and `make test` all passing.
+
+## Constraints
+
+- Scope only roadmap item 7.2.3. Do not implement filesystem discovery,
+  grouping into clone classes, abstract syntax tree refinement, HTML output, or
+  CLI wiring in this change.
+- Keep the implementation in `crates/whitaker_clones_core/`, reusing
+  `crates/whitaker_sarif/` for all SARIF modelling and builder logic.
+- Do not bypass `whitaker_sarif` by hand-assembling JSON strings.
+- Keep every Rust source file below 400 lines. Add sibling modules rather than
+  growing `token/`, `index/`, or `lib.rs` into large files.
+- Every new Rust module must begin with a `//!` module-level comment.
+- Every public API added for 7.2.3 must carry Rustdoc with examples that pass
+  under `make test`.
+- Use workspace-pinned `rstest`, `rstest-bdd`, and `rstest-bdd-macros`
+  (`0.5.0`) for unit and behavioural coverage.
+- Behaviour tests must stay within the workspace Clippy argument threshold of
+  1. A step function may parse at most 3 values in addition to the world
+  fixture.
+- Integration tests under `tests/` must avoid `unwrap()` and `expect()`.
+- Preserve deterministic behaviour. The same accepted inputs must always yield
+  identical result ordering, fingerprints, messages, and spans.
+- Use integer arithmetic for threshold decisions. Workspace Clippy denies
+  float arithmetic and precision-loss casts in implementation crates.
+- Record all final 7.2.3 decisions in
+  `docs/whitaker-clone-detector-design.md`.
+- Do not mark roadmap item 7.2.3 done until the implementation, tests, and all
+  quality gates succeed.
+
+## Tolerances
+
+- Scope tolerance: if implementation starts requiring filesystem crawling,
+  command-line parsing, or AST refinement to make Run 0 useful, stop and
+  escalate because that crosses into roadmap items 7.3.x and later CLI work.
+- Crate-boundary tolerance: if `whitaker_clones_core` cannot emit Run 0
+  without pushing non-trivial logic back into `whitaker_sarif` or a new crate,
+  stop and escalate with the concrete boundary problem.
+- Dependency tolerance: if implementation requires a new third-party crate
+  beyond workspace dependencies, stop and escalate before adding it. This is
+  especially important if the design sketch's aspirational `Blake3` fingerprint
+  shape becomes mandatory.
+- Size tolerance: if the change exceeds 18 touched files or 1600 net new lines
+  of code, stop and escalate before proceeding further.
+- Validation tolerance: if `make check-fmt`, `make lint`, or `make test` still
+  fail after 3 targeted fix iterations, stop and escalate with the saved log
+  paths.
+- SARIF tolerance: if local documentation is insufficient to resolve a SARIF
+  field-shape question, use the Firecrawl MCP to fetch the relevant SARIF spec
+  details before continuing rather than guessing.
+
+## Risks
+
+- Fingerprint-shape risk: the design document sketches a `Blake3`-based
+  fragment key, but 7.2.2 shipped an opaque string `FragmentId` specifically to
+  defer that decision. Mitigation: keep 7.2.3 on deterministic string-backed
+  fragment IDs and, if needed, derive any extra pair hash from existing
+  workspace dependencies rather than adding `blake3`.
+- Threshold-arithmetic risk: Jaccard acceptance wants ratios, but the workspace
+  denies float arithmetic and precision-loss casts. Mitigation: represent
+  similarity as integer numerator and denominator pairs, compare thresholds via
+  cross-multiplication, and only format decimals in a tightly scoped helper for
+  human-facing text or SARIF properties.
+- Span-conversion risk: retained fingerprints currently store byte ranges, but
+  SARIF locations need 1-based line and column regions. Mitigation: add a
+  dedicated byte-index helper with unit tests for single-line, multi-line,
+  trailing-newline, and end-of-file cases.
+- Duplicate-emission risk: the same `CandidatePair` can appear more than once
+  through repeated inputs or reversed ordering. Mitigation: canonicalize pairs,
+  choose one primary location deterministically, and deduplicate emitted
+  results before finalizing the run.
+- Result-shape risk: `whitaker_sarif::deduplicate_results()` keys on
+  `(whitakerFragment, file, region)`, so a poor primary-location choice would
+  undermine merge behaviour later. Mitigation: make the lexically smaller
+  fragment the primary result location and keep the peer fragment in
+  `related_locations`.
+- Test-ergonomics risk: BDD step functions can easily exceed the argument
+  threshold when modelling two fragments, thresholds, and expected results.
+  Mitigation: store fragment data in a world struct and keep individual steps
+  small and incremental.
+
+## Progress
+
+- [x] Stage A: Gather repository context and draft this ExecPlan
+  (2026-03-29).
+- [ ] Stage B: Add failing unit tests for threshold acceptance, byte-range to
+  SARIF-region conversion, stable fingerprints, and deterministic result
+  ordering.
+- [ ] Stage C: Add failing `rstest-bdd` feature scenarios for accepted,
+  rejected, and malformed Run 0 emission.
+- [ ] Stage D: Add the new acceptance and Run 0 emission modules in
+  `crates/whitaker_clones_core/` and wire their public exports.
+- [ ] Stage E: Make the targeted tests green and refactor for readability while
+  keeping files below 400 lines.
+- [ ] Stage F: Update `docs/whitaker-clone-detector-design.md` with
+  `## Implementation decisions (7.2.3)`.
+- [ ] Stage G: Mark roadmap item 7.2.3 done in `docs/roadmap.md`.
+- [ ] Stage H: Run documentation and code quality gates successfully.
+- [ ] Stage I: Finalize the living sections in this ExecPlan after
+  implementation.
+
+## Surprises & Discoveries
+
+- `whitaker_clones_core` already provides the exact 7.2.3 upstream inputs that
+  matter: canonical `CandidatePair`, deterministic `FragmentId`, and retained
+  `Fingerprint { hash, range }` values.
+- `whitaker_sarif` already ships the builders and rule IDs that 7.2.3 needs:
+  `RunBuilder`, `ResultBuilder`, `LocationBuilder`, `RegionBuilder`,
+  `WhitakerPropertiesBuilder`, `WHK001_ID`, and `WHK002_ID`.
+- `whitaker_sarif::merge::deduplicate_results()` deduplicates only on the
+  first location plus the `whitakerFragment` fingerprint. This makes the
+  primary-versus-related location choice part of 7.2.3's observable contract.
+- There is no existing byte-offset to line-and-column mapper in
+  `whitaker_clones_core` or `whitaker_sarif`. A dedicated helper is required
+  for 7.2.3.
+- The current design document says Run 0 is produced by
+  `whitaker_clones_cli@token`, but roadmap 7.2.3 is implementable as a pure
+  library API in `whitaker_clones_core`; the CLI-specific producer string can
+  stay as a small parameter rather than forcing CLI work now.
+- Workspace dependencies already include `whitaker_sarif`, `camino`, and
+  `sha2`. If a stable hash beyond `FragmentId` is needed, 7.2.3 can likely use
+  existing dependencies without widening the dependency surface.
+
+## Decision Log
+
+- Decision: keep 7.2.3 inside `crates/whitaker_clones_core/` and add a
+  dependency on `whitaker_sarif` there. Rationale: the design assigns scoring
+  and token-pass processing to clone core, while `whitaker_sarif` is already a
+  pure modelling crate and should remain that way. Date/Author: 2026-03-29 /
+  Codex.
+- Decision: emit one SARIF result per accepted pair, not per future clone
+  class. Rationale: roadmap 7.2.3 is explicitly pair-based; grouping belongs to
+  later work. Date/Author: 2026-03-29 / Codex.
+- Decision: choose the lexically smaller fragment ID as the primary result
+  location and place the peer fragment in `related_locations`. Rationale: this
+  makes result ordering and deduplication stable, and prevents swapped-pair
+  duplicates. Date/Author: 2026-03-29 / Codex.
+- Decision: compare Jaccard thresholds with integer cross-multiplication rather
+  than floating-point arithmetic. Rationale: this matches workspace lint policy
+  and keeps acceptance deterministic. Date/Author: 2026-03-29 / Codex.
+- Decision: compute SARIF regions from byte ranges using a dedicated UTF-8
+  byte-line index helper and record both line-column data and byte
+  offset-length data in the `Region`. Rationale: retained fingerprints are
+  byte-based today, so the mapping should stay lossless and deterministic.
+  Date/Author: 2026-03-29 / Codex.
+
+## Context and orientation
+
+### Repository state
+
+The repository root is `/home/user/project`. Roadmap items 7.2.1 and 7.2.2
+already shipped `crates/whitaker_clones_core/` with:
+
+- `src/token/` for normalization, shingling, rolling hash, and winnowing.
+- `src/index/` for deterministic MinHash sketches and LSH candidate pairs.
+- `tests/token_pass_behaviour.rs` and `tests/min_hash_lsh_behaviour.rs` for
+  existing BDD coverage.
+
+The repository also already contains `crates/whitaker_sarif/`, which exports
+the SARIF model and builder surface needed for Run 0:
+
+- `RunBuilder`, `ResultBuilder`, `LocationBuilder`, and `RegionBuilder`
+- `WHK001_ID`, `WHK002_ID`
+- `WhitakerPropertiesBuilder`
+- `merge_runs()` and `deduplicate_results()`
+
+### Design requirements from `docs/whitaker-clone-detector-design.md`
+
+The clone-detector design currently states all of the following:
+
+1. The token pass performs candidate pairing first, then Jaccard similarity,
+   then SARIF emission.
+2. Run 0 holds token-pass results and uses the Type-1 or Type-2 rule IDs.
+3. Each result includes `message.text`, `locations[0]`,
+   `relatedLocations[*]`, `partialFingerprints`, and `properties`.
+4. `partialFingerprints` should include a stable Whitaker fragment key and a
+   token hash.
+5. `properties.whitaker` should include the profile, `k`, `window`, and
+   `jaccard`.
+
+### Existing code that matters
+
+- `crates/whitaker_clones_core/src/index/types.rs`
+  `CandidatePair` canonicalizes pair ordering and suppresses self-pairs.
+- `crates/whitaker_clones_core/src/token/types.rs`
+  `Fingerprint` already carries stable byte ranges.
+- `crates/whitaker_sarif/src/merge.rs`
+  deduplicates by `(whitakerFragment, file, region)`.
+- `crates/whitaker_sarif/src/whitaker_properties.rs`
+  currently expects numeric `jaccard` and `cosine` fields in
+  `WhitakerProperties`.
+
+### Testing and documentation references
+
+The implementation should follow these local guides while keeping this plan
+self-contained:
+
+- `docs/rstest-bdd-users-guide.md` for fixture-backed BDD tests and step
+  wiring.
+- `docs/rust-testing-with-rstest-fixtures.md` for reusable test-data fixtures.
+- `docs/rust-doctest-dry-guide.md` for Rustdoc example style.
+- `docs/complexity-antipatterns-and-refactoring-strategies.md` for keeping the
+  implementation split into small, readable helpers.
+- `docs/whitaker-dylint-suite-design.md` for workspace testing and quality-gate
+  expectations.
+
+## Proposed implementation shape
+
+Keep 7.2.3 narrow by adding one new module subtree for token-pass acceptance
+and Run 0 emission. A concrete shape that fits the current crate structure is:
+
+- `crates/whitaker_clones_core/src/run0/mod.rs`
+  public re-exports and module wiring.
+- `crates/whitaker_clones_core/src/run0/types.rs`
+  input structs such as `TokenFragment`, `AcceptedPair`, `TokenPassConfig`, and
+  a small `SimilarityRatio` or equivalent integer-backed score type.
+- `crates/whitaker_clones_core/src/run0/error.rs`
+  typed errors for missing fragments, empty retained fingerprints, invalid byte
+  ranges, and malformed score formatting.
+- `crates/whitaker_clones_core/src/run0/score.rs`
+  Jaccard intersection, union, threshold predicates, and deterministic decimal
+  formatting helpers.
+- `crates/whitaker_clones_core/src/run0/span.rs`
+  byte-range to SARIF-region conversion.
+- `crates/whitaker_clones_core/src/run0/emit.rs`
+  conversion from accepted token pairs into a `whitaker_sarif::Run`.
+- `crates/whitaker_clones_core/src/run0/tests.rs`
+  focused unit tests local to the new module.
+
+Update `crates/whitaker_clones_core/src/lib.rs` to re-export the public Run 0
+API alongside the existing token and index APIs.
+
+Update `crates/whitaker_clones_core/Cargo.toml` to add the workspace
+dependencies actually needed by the new module:
+
+- `whitaker_sarif`
+- `camino` only if path normalization is needed in the final API
+- `sha2` only if a stable pair hash is needed beyond deterministic string
+  concatenation
+
+The initial public API should stay explicit and builder-friendly. A concrete
+shape to implement is:
+
+```rust
+//! Example public surface only; the implementation may rename items to fit the
+//! crate, but the separation of concerns should stay the same.
+
+use whitaker_sarif::Run;
+
+pub struct TokenFragment {
+    pub id: FragmentId,
+    pub file_uri: String,
+    pub source_text: String,
+    pub retained_fingerprints: Vec<Fingerprint>,
+}
+
+pub struct TokenPassConfig {
+    pub tool_name: String,
+    pub tool_version: String,
+    pub shingle_size: usize,
+    pub winnow_window: usize,
+    pub type1_threshold_num: usize,
+    pub type1_threshold_den: usize,
+    pub type2_threshold_num: usize,
+    pub type2_threshold_den: usize,
+}
+
+pub struct AcceptedPair {
+    pub pair: CandidatePair,
+    pub profile: NormProfile,
+    pub score: SimilarityRatio,
+}
+
+pub fn accept_candidate_pairs(
+    fragments: &[TokenFragment],
+    candidates: &[CandidatePair],
+    config: &TokenPassConfig,
+) -> Run0Result<Vec<AcceptedPair>>;
+
+pub fn emit_run0(
+    fragments: &[TokenFragment],
+    accepted_pairs: &[AcceptedPair],
+    config: &TokenPassConfig,
+) -> Run0Result<Run>;
+```
+
+Use parameter structs rather than long function argument lists so the plan
+stays within the workspace's Clippy `too_many_arguments` threshold.
+
+## Detailed plan of work
+
+### Stage B: Add failing unit tests first
+
+Before implementation, add focused unit tests under
+`crates/whitaker_clones_core/src/run0/tests.rs` that fail against the current
+codebase:
+
+1. Threshold acceptance at exact boundaries for T1 and T2.
+2. Rejection just below the threshold.
+3. Jaccard set semantics: duplicate retained fingerprint hashes do not inflate
+   the score.
+4. Byte-range conversion for a single-line fragment.
+5. Byte-range conversion for a multi-line fragment with a trailing newline.
+6. Canonical pair ordering produces one primary result and one related
+   location.
+7. Stable result ordering for multiple accepted pairs.
+8. Duplicate or reversed accepted pairs produce one emitted result.
+9. Missing fragment data or invalid byte ranges produce typed errors.
+
+These tests provide the red stage for the acceptance and emission logic.
+
+### Stage C: Add failing BDD coverage
+
+Add:
+
+- `crates/whitaker_clones_core/tests/features/run0_sarif.feature`
+- `crates/whitaker_clones_core/tests/run0_sarif_behaviour.rs`
+
+Use the existing `MinHashLshWorld` and `SarifWorld` patterns as the model: a
+fixture-backed world with `RefCell` fields and `match`-based helper accessors.
+
+The feature file should cover at least:
+
+1. Happy path: a Type-1 pair above threshold emits one `WHK001` result with
+   one primary location and one related location.
+2. Happy path: a Type-2 pair above threshold emits one `WHK002` result with
+   `properties.whitaker.profile = "T2"` and the configured `k` and `window`.
+3. Unhappy path: a pair below threshold emits no result.
+4. Unhappy path: an empty retained-fingerprint set fails before emission.
+5. Edge case: a multi-line byte range yields the expected 1-based start and end
+   lines and columns.
+6. Edge case: reversed pair input still emits one deterministic result.
+
+Keep every step under the argument-count limit by loading fragment details into
+the world incrementally rather than parsing both fragments and all expected
+fields in one step.
+
+### Stage D: Implement acceptance and span mapping
+
+Create the new `run0/` module subtree.
+
+In `score.rs`:
+
+1. Deduplicate retained fingerprint hashes per fragment to honour set semantics.
+2. Compute `intersection` and `union` counts using integer arithmetic only.
+3. Compare against thresholds via cross-multiplication:
+   `intersection * threshold_den >= union * threshold_num`.
+4. Add a small helper that formats the accepted score into a stable decimal
+   string for `message.text`.
+5. If `WhitakerProperties` still requires `f64`, convert only in one
+   quarantined helper so the rest of the logic stays integer-based.
+
+In `span.rs`:
+
+1. Build a line-start index from the fragment's source text once.
+2. Convert a half-open byte range into:
+   - `start_line`
+   - `start_column`
+   - `end_line`
+   - `end_column`
+   - `byte_offset`
+   - `byte_length`
+3. Reject out-of-bounds or inverted ranges with a typed error.
+
+The span helper must be pure and deterministic so it can be unit-tested without
+SARIF builders in the way.
+
+### Stage E: Implement Run 0 emission
+
+In `emit.rs`:
+
+1. Resolve the left and right `TokenFragment` values for each accepted pair.
+2. Choose the primary fragment deterministically from the canonical pair order.
+3. Convert the primary and peer fingerprint byte ranges into SARIF `Region`
+   values.
+4. Use `LocationBuilder` for the primary `locations[0]`.
+5. Use `RelatedLocation` for the peer occurrence so the result captures both
+   fragments without creating a second swapped result.
+6. Use `ResultBuilder` with:
+   - `rule_id = WHK001_ID` for `NormProfile::T1`
+   - `rule_id = WHK002_ID` for `NormProfile::T2`
+   - a stable, human-readable message:
+     `Type-{N} clone: {fileA}:{spanA} <-> {fileB}:{spanB} (sim = {score})`
+7. Populate `partial_fingerprints` with at least:
+   - `whitakerFragment`: stable pair fingerprint used for deduplication
+   - `tokenHash`: stable fingerprint derived from the accepted pair's retained
+     token hashes
+8. Populate `properties.whitaker` with:
+   - `profile`
+   - `k`
+   - `window`
+   - `jaccard`
+   - `cosine = 0.0` for Run 0
+   - `groupId = 0`
+   - `classSize = 2`
+9. Sort results deterministically before finalizing the run.
+10. Run the emitted result list through `whitaker_sarif::deduplicate_results()`
+    as a final safety net.
+
+Construct the run with `RunBuilder`. Use a producer name compatible with the
+design, but keep it configurable through `TokenPassConfig` so 7.2.3 remains a
+library API.
+
+### Stage F: Update documentation
+
+Append `## Implementation decisions (7.2.3)` to
+`docs/whitaker-clone-detector-design.md`.
+
+Record the final decisions explicitly, including:
+
+1. The stable pair-fingerprint shape used for `whitakerFragment`.
+2. The token-hash shape used for `partialFingerprints["tokenHash"]`.
+3. The exact threshold representation and comparison strategy.
+4. The primary-versus-related location contract.
+5. The byte-range to line-column mapping rules.
+6. Any pragmatic deviation from the earlier `Blake3` sketch in the design.
+
+Do not mark the roadmap item done until the implementation and all quality
+gates pass.
+
+### Stage G: Mark the roadmap item done
+
+After implementation and successful validation, change the 7.2.3 checkbox in
+`docs/roadmap.md` from `[ ]` to `[x]`.
+
+### Stage H: Validation and quality gates
+
+Because the implementation touches Rust code and Markdown, the implementation
+turn must run all repository-required gates with `tee` and `set -o pipefail`.
+Use distinct log files so failures are inspectable after truncated output.
+
+Run:
+
+```bash
+set -o pipefail && make fmt 2>&1 | tee /tmp/7-2-3-fmt.log
+set -o pipefail && make markdownlint 2>&1 | tee /tmp/7-2-3-markdownlint.log
+set -o pipefail && make nixie 2>&1 | tee /tmp/7-2-3-nixie.log
+set -o pipefail && make check-fmt 2>&1 | tee /tmp/7-2-3-check-fmt.log
+set -o pipefail && make lint 2>&1 | tee /tmp/7-2-3-lint.log
+set -o pipefail && make test 2>&1 | tee /tmp/7-2-3-test.log
+```
+
+During implementation, use targeted commands for quick feedback before the full
+workspace gates:
+
+```bash
+set -o pipefail && cargo test -p whitaker_clones_core 2>&1 | tee /tmp/7-2-3-core-test.log
+set -o pipefail && cargo clippy -p whitaker_clones_core --all-targets --all-features -- -D warnings 2>&1 | tee /tmp/7-2-3-core-lint.log
+```
+
+Expected end-state signals:
+
+1. The new unit tests and BDD scenarios pass.
+2. `make check-fmt`, `make lint`, and `make test` pass.
+3. `docs/whitaker-clone-detector-design.md` contains
+   `## Implementation decisions (7.2.3)`.
+4. `docs/roadmap.md` shows 7.2.3 as done.
+
+## Acceptance criteria
+
+The implementation is complete when a novice can verify all of the following:
+
+1. Calling the new `emit_run0` API with a Type-1 accepted pair returns a
+   `whitaker_sarif::Run` containing one `WHK001` result.
+2. Calling the same API with a Type-2 accepted pair returns one `WHK002`
+   result.
+3. A below-threshold candidate pair does not appear in the emitted run.
+4. Reversed pair inputs still emit the same stable result once.
+5. A multi-line retained fingerprint range is represented with correct 1-based
+   SARIF span fields and matching byte offset-length fields.
+6. Serializing the emitted run to JSON twice yields identical output for the
+   same input.
+
+## Outcomes & Retrospective
+
+This section is intentionally empty during the draft phase. The implementation
+turn must replace it with:
+
+- what shipped,
+- what changed from the draft,
+- final validation results and log paths,
+- and any follow-up work that should remain out of scope for 7.2.3.

--- a/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
+++ b/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
@@ -1,4 +1,4 @@
-# Emit SARIF Run 0 for accepted Type-1 and Type-2 clone pairs (roadmap 7.2.3)
+# Emit Static Analysis Results Interchange Format (SARIF) Run 0 for accepted Type-1 and Type-2 clone pairs (roadmap 7.2.3)
 
 This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
@@ -26,7 +26,7 @@ Observable outcome:
 2. Accepted Type-1 pairs produce `WHK001` results and accepted Type-2 pairs
    produce `WHK002` results.
 3. Each emitted result carries deterministic `message`, `locations`,
-   `related_locations`, `partial_fingerprints`, and Whitaker `properties`.
+   `relatedLocations`, `partial_fingerprints`, and Whitaker `properties`.
 4. Unit tests cover happy paths, unhappy paths, threshold boundaries,
    multi-line span conversion, stable ordering, and duplicate suppression.
 5. Behaviour-driven development (BDD) tests using `rstest-bdd` v0.5.0 exercise
@@ -43,7 +43,7 @@ Observable outcome:
 
 - Scope only roadmap item 7.2.3. Do not implement filesystem discovery,
   grouping into clone classes, abstract syntax tree refinement, HTML output, or
-  CLI wiring in this change.
+  command-line interface (CLI) wiring in this change.
 - Keep the implementation in `crates/whitaker_clones_core/`, reusing
   `crates/whitaker_sarif/` for all SARIF modelling and builder logic.
 - Do not bypass `whitaker_sarif` by hand-assembling JSON strings.

--- a/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
+++ b/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
@@ -26,7 +26,7 @@ Observable outcome:
 2. Accepted Type-1 pairs produce `WHK001` results, and accepted Type-2 pairs
    produce `WHK002` results.
 3. Each emitted result carries deterministic `message`, `locations`,
-   `relatedLocations`, `partial_fingerprints`, and Whitaker `properties`.
+   `relatedLocations`, `partialFingerprints`, and Whitaker `properties`.
 4. Unit tests cover happy paths, unhappy paths, threshold boundaries,
    multi-line span conversion, stable ordering, and duplicate suppression.
 5. Behaviour-driven development (BDD) tests using `rstest-bdd` v0.5.0 exercise
@@ -457,7 +457,7 @@ In `emit.rs`:
    - `rule_id = WHK002_ID` for `NormProfile::T2`
    - a stable, human-readable message:
      `Type-{N} clone: {fileA}:{spanA} <-> {fileB}:{spanB} (sim = {score})`
-7. Populate `partial_fingerprints` with at least:
+7. Populate `partialFingerprints` with at least:
    - `whitakerFragment`: stable pair fingerprint used for deduplication
    - `tokenHash`: stable fingerprint derived from the accepted pair's retained
      token hashes

--- a/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
+++ b/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
@@ -4,7 +4,7 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 This document must be maintained in accordance with `AGENTS.md`.
 
@@ -122,20 +122,20 @@ Observable outcome:
 
 - [x] Stage A: Gather repository context and draft this ExecPlan
   (2026-03-29).
-- [ ] Stage B: Add failing unit tests for threshold acceptance, byte-range to
+- [x] Stage B: Add failing unit tests for threshold acceptance, byte-range to
   SARIF-region conversion, stable fingerprints, and deterministic result
-  ordering.
-- [ ] Stage C: Add failing `rstest-bdd` feature scenarios for accepted,
+  ordering (completed 2026-03-30).
+- [x] Stage C: Add failing `rstest-bdd` feature scenarios for accepted,
   rejected, and malformed Run 0 emission.
-- [ ] Stage D: Add the new acceptance and Run 0 emission modules in
+- [x] Stage D: Add the new acceptance and Run 0 emission modules in
   `crates/whitaker_clones_core/` and wire their public exports.
-- [ ] Stage E: Make the targeted tests green and refactor for readability while
+- [x] Stage E: Make the targeted tests green and refactor for readability while
   keeping files below 400 lines.
-- [ ] Stage F: Update `docs/whitaker-clone-detector-design.md` with
+- [x] Stage F: Update `docs/whitaker-clone-detector-design.md` with
   `## Implementation decisions (7.2.3)`.
-- [ ] Stage G: Mark roadmap item 7.2.3 done in `docs/roadmap.md`.
-- [ ] Stage H: Run documentation and code quality gates successfully.
-- [ ] Stage I: Finalize the living sections in this ExecPlan after
+- [x] Stage G: Mark roadmap item 7.2.3 done in `docs/roadmap.md`.
+- [x] Stage H: Run documentation and code quality gates successfully.
+- [x] Stage I: Finalize the living sections in this ExecPlan after
   implementation.
 
 ## Surprises & Discoveries
@@ -159,6 +159,12 @@ Observable outcome:
 - Workspace dependencies already include `whitaker_sarif`, `camino`, and
   `sha2`. If a stable hash beyond `FragmentId` is needed, 7.2.3 can likely use
   existing dependencies without widening the dependency surface.
+- `whitaker_sarif::WhitakerProperties` still requires numeric `jaccard` and
+  `cosine` fields, so 7.2.3 needs one narrowly scoped decimal-string-to-`f64`
+  conversion helper even though the acceptance logic itself stays integer-only.
+- The workspace Clippy threshold of four arguments shaped the final public API:
+  `TokenFragment::new` now sets source identity only, while retained
+  fingerprints are supplied via `.with_retained_fingerprints(...)`.
 
 ## Decision Log
 
@@ -182,6 +188,15 @@ Observable outcome:
   offset-length data in the `Region`. Rationale: retained fingerprints are
   byte-based today, so the mapping should stay lossless and deterministic.
   Date/Author: 2026-03-29 / Codex.
+- Decision: use SHA-256 hex digests for both the pair fingerprint and the
+  combined token hash. Rationale: `sha2` is already a workspace dependency,
+  while the earlier Blake3 shape was only aspirational and not yet committed
+  anywhere else in the codebase. Date/Author: 2026-03-30 / Codex.
+- Decision: derive the primary SARIF span from the first retained fingerprint
+  of each accepted fragment. Rationale: 7.2.3 only needs stable pair emission,
+  not clone-class region aggregation, and the first retained fingerprint is the
+  narrowest deterministic span already available from 7.2.1. Date/Author:
+  2026-03-30 / Codex.
 
 ## Context and orientation
 
@@ -242,6 +257,28 @@ self-contained:
   implementation split into small, readable helpers.
 - `docs/whitaker-dylint-suite-design.md` for workspace testing and quality-gate
   expectations.
+
+## Outcomes & Retrospective
+
+- 7.2.3 now ships as a dedicated `run0/` module inside
+  `crates/whitaker_clones_core/`, exposing acceptance and SARIF-emission APIs
+  without pulling in CLI concerns.
+- Accepted Type-1 and Type-2 pairs now emit deterministic SARIF Run 0 results
+  via `whitaker_sarif`, including stable ordering, primary-versus-related
+  locations, SHA-256 partial fingerprints, Whitaker properties, and byte-range
+  to region conversion.
+- Unit coverage and `rstest-bdd` behavioural coverage now exercise threshold
+  boundaries, malformed inputs, multi-line spans, duplicate suppression, and
+  deterministic primary-location selection.
+- `docs/whitaker-clone-detector-design.md` records the final 7.2.3
+  implementation decisions, and `docs/roadmap.md` now marks roadmap item 7.2.3
+  complete.
+- Final quality gates passed with logs captured at:
+  `/tmp/7-2-3-final-fmt.log`, `/tmp/7-2-3-final-markdownlint.log`,
+  `/tmp/7-2-3-final-nixie.log`, `/tmp/7-2-3-final-check-fmt.log`,
+  `/tmp/7-2-3-final-lint.log`, and `/tmp/7-2-3-final-test.log`.
+- Final validation summary: `make test` completed successfully with
+  `Summary [ 111.463s] 1188 tests run: 1188 passed, 2 skipped`.
 
 ## Proposed implementation shape
 
@@ -509,13 +546,3 @@ The implementation is complete when a novice can verify all of the following:
    SARIF span fields and matching byte offset-length fields.
 6. Serializing the emitted run to JSON twice yields identical output for the
    same input.
-
-## Outcomes & Retrospective
-
-This section is intentionally empty during the draft phase. The implementation
-turn must replace it with:
-
-- what shipped,
-- what changed from the draft,
-- final validation results and log paths,
-- and any follow-up work that should remain out of scope for 7.2.3.

--- a/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
+++ b/docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md
@@ -23,7 +23,7 @@ Observable outcome:
 1. `whitaker_clones_core` exposes a documented API that accepts token-pass
    fragment data plus candidate pairs and returns a SARIF `Run` for the token
    pass.
-2. Accepted Type-1 pairs produce `WHK001` results and accepted Type-2 pairs
+2. Accepted Type-1 pairs produce `WHK001` results, and accepted Type-2 pairs
    produce `WHK002` results.
 3. Each emitted result carries deterministic `message`, `locations`,
    `relatedLocations`, `partial_fingerprints`, and Whitaker `properties`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -251,7 +251,7 @@
 - [x] 7.2.2. Implement MinHash + LSH candidate generation with configurable
   bands and rows. See
   [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.
-- [ ] 7.2.3. Emit SARIF run 0 for accepted Type-1 and Type-2 pairs with stable
+- [x] 7.2.3. Emit SARIF run 0 for accepted Type-1 and Type-2 pairs with stable
   fingerprints and spans. See
   [clone detector design](whitaker-clone-detector-design.md) §SARIF emission
   (Run 0). Requires 7.1.1.

--- a/docs/whitaker-clone-detector-design.md
+++ b/docs/whitaker-clone-detector-design.md
@@ -475,9 +475,9 @@ cargo whitaker clones report --in target/whitaker/clones.refined.sarif --html
    rather than being silently coerced.
 
 3. **Stable fingerprint shape.** `partialFingerprints["whitakerFragment"]` is
-   a SHA-256 hex digest over `left_fragment_id`, `right_fragment_id`, and the
+   an SHA-256 hex digest over `left_fragment_id`, `right_fragment_id`, and the
    emitted profile, separated by NUL bytes. `partialFingerprints["tokenHash"]`
-   is a SHA-256 hex digest over the sorted, deduplicated retained token hashes
+   is an SHA-256 hex digest over the sorted, deduplicated retained token hashes
    from both accepted fragments encoded with big-endian bytes. This replaces
    the earlier aspirational Blake3 sketch while staying deterministic and
    within existing workspace dependencies.
@@ -503,9 +503,14 @@ cargo whitaker clones report --in target/whitaker/clones.refined.sarif --html
    using a line-start index over the original source text.
 
 7. **Explicit empty-input behaviour.** Sketching an empty retained-fingerprint
-   list returns `IndexError::EmptyFingerprintSet`. Candidate generation stops
-   at that error so later pipeline stages can decide whether to skip the
-   fragment or surface the failure.
+   list returns `IndexError::EmptyFingerprintSet` at the index/minhash layer.
+   The Run 0 layer (`run0/emit.rs`) does not propagate this error directly;
+   instead, it surfaces `Run0Error::EmptyFingerprintSet` when
+   `jaccard_similarity` returns `None` for empty fingerprint sets. Callers
+   should match on `Run0Error::EmptyFingerprintSet` for Run 0 operations or
+   translate it to `IndexError::EmptyFingerprintSet` if normalizing errors
+   across layers. Candidate generation stops at that error so later pipeline
+   stages can decide whether to skip the fragment or surface the failure.
 
 8. **Canonical, deduplicated candidate pairs.** `LshIndex` buckets fragments by
    `(band_index, band_values)` and stores members in ordered sets. Candidate

--- a/docs/whitaker-clone-detector-design.md
+++ b/docs/whitaker-clone-detector-design.md
@@ -459,12 +459,55 @@ cargo whitaker clones report --in target/whitaker/clones.refined.sarif --html
    reported as typed `IndexError` values rather than silently rounded or
    clamped.
 
-4. **Explicit empty-input behaviour.** Sketching an empty retained-fingerprint
+## Implementation decisions (7.2.3)
+
+1. **Dedicated `run0/` module subtree.** Roadmap item 7.2.3 ships as a new
+   `run0/` module subtree inside `crates/whitaker_clones_core/`. The public
+   surface exports `TokenFragment`, `TokenPassConfig`, `SimilarityThreshold`,
+   `SimilarityRatio`, `AcceptedPair`, `accept_candidate_pairs`, and
+   `emit_run0`, keeping token-pass acceptance and SARIF emission together
+   without widening the `whitaker_sarif` crate's remit.
+
+2. **Profile-specific acceptance.** `TokenFragment` now records the
+   normalization profile that produced it. `accept_candidate_pairs` only emits
+   `T1` for `NormProfile::T1` fragments and `T2` for `NormProfile::T2`
+   fragments; mixed-profile candidate pairs fail with a typed `Run0Error`
+   rather than being silently coerced.
+
+3. **Stable fingerprint shape.** `partialFingerprints["whitakerFragment"]` is
+   a SHA-256 hex digest over `left_fragment_id`, `right_fragment_id`, and the
+   emitted profile, separated by NUL bytes. `partialFingerprints["tokenHash"]`
+   is a SHA-256 hex digest over the sorted, deduplicated retained token hashes
+   from both accepted fragments encoded with big-endian bytes. This replaces
+   the earlier aspirational Blake3 sketch while staying deterministic and
+   within existing workspace dependencies.
+
+4. **Integer-only threshold and score handling.** Jaccard similarity is
+   computed with set semantics over unique retained token hashes and compared
+   against validated rational thresholds using integer cross-multiplication.
+   Human-facing score text uses a six-decimal repeated-subtraction formatter,
+   and Whitaker's numeric `jaccard` field is populated by parsing that stable
+   decimal string back into `f64` in one quarantined helper.
+
+5. **Primary-versus-related location contract.** Each accepted pair emits one
+   SARIF result whose primary location is the canonical left fragment from
+   `CandidatePair`, while the peer fragment is stored in one `relatedLocation`.
+   The emitted result list is sorted deterministically and then passed through
+   `whitaker_sarif::deduplicate_results()` so repeated or reversed accepted
+   pairs collapse to one stable result.
+
+6. **Byte-range mapping rules.** SARIF regions are derived from each
+   fragment's first retained fingerprint range. The mapper validates in-bounds,
+   non-empty, UTF-8-aligned half-open byte ranges, records `byteOffset` and
+   `byteLength`, and converts the range to 1-based line-column coordinates
+   using a line-start index over the original source text.
+
+7. **Explicit empty-input behaviour.** Sketching an empty retained-fingerprint
    list returns `IndexError::EmptyFingerprintSet`. Candidate generation stops
    at that error so later pipeline stages can decide whether to skip the
    fragment or surface the failure.
 
-5. **Canonical, deduplicated candidate pairs.** `LshIndex` buckets fragments by
+8. **Canonical, deduplicated candidate pairs.** `LshIndex` buckets fragments by
    `(band_index, band_values)` and stores members in ordered sets. Candidate
    pairs are emitted in lexical `FragmentId` order, self-pairs are suppressed,
    and repeated collisions across multiple bands still produce one stable


### PR DESCRIPTION
## Summary
- Implements Run 0 emission for accepted Type-1 and Type-2 clone pairs. Adds a new run0 module under `crates/whitaker_clones_core/` with `accept_candidate_pairs` and `emit_run0`, plus unit tests and BDD coverage, and updates docs and roadmap accordingly.

## What’s included
- New module subtree: `crates/whitaker_clones_core/src/run0/` containing:
  - `emit.rs` (SARIF emission logic)
  - `error.rs` (typed Run 0 errors)
  - `mod.rs` (module wiring)
  - `score.rs` (integer-based Jaccard scoring and thresholds)
  - `span.rs` (byte-range to SARIF region conversion)
  - `types.rs` (public input/output types)
  - `tests.rs` (unit tests for Run 0 logic)
- Public API exposure in `crates/whitaker_clones_core/src/lib.rs` for Run 0:
  - `AcceptedPair`, `Run0Error`, `Run0Result`, `SimilarityRatio`, `SimilarityThreshold`, `TokenFragment`, `TokenPassConfig`, `accept_candidate_pairs`, `emit_run0`.
- Behavioural and integration tests:
  - `crates/whitaker_clones_core/src/run0_sarif.feature` (BDD feature file)
  - `crates/whitaker_clones_core/src/run0_sarif_behaviour.rs` (BDD harness)
- Tests and fixtures for Run 0 emission:
  - `crates/whitaker_clones_core/tests/features/run0_sarif.feature` (feature area)
  - `crates/whitaker_clones_core/tests/run0_sarif_behaviour.rs` (behaviour tests)
- ExecPlan living document updated to reflect implementation:
  - `docs/execplans/7-2-3-emit-sarif-run-0-for-accepted-type-1-and-type-2-pairs.md` (status COMPLETE)
- Roadmap and design updates:
  - `docs/roadmap.md` updated to mark 7.2.3 as done
  - `docs/whitaker-clone-detector-design.md` updated with dedicated 7.2.3 decisions (in-file section)

## Rationale
- This completes roadmap item 7.2.3 by turning the prior planning into a concrete, test-covered Run 0 emission path. The new `run0` module reuses existing SARIF tooling (`whitaker_sarif`) and keeps emission logic encapsulated within `whitaker_clones_core` as planned, enabling deterministic results and stable regions for downstream tooling.

## Implementation plan (high level)
- Stage A: Draft ExecPlan (completed)
- Stage B: Add unit tests for thresholds, span mapping, and deterministic ordering (completed)
- Stage C: Add BDD coverage for Run 0 emission (completed)
- Stage D: Implement run0 module skeleton and API surface (completed)
- Stage E: Implement Run 0 emission logic (completed)
- Stage F: Documentation updates (`## Implementation decisions (7.2.3)`) (completed)
- Stage G: Mark roadmap item done in `docs/roadmap.md` (completed)
- Stage H: Validate with all gates (fmt, lint, test, etc.) (completed)
- Stage I: Finalize ExecPlan post-implementation (completed)

## How to review
- Verify the new Run 0 API surface and the emitted SARIF run shape align with the design goals (one SARIF result per accepted pair, with stable primary/related locations and fingerprints).
- Confirm deterministic sorting and deduplication behavior for multiple accepted pairs.
- Check unit and behavioural tests exercise threshold boundaries, multi-line span conversion, and reversed-pair determinism.
- Review documentation updates for accuracy and consistency with the code changes.

## Documentation impact
- Introduces a new ExecPlan living document updated to COMPLETE status.
- Roadmap and design docs reflect the implemented Run 0 emission decisions and outcomes.

## Acceptance criteria
- The PR implements Run 0 emission for Type-1 and Type-2 accepted pairs with deterministic results.
- Unit tests and BDD tests cover happy paths, threshold boundaries, multi-line spans, and reversed inputs.
- The emitted SARIF run uses the existing `whitaker_sarif` tooling and carries stable fingerprints and 1-based SARIF regions.
- Documentation and roadmap reflect completion of 7.2.3.


📎 **Task**: https://www.devboxer.com/task/81bbb2d8-2581-49d3-a21b-cba40d1d3c53

📎 **Task**: https://www.devboxer.com/task/3515b49a-8747-49b6-80b3-5e2575dce6dd

## Summary by Sourcery

Implement token-pass Run 0 SARIF emission for accepted clone pairs and expose a public API for acceptance and emission in whitaker_clones_core.

New Features:
- Add a dedicated run0 module in whitaker_clones_core for token-pass acceptance and SARIF Run 0 emission.
- Expose public types and functions for Run 0, including TokenFragment, TokenPassConfig, AcceptedPair, SimilarityThreshold, accept_candidate_pairs, and emit_run0.
- Introduce deterministic Jaccard-based scoring and threshold handling for Type-1 and Type-2 clone pairs.

Enhancements:
- Define stable pair and token hash fingerprints using SHA-256 for SARIF partialFingerprints.
- Implement byte-range to SARIF region mapping with validation for UTF-8 alignment and bounds.
- Ensure deterministic sorting and deduplication of emitted SARIF results based on rule, fingerprints, and message.

Documentation:
- Document implementation decisions for roadmap item 7.2.3 in the clone-detector design and add a detailed ExecPlan for Run 0 emission.
- Update the roadmap to mark SARIF Run 0 emission for accepted Type-1 and Type-2 pairs as complete.

Tests:
- Add unit tests for similarity scoring, threshold boundaries, span mapping, acceptance logic, and Run 0 emission behaviour.
- Add BDD feature scenarios and harness for end-to-end Run 0 SARIF emission, including edge cases for empty inputs, multi-line spans, and reversed pairs.