### PR TITLE
Installer: switch to cargo-binstall with fallbacks

### DIFF
--- a/installer/src/deps.rs
+++ b/installer/src/deps.rs
@@ -66,6 +66,14 @@ pub struct DylintToolStatus {
     pub dylint_link: bool,
 }
 
+/// Available installation backends for dependency crates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstallBackend {
+    Binstall,
+    BinstallSubcommand,
+    Install,
+}
+
 impl DylintToolStatus {
     /// Returns `true` if both tools are installed.
     ///
@@ -124,8 +132,8 @@ pub fn check_dylint_tools(executor: &dyn CommandExecutor) -> DylintToolStatus {
 
 /// Installs missing Dylint tools.
 ///
-/// Uses `cargo binstall` if available for faster installation, otherwise
-/// falls back to `cargo install`.
+/// Uses `cargo-binstall` if available for faster installation, otherwise falls
+/// back to `cargo binstall` or `cargo install`.
 ///
 /// # Arguments
 ///
@@ -143,14 +151,14 @@ pub fn install_dylint_tools(
     executor: &dyn CommandExecutor,
     status: &DylintToolStatus,
 ) -> Result<()> {
-    let use_binstall = is_binstall_available(executor);
+    let backend = install_backend(executor);
 
     if !status.cargo_dylint {
-        install_tool(executor, "cargo-dylint", use_binstall)?;
+        install_tool(executor, "cargo-dylint", backend)?;
     }
 
     if !status.dylint_link {
-        install_tool(executor, "dylint-link", use_binstall)?;
+        install_tool(executor, "dylint-link", backend)?;
     }
 
     Ok(())
@@ -166,21 +174,27 @@ fn is_dylint_link_installed(executor: &dyn CommandExecutor) -> bool {
     command_succeeds(executor, "dylint-link", &["--version"])
 }
 
-/// Checks if `cargo binstall` is available.
-fn is_binstall_available(executor: &dyn CommandExecutor) -> bool {
-    command_succeeds(executor, "cargo", &["binstall", "--version"])
+/// Selects the preferred backend for installing dependency crates.
+fn install_backend(executor: &dyn CommandExecutor) -> InstallBackend {
+    if command_succeeds(executor, "cargo-binstall", &["--version"]) {
+        InstallBackend::Binstall
+    } else if command_succeeds(executor, "cargo", &["binstall", "--version"]) {
+        InstallBackend::BinstallSubcommand
+    } else {
+        InstallBackend::Install
+    }
 }
 
 /// Installs a single tool using binstall or cargo install.
 fn install_tool(
     executor: &dyn CommandExecutor,
     name: &'static str,
-    use_binstall: bool,
+    backend: InstallBackend,
 ) -> Result<()> {
-    let output = if use_binstall {
-        executor.run("cargo", &["binstall", "-y", name])?
-    } else {
-        executor.run("cargo", &["install", name])?
+    let output = match backend {
+        InstallBackend::Binstall => executor.run("cargo-binstall", &["-y", name])?,
+        InstallBackend::BinstallSubcommand => executor.run("cargo", &["binstall", "-y", name])?,
+        InstallBackend::Install => executor.run("cargo", &["install", name])?,
     };
 
     if !output.status.success() {

--- a/installer/src/deps/tests.rs
+++ b/installer/src/deps/tests.rs
@@ -76,7 +76,18 @@ fn test_install_dylint_tools_failure(
     executor.assert_finished();
 }
 
-/// Constructs an `ExpectedCall` for checking if cargo-binstall is available.
+/// Constructs an `ExpectedCall` for checking if `cargo-binstall` is available.
+///
+/// Returns an `ExpectedCall` with `cmd="cargo-binstall", args=["--version"]`.
+fn cargo_binstall_version_check(result: Result<Output>) -> ExpectedCall {
+    ExpectedCall {
+        cmd: "cargo-binstall",
+        args: vec!["--version"],
+        result,
+    }
+}
+
+/// Constructs an `ExpectedCall` for checking if cargo binstall is available.
 ///
 /// Returns an `ExpectedCall` with cmd="cargo", args=["binstall", "--version"].
 fn binstall_version_check(result: Result<Output>) -> ExpectedCall {
@@ -87,7 +98,18 @@ fn binstall_version_check(result: Result<Output>) -> ExpectedCall {
     }
 }
 
-/// Constructs an `ExpectedCall` for installing cargo-dylint via binstall.
+/// Constructs an `ExpectedCall` for installing cargo-dylint via `cargo-binstall`.
+///
+/// Returns an `ExpectedCall` with `cmd="cargo-binstall", args=["-y", "cargo-dylint"]`.
+fn cargo_binstall_install_cargo_dylint(result: Result<Output>) -> ExpectedCall {
+    ExpectedCall {
+        cmd: "cargo-binstall",
+        args: vec!["-y", "cargo-dylint"],
+        result,
+    }
+}
+
+/// Constructs an `ExpectedCall` for installing cargo-dylint via cargo binstall.
 ///
 /// Returns an `ExpectedCall` with cmd="cargo", args=["binstall", "-y", "cargo-dylint"].
 fn binstall_install_cargo_dylint(result: Result<Output>) -> ExpectedCall {
@@ -98,7 +120,18 @@ fn binstall_install_cargo_dylint(result: Result<Output>) -> ExpectedCall {
     }
 }
 
-/// Constructs an `ExpectedCall` for installing dylint-link via binstall.
+/// Constructs an `ExpectedCall` for installing dylint-link via `cargo-binstall`.
+///
+/// Returns an `ExpectedCall` with `cmd="cargo-binstall", args=["-y", "dylint-link"]`.
+fn cargo_binstall_install_dylint_link(result: Result<Output>) -> ExpectedCall {
+    ExpectedCall {
+        cmd: "cargo-binstall",
+        args: vec!["-y", "dylint-link"],
+        result,
+    }
+}
+
+/// Constructs an `ExpectedCall` for installing dylint-link via cargo binstall.
 ///
 /// Returns an `ExpectedCall` with cmd="cargo", args=["binstall", "-y", "dylint-link"].
 fn binstall_install_dylint_link(result: Result<Output>) -> ExpectedCall {
@@ -240,9 +273,28 @@ fn check_dylint_tools_reports_missing_cargo_dylint() {
 }
 
 #[test]
-fn install_dylint_tools_uses_binstall_when_available() {
+fn install_dylint_tools_prefers_cargo_binstall_when_available() {
     test_install_dylint_tools_success(
         vec![
+            cargo_binstall_version_check(Ok(success_output())),
+            cargo_binstall_install_cargo_dylint(Ok(success_output())),
+            cargo_binstall_install_dylint_link(Ok(success_output())),
+        ],
+        DylintToolStatus {
+            cargo_dylint: false,
+            dylint_link: false,
+        },
+    );
+}
+
+#[test]
+fn install_dylint_tools_uses_cargo_binstall_subcommand_when_executable_missing() {
+    test_install_dylint_tools_success(
+        vec![
+            cargo_binstall_version_check(Err(std::io::Error::other(
+                "failed to execute cargo-binstall",
+            )
+            .into())),
             binstall_version_check(Ok(success_output())),
             binstall_install_cargo_dylint(Ok(success_output())),
             binstall_install_dylint_link(Ok(success_output())),
@@ -258,6 +310,7 @@ fn install_dylint_tools_uses_binstall_when_available() {
 fn install_dylint_tools_falls_back_to_cargo_install() {
     test_install_dylint_tools_success(
         vec![
+            cargo_binstall_version_check(Ok(failure_output("no cargo-binstall"))),
             binstall_version_check(Ok(failure_output("no binstall"))),
             cargo_install_cargo_dylint(Ok(success_output())),
         ],
@@ -272,6 +325,10 @@ fn install_dylint_tools_falls_back_to_cargo_install() {
 fn install_dylint_tools_falls_back_to_cargo_install_on_binstall_error() {
     test_install_dylint_tools_success(
         vec![
+            cargo_binstall_version_check(Err(std::io::Error::other(
+                "failed to execute cargo-binstall",
+            )
+            .into())),
             binstall_version_check(Err(std::io::Error::other(
                 "failed to execute cargo binstall",
             )
@@ -289,6 +346,26 @@ fn install_dylint_tools_falls_back_to_cargo_install_on_binstall_error() {
 fn install_dylint_tools_reports_install_failure() {
     test_install_dylint_tools_failure(
         vec![
+            cargo_binstall_version_check(Ok(success_output())),
+            cargo_binstall_install_cargo_dylint(Ok(failure_output("network down"))),
+        ],
+        DylintToolStatus {
+            cargo_dylint: false,
+            dylint_link: true,
+        },
+        "cargo-dylint",
+        "network down",
+    );
+}
+
+#[test]
+fn install_dylint_tools_reports_install_failure_for_cargo_subcommand_binstall() {
+    test_install_dylint_tools_failure(
+        vec![
+            cargo_binstall_version_check(Err(std::io::Error::other(
+                "failed to execute cargo-binstall",
+            )
+            .into())),
             binstall_version_check(Ok(success_output())),
             binstall_install_cargo_dylint(Ok(failure_output("network down"))),
         ],
@@ -305,6 +382,27 @@ fn install_dylint_tools_reports_install_failure() {
 fn install_dylint_tools_reports_dylint_link_install_failure() {
     test_install_dylint_tools_failure(
         vec![
+            cargo_binstall_version_check(Ok(success_output())),
+            cargo_binstall_install_cargo_dylint(Ok(success_output())),
+            cargo_binstall_install_dylint_link(Ok(failure_output("dylint-link failed"))),
+        ],
+        DylintToolStatus {
+            cargo_dylint: false,
+            dylint_link: false,
+        },
+        "dylint-link",
+        "dylint-link failed",
+    );
+}
+
+#[test]
+fn install_dylint_tools_reports_dylint_link_install_failure_for_cargo_subcommand_binstall() {
+    test_install_dylint_tools_failure(
+        vec![
+            cargo_binstall_version_check(Err(std::io::Error::other(
+                "failed to execute cargo-binstall",
+            )
+            .into())),
             binstall_version_check(Ok(success_output())),
             binstall_install_cargo_dylint(Ok(success_output())),
             binstall_install_dylint_link(Ok(failure_output("dylint-link failed"))),

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -125,18 +125,18 @@ fn ensure_dylint_tools_installs_missing_tools(
             result: Ok(failure_output("missing dylint-link")),
         },
         ExpectedCall {
-            cmd: "cargo",
-            args: vec!["binstall", "--version"],
+            cmd: "cargo-binstall",
+            args: vec!["--version"],
             result: Ok(success_output()),
         },
         ExpectedCall {
-            cmd: "cargo",
-            args: vec!["binstall", "-y", "cargo-dylint"],
+            cmd: "cargo-binstall",
+            args: vec!["-y", "cargo-dylint"],
             result: Ok(success_output()),
         },
         ExpectedCall {
-            cmd: "cargo",
-            args: vec!["binstall", "-y", "dylint-link"],
+            cmd: "cargo-binstall",
+            args: vec!["-y", "dylint-link"],
             result: Ok(success_output()),
         },
     ]);
@@ -178,13 +178,13 @@ fn ensure_dylint_tools_propagates_install_failures() {
             result: Ok(success_output()),
         },
         ExpectedCall {
-            cmd: "cargo",
-            args: vec!["binstall", "--version"],
+            cmd: "cargo-binstall",
+            args: vec!["--version"],
             result: Ok(success_output()),
         },
         ExpectedCall {
-            cmd: "cargo",
-            args: vec!["binstall", "-y", "cargo-dylint"],
+            cmd: "cargo-binstall",
+            args: vec!["-y", "cargo-dylint"],
             result: Ok(failure_output("install failed")),
         },
     ]);


### PR DESCRIPTION
## Summary
- Update installer to use cargo-binstall as the preferred backend for installing dependency crates, with fallbacks to cargo binstall subcommand or cargo install when cargo-binstall is not available.

## Changes
### Core functionality
- Introduced InstallBackend enum with variants: Binstall, BinstallSubcommand, Install
- Added install_backend(executor) to detect the best available backend:
  - cargo-binstall (preferred)
  - cargo binstall subcommand
  - cargo install as last resort
- Updated install_tool to dispatch installation to the selected backend:
  - Binstall => cargo-binstall -y <name>
  - BinstallSubcommand => cargo binstall -y <name>
  - Install => cargo install <name>
- Updated docs/comments to reflect the new backend selection and fallbacks

### Tests
- Updated tests to align with the new backend logic across:
  - installer/src/deps/tests.rs
  - installer/src/tests.rs
- Added test helpers for cargo-binstall version checks and install commands
- Added tests to cover:
  - cargo-binstall available: uses cargo-binstall for both tools
  - cargo-binstall missing but cargo binstall available: uses cargo binstall subcommand
  - neither available: falls back to cargo install
  - proper failure propagation for each backend (cargo-binstall, cargo binstall, cargo install)

## Test plan
- Run cargo test to ensure all tests pass:
  - Load scenarios where cargo-binstall is available, unavailable, or errors
  - Validate correct command sequences are called in each scenario
- Verify that failures are reported for the tool installation steps as expected

## Migration and compatibility
- This change preserves backward compatibility: if neither cargo-binstall nor the cargo binstall subcommand is available, installation falls back to cargo install
- Users with cargo-binstall installed will experience faster installs

## Notes
- The test suite now reflects the new preferred backend and its fallbacks
- No user-facing API changes outside of the installer behavior


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/ee0becce-b7fd-4375-86ce-07619b0b65a4

## Summary by Sourcery

Prefer cargo-binstall as the primary backend for installing Dylint tools, with automatic fallback to the cargo binstall subcommand or cargo install when necessary.

New Features:
- Introduce an InstallBackend enum to represent available installation backends for dependency crates.

Enhancements:
- Update Dylint tool installation to select the best available backend (cargo-binstall, cargo binstall subcommand, or cargo install) via a single detection function.
- Adjust installer behavior and documentation to reflect the new backend preference order and usage of cargo-binstall as the default where available.

Tests:
- Extend installer tests to cover cargo-binstall as the preferred backend, fallback to the cargo binstall subcommand, and final fallback to cargo install, including failure propagation for each path.
- Refactor test helpers to model cargo-binstall version checks and installation commands for both cargo-dylint and dylint-link.