### PR TITLE
Guard rolling-release restore when assets missing or release absent

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -294,14 +294,23 @@ jobs:
           # assets before attempting to download. The release may contain
           # only lint archives when dependency binaries have not yet been
           # published, e.g. during bootstrapping.
-          asset_names=$(gh release view rolling --json assets --jq '.assets[].name' 2>/dev/null) || {
-            echo "Rolling release does not exist yet; skipping restore."
-            exit 0
-          }
+          gh_err=$(mktemp)
+          if ! asset_names=$(gh release view rolling --json assets --jq '.assets[].name' 2>"$gh_err"); then
+            if grep -qi "release not found" "$gh_err"; then
+              echo "Rolling release does not exist yet; skipping restore."
+              rm -f "$gh_err"
+              exit 0
+            fi
+            echo "::error::gh release view failed:" >&2
+            cat "$gh_err" >&2
+            rm -f "$gh_err"
+            exit 1
+          fi
+          rm -f "$gh_err"
           has_dep_assets=false
           for name in $asset_names; do
             case "$name" in
-              *.tgz|*.zip|*.sha256) has_dep_assets=true; break ;;
+              *.tgz|*.zip) has_dep_assets=true; break ;;
             esac
           done
           if [[ "$has_dep_assets" == "false" ]]; then

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -290,7 +290,24 @@ jobs:
         run: |
           set -euxo pipefail
           mkdir -p dist
-          # Download dependency binaries from previous rolling release
+          # Check whether the rolling release has any dependency binary
+          # assets before attempting to download. The release may contain
+          # only lint archives when dependency binaries have not yet been
+          # published, e.g. during bootstrapping.
+          asset_names=$(gh release view rolling --json assets --jq '.assets[].name' 2>/dev/null) || {
+            echo "Rolling release does not exist yet; skipping restore."
+            exit 0
+          }
+          has_dep_assets=false
+          for name in $asset_names; do
+            case "$name" in
+              *.tgz|*.zip|*.sha256) has_dep_assets=true; break ;;
+            esac
+          done
+          if [[ "$has_dep_assets" == "false" ]]; then
+            echo "No dependency binary assets found on rolling release; skipping restore."
+            exit 0
+          fi
           gh release download rolling \
             --pattern '*.tgz' \
             --pattern '*.zip' \

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -307,21 +307,22 @@ jobs:
             exit 1
           fi
           rm -f "$gh_err"
-          has_dep_assets=false
-          for name in $asset_names; do
+          # Filter the asset list for dependency binary archives and their
+          # checksums using newline-safe iteration, then download each by
+          # exact name so the probe and download cannot diverge.
+          has_archives=false
+          download_args=()
+          while IFS= read -r name; do
             case "$name" in
-              *.tgz|*.zip) has_dep_assets=true; break ;;
+              *.tgz|*.zip) has_archives=true; download_args+=(--pattern "$name") ;;
+              *.sha256)                       download_args+=(--pattern "$name") ;;
             esac
-          done
-          if [[ "$has_dep_assets" == "false" ]]; then
+          done <<< "$asset_names"
+          if [[ "$has_archives" == "false" ]]; then
             echo "No dependency binary assets found on rolling release; skipping restore."
             exit 0
           fi
-          gh release download rolling \
-            --pattern '*.tgz' \
-            --pattern '*.zip' \
-            --pattern '*.sha256' \
-            --dir dist
+          gh release download rolling "${download_args[@]}" --dir dist
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -236,6 +236,12 @@ def test_restore_step_guards_against_missing_dependency_assets(
     assert "gh release download rolling" in run_script, (
         "restore step must still download assets when they are present"
     )
+    assert run_script.index("gh release view rolling") < run_script.index(
+        "gh release download rolling"
+    ), (
+        "restore step must probe the rolling release assets before attempting "
+        "to download them"
+    )
 
     # The guard must use an archive-specific predicate (.tgz/.zip) so that
     # checksum-only releases do not falsely trigger a download attempt.

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -204,6 +204,43 @@ def test_publish_job_runs_even_if_build_lints_fails(workflow_text: str) -> None:
     )
 
 
+def test_restore_step_guards_against_missing_dependency_assets(
+    workflow_text: str,
+) -> None:
+    """Ensure restore step checks for dependency assets before downloading.
+
+    The rolling release may contain only lint archives (no .tgz/.zip/.sha256
+    dependency binary assets) during bootstrapping or when dependency binaries
+    have not yet been published. The restore step must probe the release
+    assets and skip gracefully rather than failing on a no-match download.
+    """
+    workflow_mapping = _load_workflow_mapping(workflow_text)
+    jobs = _get_job_dict(workflow_mapping, "jobs")
+    publish_job = _get_job_dict(jobs, "publish")
+    restore_step = _find_step_by_name(
+        publish_job.get("steps"),
+        "Restore dependency archives from previous release",
+    )
+    assert restore_step is not None, (
+        "publish job must have a 'Restore dependency archives from previous "
+        "release' step"
+    )
+    run_script = restore_step.get("run", "")
+    assert isinstance(run_script, str), "restore step must have a run script"
+
+    assert "gh release view rolling" in run_script, (
+        "restore step must probe the rolling release assets before downloading"
+    )
+    assert "gh release download rolling" in run_script, (
+        "restore step must still download assets when they are present"
+    )
+    # The guard must exit 0 when no dependency assets are found rather than
+    # letting gh release download fail on a no-match pattern.
+    assert "exit 0" in run_script, (
+        "restore step must exit cleanly when no dependency assets are found"
+    )
+
+
 @pytest.mark.skipif(
     os.getenv("ACT_WORKFLOW_TESTS") != "1",
     reason="set ACT_WORKFLOW_TESTS=1 to run act workflow smoke tests",

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -243,13 +243,19 @@ def test_restore_step_guards_against_missing_dependency_assets(
         "to download them"
     )
 
-    # The guard must use an archive-specific predicate (.tgz/.zip) so that
-    # checksum-only releases do not falsely trigger a download attempt.
-    assert re.search(r"\*\.tgz", run_script), (
-        "restore step guard must check for .tgz archive extensions"
+    # The guard must use a case-based control flow to filter archives by
+    # extension, ensuring checksum-only releases do not falsely trigger
+    # a download attempt.
+    assert re.search(r"case\s+[\"']?\$", run_script), (
+        "restore step must use a case statement to filter asset names by "
+        "extension pattern"
     )
-    assert re.search(r"\*\.zip", run_script), (
-        "restore step guard must check for .zip archive extensions"
+    assert re.search(
+        r"\*\.tgz\s*\|\s*\*\.zip\s*\)",
+        run_script,
+    ), (
+        "restore step case guard must check for .tgz and .zip archive "
+        "extensions specifically"
     )
 
     # The guard must exit 0 when no dependency assets are found rather than
@@ -260,9 +266,14 @@ def test_restore_step_guards_against_missing_dependency_assets(
 
     # Only release-not-found errors are benign; auth/network/API failures
     # must propagate so incomplete releases are not silently published.
-    assert "release not found" in run_script.lower(), (
-        "restore step must specifically match the 'release not found' error "
-        "rather than swallowing all gh failures"
+    assert re.search(
+        r"grep\s+.*\s+[\"'](release not found|no releases? found|404)",
+        run_script,
+        re.IGNORECASE,
+    ), (
+        "restore step must use grep to specifically match missing-release "
+        "errors (release not found, no releases found, 404) rather than "
+        "swallowing all gh failures"
     )
     assert "exit 1" in run_script, (
         "restore step must fail on unexpected gh errors (auth, network, API)"

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -22,6 +22,7 @@ Run the `act` smoke test:
 from __future__ import annotations
 
 import os
+import re
 import shlex
 from collections.abc import Mapping
 from pathlib import Path
@@ -207,12 +208,13 @@ def test_publish_job_runs_even_if_build_lints_fails(workflow_text: str) -> None:
 def test_restore_step_guards_against_missing_dependency_assets(
     workflow_text: str,
 ) -> None:
-    """Ensure restore step checks for dependency assets before downloading.
+    """Ensure restore step checks for archive assets before downloading.
 
-    The rolling release may contain only lint archives (no .tgz/.zip/.sha256
-    dependency binary assets) during bootstrapping or when dependency binaries
-    have not yet been published. The restore step must probe the release
-    assets and skip gracefully rather than failing on a no-match download.
+    The rolling release may contain only lint archives (no .tgz/.zip
+    dependency binary assets) during bootstrapping or when dependency
+    binaries have not yet been published. The restore step must probe the
+    release assets, check specifically for archive file extensions, and
+    skip gracefully rather than failing on a no-match download.
     """
     workflow_mapping = _load_workflow_mapping(workflow_text)
     jobs = _get_job_dict(workflow_mapping, "jobs")
@@ -234,10 +236,30 @@ def test_restore_step_guards_against_missing_dependency_assets(
     assert "gh release download rolling" in run_script, (
         "restore step must still download assets when they are present"
     )
+
+    # The guard must use an archive-specific predicate (.tgz/.zip) so that
+    # checksum-only releases do not falsely trigger a download attempt.
+    assert re.search(r"\*\.tgz", run_script), (
+        "restore step guard must check for .tgz archive extensions"
+    )
+    assert re.search(r"\*\.zip", run_script), (
+        "restore step guard must check for .zip archive extensions"
+    )
+
     # The guard must exit 0 when no dependency assets are found rather than
     # letting gh release download fail on a no-match pattern.
     assert "exit 0" in run_script, (
         "restore step must exit cleanly when no dependency assets are found"
+    )
+
+    # Only release-not-found errors are benign; auth/network/API failures
+    # must propagate so incomplete releases are not silently published.
+    assert "release not found" in run_script.lower(), (
+        "restore step must specifically match the 'release not found' error "
+        "rather than swallowing all gh failures"
+    )
+    assert "exit 1" in run_script, (
+        "restore step must fail on unexpected gh errors (auth, network, API)"
     )
 
 


### PR DESCRIPTION
## Summary
- Adds a safety guard to the rolling-release restore step to skip downloading dependency archives if no assets exist on the rolling release (bootstrapping scenarios). Also handles the scenario where the rolling release does not exist yet.

## Changes
### CI Workflow
- .github/workflows/rolling-release.yml
  - Probes the rolling release for dependency assets before attempting to download
  - Uses gh release view to list assets; if the rolling release does not exist, prints a message and exits with code 0
  - If assets exist but none match *.tgz or *.zip, prints a message and exits with code 0
  - Keeps existing download logic for cases where assets are present

### Tests
- tests/workflows/test_rolling_release_workflow.py
  - Added test_restore_step_guards_against_missing_dependency_assets
  - Verifies the restore step includes:
    - gh release view rolling
    - gh release download rolling
    - exit 0 when no assets are found or the release does not exist
    - exit 1 on unexpected gh errors

### Rationale
- Prevents failures during bootstrapping when dependency binaries are not yet published by gracefully skipping the restore step when assets are absent or the release is not available
- The restore step now validates asset presence using archive extensions and will not attempt downloads unless *.tgz or *.zip assets are found

### How to test
- Run pytest for tests/workflows/test_rolling_release_workflow.py
- In CI, run the rolling-release workflow to verify behavior in asset-present, asset-missing, and release-missing scenarios

### Notes
- The guard relies on the gh CLI; ensure GH CLI is available in CI as part of the workflow runner (existing setup)

📎 **Task**: https://www.devboxer.com/task/9ff02fe4-6156-49a1-82c6-ab2041d48dcd