### PR TITLE
Add Verus/Kani proofs and ExecPlan for LSH invariants (7.2.4/7.2.5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ result_large_err = "deny"
 unknown_lints = "deny"
 renamed_and_removed_lints = "deny"
 missing_docs = "deny"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 
 [workspace.lints.rustdoc]
 missing_crate_level_docs = "deny"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie publish-check typecheck install-smoke package-lints workflow-test workflow-test-deps verus kani
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie publish-check typecheck install-smoke package-lints workflow-test workflow-test-deps verus kani verus-clone-detector kani kani-clone-detector
 
 APP ?= whitaker-installer
 CARGO ?= cargo
@@ -121,8 +121,14 @@ typecheck:
 verus: ## Run the pinned Verus proof sidecar
 	./scripts/run-verus.sh
 
-kani: ## Run the pinned Kani bounded model checker
+verus-clone-detector: ## Run clone-detector Verus proofs
+	./scripts/run-verus.sh clone-detector
+
+kani: ## Run practical Kani sidecar harnesses
 	./scripts/run-kani.sh
+
+kani-clone-detector: ## Run clone-detector Kani harnesses
+	./scripts/run-kani.sh clone-detector
 
 install-smoke: ## Install whitaker-installer and verify basic functionality
 	set -eu; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie publish-check typecheck install-smoke package-lints workflow-test workflow-test-deps verus kani verus-clone-detector kani kani-clone-detector
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie publish-check typecheck install-smoke package-lints workflow-test workflow-test-deps verus kani verus-clone-detector kani-clone-detector
 
 APP ?= whitaker-installer
 CARGO ?= cargo

--- a/crates/whitaker_clones_core/src/index/kani.rs
+++ b/crates/whitaker_clones_core/src/index/kani.rs
@@ -1,0 +1,87 @@
+//! Kani harnesses for bounded `LshConfig::new` verification.
+//!
+//! Run directly with:
+//!
+//! ```bash
+//! cargo kani --manifest-path crates/whitaker_clones_core/Cargo.toml \
+//!   --harness verify_lsh_config_new_symbolic
+//! ```
+//!
+//! Or through the repository wrapper:
+//!
+//! ```bash
+//! make kani-clone-detector
+//! ```
+
+use super::{IndexError, LshConfig, MINHASH_SIZE};
+
+#[kani::proof]
+#[kani::unwind(4)]
+fn verify_lsh_config_new_smoke() {
+    let config = match LshConfig::new(32, 4) {
+        Ok(config) => config,
+        Err(error) => panic!("expected valid LSH config, got {error:?}"),
+    };
+
+    kani::assert(config.bands() == 32, "smoke harness should keep band count");
+    kani::assert(config.rows() == 4, "smoke harness should keep row count");
+}
+
+#[kani::proof]
+#[kani::unwind(4)]
+fn verify_lsh_config_new_symbolic() {
+    let bands: usize = kani::any();
+    let rows: usize = kani::any();
+    kani::assume(bands <= MINHASH_SIZE);
+    kani::assume(rows <= MINHASH_SIZE);
+
+    match LshConfig::new(bands, rows) {
+        Ok(config) => {
+            kani::assert(bands > 0, "accepted configs must reject zero bands");
+            kani::assert(rows > 0, "accepted configs must reject zero rows");
+            kani::assert(
+                bands * rows == MINHASH_SIZE,
+                "accepted configs must match the fixed sketch width",
+            );
+            kani::assert(config.bands() == bands, "accepted config keeps band count");
+            kani::assert(config.rows() == rows, "accepted config keeps row count");
+        }
+        Err(IndexError::ZeroBands) => {
+            kani::assert(bands == 0, "ZeroBands must mean the input bands were zero");
+        }
+        Err(IndexError::ZeroRows) => {
+            kani::assert(
+                bands != 0,
+                "ZeroRows occurs only after non-zero bands validate",
+            );
+            kani::assert(rows == 0, "ZeroRows must mean the input rows were zero");
+        }
+        Err(IndexError::InvalidBandRowProduct {
+            bands: actual_bands,
+            rows: actual_rows,
+            expected,
+        }) => {
+            kani::assert(actual_bands == bands, "error should report the input bands");
+            kani::assert(actual_rows == rows, "error should report the input rows");
+            kani::assert(
+                expected == MINHASH_SIZE,
+                "error should report the fixed MinHash size",
+            );
+            kani::assert(
+                bands > 0,
+                "invalid product errors are only possible after zero-band validation",
+            );
+            kani::assert(
+                rows > 0,
+                "invalid product errors are only possible after zero-row validation",
+            );
+            kani::assert(
+                bands.checked_mul(rows) != Some(MINHASH_SIZE),
+                "invalid product errors require a non-matching product",
+            );
+        }
+        Err(IndexError::EmptyFingerprintSet) => {
+            kani::assert(false, "LshConfig::new must not produce fingerprint errors");
+        }
+    }
+}

--- a/crates/whitaker_clones_core/src/index/kani.rs
+++ b/crates/whitaker_clones_core/src/index/kani.rs
@@ -12,6 +12,15 @@
 //! ```bash
 //! make kani-clone-detector
 //! ```
+//!
+//! The harness set deliberately splits bounded semantic coverage from overflow
+//! coverage:
+//!
+//! - `verify_lsh_config_new_smoke` checks one accepted concrete path.
+//! - `verify_lsh_config_new_symbolic` exhausts the constructor across the
+//!   bounded `[0, 128]²` input space.
+//! - `verify_lsh_config_new_overflow_product` drives the `checked_mul(None)`
+//!   branch with non-zero overflowing inputs.
 
 use super::{IndexError, LshConfig, MINHASH_SIZE};
 
@@ -78,6 +87,50 @@ fn verify_lsh_config_new_symbolic() {
             kani::assert(
                 bands.checked_mul(rows) != Some(MINHASH_SIZE),
                 "invalid product errors require a non-matching product",
+            );
+        }
+        Err(IndexError::EmptyFingerprintSet) => {
+            kani::assert(false, "LshConfig::new must not produce fingerprint errors");
+        }
+    }
+}
+
+#[kani::proof]
+#[kani::unwind(4)]
+fn verify_lsh_config_new_overflow_product() {
+    let bands: usize = kani::any();
+    let rows = 2usize;
+    kani::assume(bands > 0);
+    kani::assume(bands > usize::MAX / rows);
+    kani::assert(
+        bands.checked_mul(rows).is_none(),
+        "overflow harness must drive the checked_mul(None) branch",
+    );
+
+    match LshConfig::new(bands, rows) {
+        Ok(_) => {
+            kani::assert(false, "overflowing products must be rejected");
+        }
+        Err(IndexError::ZeroBands) => {
+            kani::assert(false, "overflow harness assumes non-zero bands");
+        }
+        Err(IndexError::ZeroRows) => {
+            kani::assert(false, "overflow harness assumes non-zero rows");
+        }
+        Err(IndexError::InvalidBandRowProduct {
+            bands: actual_bands,
+            rows: actual_rows,
+            expected,
+        }) => {
+            kani::assert(actual_bands == bands, "error should report the input bands");
+            kani::assert(actual_rows == rows, "error should report the input rows");
+            kani::assert(
+                expected == MINHASH_SIZE,
+                "error should report the fixed MinHash size",
+            );
+            kani::assert(
+                bands.checked_mul(rows).is_none(),
+                "overflow harness must keep the overflowing product precondition",
             );
         }
         Err(IndexError::EmptyFingerprintSet) => {

--- a/crates/whitaker_clones_core/src/index/mod.rs
+++ b/crates/whitaker_clones_core/src/index/mod.rs
@@ -1,6 +1,8 @@
 //! MinHash and LSH indexing for token-pass candidate generation.
 
 mod error;
+#[cfg(kani)]
+mod kani;
 mod lsh;
 mod minhash;
 mod types;

--- a/crates/whitaker_clones_core/src/index/tests.rs
+++ b/crates/whitaker_clones_core/src/index/tests.rs
@@ -69,6 +69,8 @@ fn fragment_ids() -> FragmentIds {
 #[case(((0, 4), IndexError::ZeroBands))]
 #[case(((4, 0), IndexError::ZeroRows))]
 #[case(((8, 8), IndexError::invalid_band_row_product(8, 8)))]
+#[case(((3, 42), IndexError::invalid_band_row_product(3, 42)))]
+#[case(((usize::MAX, 2), IndexError::invalid_band_row_product(usize::MAX, 2)))]
 fn config_rejects_invalid_inputs(#[case] case: ((usize, usize), IndexError)) {
     let ((bands, rows), expected) = case;
 
@@ -79,6 +81,7 @@ fn config_rejects_invalid_inputs(#[case] case: ((usize, usize), IndexError)) {
 #[case((1, MINHASH_SIZE))]
 #[case((2, MINHASH_SIZE / 2))]
 #[case((4, MINHASH_SIZE / 4))]
+#[case((32, 4))]
 fn config_accepts_valid_inputs(#[case] case: (usize, usize)) {
     let (bands, rows) = case;
 

--- a/crates/whitaker_clones_core/tests/features/min_hash_lsh.feature
+++ b/crates/whitaker_clones_core/tests/features/min_hash_lsh.feature
@@ -35,3 +35,13 @@ Feature: MinHash and LSH candidate generation
     And fragment empty retains no hashes
     When candidate pairs are generated
     Then the candidate generation error is EmptyFingerprintSet
+
+  Scenario: Zero LSH rows surface a typed error
+    Given LSH bands 4 and rows 0
+    When candidate pairs are generated
+    Then the candidate generation error is ZeroRows
+
+  Scenario: Non-zero invalid LSH products are rejected explicitly
+    Given LSH bands 3 and rows 42
+    When candidate pairs are generated
+    Then the candidate generation error is InvalidBandRowProduct(3,42)

--- a/crates/whitaker_clones_core/tests/min_hash_lsh_behaviour.rs
+++ b/crates/whitaker_clones_core/tests/min_hash_lsh_behaviour.rs
@@ -43,11 +43,28 @@ fn parse_hashes(hashes: &str) -> Result<Vec<Fingerprint>, String> {
 }
 
 fn expected_error(name: &str) -> Result<IndexError, String> {
+    if let Some(arguments) = name
+        .strip_prefix("InvalidBandRowProduct(")
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        let Some((bands, rows)) = arguments.split_once(',') else {
+            return Err(format!(
+                "invalid InvalidBandRowProduct arguments `{arguments}`"
+            ));
+        };
+        let bands = bands
+            .parse::<usize>()
+            .map_err(|error| format!("invalid bands value `{bands}`: {error}"))?;
+        let rows = rows
+            .parse::<usize>()
+            .map_err(|error| format!("invalid rows value `{rows}`: {error}"))?;
+        return Ok(IndexError::invalid_band_row_product(bands, rows));
+    }
+
     match name {
         "ZeroBands" => Ok(IndexError::ZeroBands),
         "ZeroRows" => Ok(IndexError::ZeroRows),
         "EmptyFingerprintSet" => Ok(IndexError::EmptyFingerprintSet),
-        "InvalidBandRowProduct" => Ok(IndexError::invalid_band_row_product(0, 0)),
         other => Err(format!("unknown error name `{other}`")),
     }
 }
@@ -168,5 +185,15 @@ fn scenario_invalid_lsh_settings(world: MinHashLshWorld) {
 
 #[scenario(path = "tests/features/min_hash_lsh.feature", index = 4)]
 fn scenario_empty_fingerprints(world: MinHashLshWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/min_hash_lsh.feature", index = 5)]
+fn scenario_zero_rows(world: MinHashLshWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/min_hash_lsh.feature", index = 6)]
+fn scenario_invalid_non_zero_product(world: MinHashLshWorld) {
     let _ = world;
 }

--- a/crates/whitaker_clones_core/tests/min_hash_lsh_behaviour.rs
+++ b/crates/whitaker_clones_core/tests/min_hash_lsh_behaviour.rs
@@ -53,9 +53,11 @@ fn expected_error(name: &str) -> Result<IndexError, String> {
             ));
         };
         let bands = bands
+            .trim()
             .parse::<usize>()
             .map_err(|error| format!("invalid bands value `{bands}`: {error}"))?;
         let rows = rows
+            .trim()
             .parse::<usize>()
             .map_err(|error| format!("invalid rows value `{rows}`: {error}"))?;
         return Ok(IndexError::invalid_band_row_product(bands, rows));

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -400,8 +400,8 @@ Local workflow tests use the Makefile variables `UV` and `WORKFLOW_TEST_VENV`:
   `.venv`.
 
 Use `make workflow-test-deps` to create or refresh that environment, and
-`make workflow-test` to run the opt-in `act` plus `pytest` workflow smoke
-tests against it.
+`make workflow-test` to run the opt-in `act` plus `pytest` workflow smoke tests
+against it.
 
 ### Worked example: adding another packaging binary
 
@@ -426,8 +426,8 @@ path = "src/bin/package_example.rs"
 
 If the workflow should invoke that helper, add an assertion to
 `test_installer_packaging_bins_match_release_workflow_contract` before relying
-on it in release automation. That keeps the breakage in unit-style Python
-tests instead of the rolling-release pipeline.
+on it in release automation. That keeps the breakage in unit-style Python tests
+instead of the rolling-release pipeline.
 
 ## Dependency binary packaging
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -106,48 +106,83 @@ make check-fmt  # Verify formatting
 make fmt        # Apply formatting
 ```
 
+## Proof workflows
+
+Whitaker now ships repository-managed proof tooling for the formal verification
+work introduced around decomposition advice and the clone-detector pipeline.
+Run these commands from the workspace root.
+
+### Make targets
+
+Use the Makefile targets for normal proof runs:
+
+```sh
+make verus                 # Run all Verus proof files
+make verus-clone-detector  # Run clone-detector Verus proofs only
+make kani                  # Run all Kani harness groups
+make kani-clone-detector   # Run clone-detector Kani harnesses only
+```
+
+`make verus` currently runs both decomposition-advice proofs and the
+clone-detector `LshConfig::new` proof. `make kani` runs the decomposition
+adjacency harnesses and the clone-detector harness group in one pass.
+
+### Tooling scripts
+
+The proof targets are thin wrappers over repository scripts:
+
+- `scripts/install-verus.sh` downloads the pinned Verus release into
+  `${XDG_CACHE_HOME:-$HOME/.cache}/whitaker/verus`, makes the binaries
+  executable, and installs the Rust toolchain that Verus requests.
+- `scripts/run-verus.sh` selects proof groups and executes each `.rs` proof
+  file in turn.
+- `scripts/install-kani.sh` downloads the pinned pre-built Kani release into
+  `${XDG_CACHE_HOME:-$HOME/.cache}/whitaker/kani`, installs the matching
+  nightly Rust toolchain via `rustup`, and symlinks that toolchain into the
+  Kani directory structure.
+- `scripts/run-kani.sh` sets the Kani-specific environment, runs the
+  decomposition/common harnesses through the existing workflow, and runs the
+  clone-detector harnesses one harness per `cargo-kani` invocation so each
+  proof appears explicitly in the output.
+
+The installer scripts are idempotent. The first proof run may take longer while
+toolchains and verifier binaries are downloaded; later runs reuse the cached
+install.
+
+The installer scripts are idempotent. The first proof run may take longer while
+toolchains and verifier binaries are downloaded; later runs reuse the cached
+installation.
+
+### Examples
+
+Run the narrow clone-detector proof workflow during iteration:
+
+```sh
+make verus-clone-detector
+make kani-clone-detector
+```
+
+Run a Verus group directly through the wrapper:
+
+```sh
+./scripts/run-verus.sh clone-detector
+./scripts/run-verus.sh all --time
+```
+
+Run a specific decomposition Kani harness or the clone-detector group
+directly:
+
+```sh
+./scripts/run-kani.sh verify_build_adjacency_preserves_edges
+./scripts/run-kani.sh clone-detector
+```
+
 ## Kani bounded model checking
 
 Whitaker uses the [Kani model checker](https://model-checking.github.io/kani/)
 to verify critical algorithms with bounded symbolic verification. Kani proofs
 complement traditional testing by exhaustively checking properties over all
 possible inputs within configured bounds.
-
-### Running Kani verifications
-
-Run all Kani harnesses from the workspace root:
-
-```sh
-make kani
-```
-
-This invokes `scripts/run-kani.sh`, which:
-
-1. Installs or reuses the pinned Kani toolchain via `scripts/install-kani.sh`
-2. Sets up the required environment (library paths, toolchain selection)
-3. Runs all Kani proof harnesses in the `common` crate
-
-To run a specific harness:
-
-```sh
-./scripts/run-kani.sh verify_build_adjacency_preserves_edges
-```
-
-### Kani tooling architecture
-
-The Kani workflow mirrors the existing Verus pattern:
-
-- **`scripts/install-kani.sh`**: Pins Kani 0.67.0 and downloads the pre-built
-  tarball into `${XDG_CACHE_HOME:-$HOME/.cache}/whitaker/kani`. The script
-  installs the matching nightly Rust toolchain via `rustup` and symlinks it
-  into the Kani directory structure.
-
-- **`scripts/run-kani.sh`**: Invokes the pinned `cargo-kani` binary with the
-  correct environment. Sets `RUSTUP_TOOLCHAIN` to ensure Cargo uses the
-  Kani-pinned toolchain, and configures platform-specific library paths
-  (`DYLD_LIBRARY_PATH` on macOS, `LD_LIBRARY_PATH` on Linux).
-
-- **`make kani`**: Top-level quality gate that runs all harnesses by default.
 
 ### Writing Kani harnesses
 
@@ -182,15 +217,11 @@ Key principles:
 - **Bounded symbolic inputs**: Use fixed-size arrays or bounded ranges to keep
   the state space tractable. Rust's standard `sort_by` and nested loops can
   cause CBMC (C Bounded Model Checker) state-space explosion at higher bounds.
-
 - **Input contracts**: Use `kani::assume` to constrain symbolic inputs to match
   the preconditions that production code guarantees. Model the actual input
   contract, not arbitrary malformed inputs.
-
 - **One property per harness**: Separate harnesses simplify root-cause analysis
-  when a property fails. Six focused harnesses are clearer than one combined
-  check.
-
+  when a property fails. Focused harnesses are clearer than one combined check.
 - **Crate visibility**: Kani harnesses can call `pub(crate)` functions directly,
   avoiding the need to widen the public API for verification purposes.
 
@@ -208,8 +239,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 
 This tells `rustc` that `kani` is an expected configuration name, so normal
 `cargo check` and `cargo clippy` runs do not emit spurious warnings. The entry
-lives in `common/Cargo.toml` because the Kani harnesses currently reside in the
-`common` crate.
+lives in `common/Cargo.toml` for the decomposition harnesses and in
+`crates/whitaker_clones_core/Cargo.toml` for the clone-detector harnesses.
 
 Kani harnesses verify private helpers that are not part of the public API.
 Rather than making these helpers fully public, the following items are promoted
@@ -219,13 +250,11 @@ to `pub(crate)` visibility:
   from `mod community` to `pub(crate) mod community` so that
   `test_support::decomposition` helpers and unit tests can import
   `SimilarityEdge` and `build_adjacency`.
-
 - **`build_adjacency` function**
   (`common/src/decomposition_advice/community.rs`): Promoted from `fn` to
   `pub(crate) fn` so that colocated Kani harnesses and the test-support
   adjacency report can call it directly without widening the crate's public API
   surface.
-
 - **`SimilarityEdge::new(left, right, weight)`**
   (`common/src/decomposition_advice/community.rs`): A `pub(crate)` constructor
   added to allow Kani harnesses and test-support modules to create edge values
@@ -248,14 +277,12 @@ for integration and behaviour-driven tests:
   `build_adjacency`, and returns `Result<AdjacencyReport, AdjacencyError>`.
   Callers can `match` on the result, `.expect(...)` in tests, or propagate the
   error upward when invalid declarative input should fail the caller.
-
 - **`AdjacencyError`**: Typed validation failure for the `Err` branch. The
   shipped variants are `NonCanonicalEdge { index, left, right }` when
   `left >= right`, `EndpointOutOfRange { index, right, node_count }` when an
   endpoint exceeds the graph size, and `ZeroWeight { index }` when a weight is
   non-positive for the production contract. Callers should inspect these
   variants when they need to assert a specific rejection path.
-
 - **`AdjacencyReport`**: Wrapper around adjacency vectors on the `Ok` branch,
   with methods for testing properties:
   - `is_symmetric()`: Checks that all edges appear in both directions
@@ -263,7 +290,6 @@ for integration and behaviour-driven tests:
   - `is_sorted()`: Confirms neighbours are sorted by index
   - `neighbours_of(node)`: Returns neighbours of a node (or `None` if
     out-of-bounds)
-
 - **`EdgeInput`**: Declarative edge struct with `left`, `right`, `weight`
   fields, passed to `adjacency_report` and interpreted on the `Ok` branch as
   canonical-order, in-range, positive-weight edge input for behaviour-driven
@@ -275,7 +301,7 @@ providing a clean testing interface.
 
 See
 [`docs/execplans/6-4-5-use-kani-to-verify-build-adjacency-preserves-similarity-edges.md`](./execplans/6-4-5-use-kani-to-verify-build-adjacency-preserves-similarity-edges.md)
- for the complete design rationale and implementation decisions.
+for the complete design rationale and implementation decisions.
 
 ## Installer release helper binaries
 
@@ -347,14 +373,14 @@ formatting changes in the workflow YAML.
 
 Local workflow tests use the Makefile variables `UV` and `WORKFLOW_TEST_VENV`:
 
-- `UV` selects the `uv` executable used to create and populate the workflow-test
-  virtual environment.
+- `UV` selects the `uv` executable used to create and populate the
+  workflow-test virtual environment.
 - `WORKFLOW_TEST_VENV` selects the virtual-environment path, defaulting to
   `.venv`.
 
 Use `make workflow-test-deps` to create or refresh that environment, and
-`make workflow-test` to run the opt-in `act` plus `pytest` workflow smoke tests
-against it.
+`make workflow-test` to run the opt-in `act` plus `pytest` workflow smoke
+tests against it.
 
 ### Worked example: adding another packaging binary
 
@@ -379,8 +405,8 @@ path = "src/bin/package_example.rs"
 
 If the workflow should invoke that helper, add an assertion to
 `test_installer_packaging_bins_match_release_workflow_contract` before relying
-on it in release automation. That keeps the breakage in unit-style Python tests
-instead of the rolling-release pipeline.
+on it in release automation. That keeps the breakage in unit-style Python
+tests instead of the rolling-release pipeline.
 
 ## Dependency binary packaging
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -127,6 +127,29 @@ make kani-clone-detector   # Run clone-detector Kani harnesses only
 clone-detector `LshConfig::new` proof. `make kani` runs the decomposition
 adjacency harnesses and the clone-detector harness group in one pass.
 
+### Verus scope and trust boundary
+
+The clone-detector Verus file is intentionally an implementation-shaped model
+of `LshConfig::new` and `validate_product`, not a direct proof of the compiled
+Rust body in `crates/whitaker_clones_core`.
+
+This distinction matters. In the current sidecar setup, Verus can describe the
+contract of an external Rust function with mechanisms such as
+`assume_specification`, `external_fn_specification`, or `external_body`, but
+those routes add trusted assumptions rather than proving the production
+implementation itself. The repository therefore keeps the Verus proof honest:
+it mirrors the real branch order and `checked_mul` overflow behaviour, while
+Kani calls the actual constructor and checks its runtime behaviour directly.
+
+For `LshConfig::new`, the split is:
+
+- Verus proves the constructor model rejects zero bands, rejects zero rows,
+  accepts only exact products of `MINHASH_SIZE`, and rejects overflowing
+  products via the same `checked_mul` semantics as the runtime code.
+- Kani executes the real constructor with one concrete acceptance harness, one
+  bounded symbolic harness over `[0, 128]²`, and one overflow harness that
+  forces the `checked_mul(None)` branch.
+
 ### Tooling scripts
 
 The proof targets are thin wrappers over repository scripts:
@@ -143,11 +166,8 @@ The proof targets are thin wrappers over repository scripts:
 - `scripts/run-kani.sh` sets the Kani-specific environment, runs the
   decomposition/common harnesses through the existing workflow, and runs the
   clone-detector harnesses one harness per `cargo-kani` invocation so each
-  proof appears explicitly in the output.
-
-The installer scripts are idempotent. The first proof run may take longer while
-toolchains and verifier binaries are downloaded; later runs reuse the cached
-install.
+  proof appears explicitly in the output, including the overflow-specific
+  harness for `LshConfig::new`.
 
 The installer scripts are idempotent. The first proof run may take longer while
 toolchains and verifier binaries are downloaded; later runs reuse the cached
@@ -169,10 +189,11 @@ Run a Verus group directly through the wrapper:
 ./scripts/run-verus.sh all --time
 ```
 
-Run a specific decomposition Kani harness or the clone-detector group
-directly:
+Run all Kani groups, a specific decomposition harness, or the clone-detector
+group directly:
 
 ```sh
+./scripts/run-kani.sh
 ./scripts/run-kani.sh verify_build_adjacency_preserves_edges
 ./scripts/run-kani.sh clone-detector
 ```

--- a/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
+++ b/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
@@ -4,10 +4,7 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT (awaiting approval)
-
-Approval gate: this plan must be approved before implementation begins. Do not
-start Stage B until the user explicitly approves this document.
+Status: IN PROGRESS
 
 This document must be maintained in accordance with `AGENTS.md`.
 
@@ -147,20 +144,22 @@ Observable outcome:
 
 - [x] Stage A: Gather repository context and draft this ExecPlan
   (2026-04-08).
-- [ ] Stage B: Add clone-detector proof sidecar tooling and `Makefile`
-  targets.
-- [ ] Stage C: Add or extend failing unit tests for `LshConfig::new` happy,
-  unhappy, and edge cases.
-- [ ] Stage D: Extend `rstest-bdd` coverage for `LshConfig` configuration
-  outcomes.
-- [ ] Stage E: Add the Verus proof for `LshConfig::new` invariants.
-- [ ] Stage F: Add the minimal Kani smoke harness needed to make the
-  clone-detector Kani target observable.
-- [ ] Stage G: Update the clone-detector design document and mark roadmap
-  items 7.2.4 and 7.2.5 done.
-- [ ] Stage H: Run documentation, proof, lint, and test gates successfully.
-- [ ] Stage I: Finalize the living sections in this ExecPlan after the
-  implementation turn.
+- [x] Stage B: Add clone-detector proof sidecar tooling and `Makefile`
+  targets (2026-04-09).
+- [x] Stage C: Add or extend failing unit tests for `LshConfig::new` happy,
+  unhappy, and edge cases (2026-04-09).
+- [x] Stage D: Extend `rstest-bdd` coverage for `LshConfig` configuration
+  outcomes (2026-04-09).
+- [x] Stage E: Add the Verus proof for `LshConfig::new` invariants
+  (2026-04-09).
+- [x] Stage F: Add the minimal Kani smoke harness needed to make the
+  clone-detector Kani target observable (2026-04-09).
+- [x] Stage G: Update the clone-detector design document and mark roadmap
+  items 7.2.4 and 7.2.5 done (2026-04-09).
+- [x] Stage H: Run documentation, proof, lint, and test gates successfully
+  (2026-04-09).
+- [x] Stage I: Finalize the living sections in this ExecPlan after the
+  implementation turn (2026-04-09).
 
 ## Surprises & Discoveries
 
@@ -193,6 +192,16 @@ Observable outcome:
   local Kani target from heavier exhaustive runs, and use documented
   `kani::assume` guards plus explicit unwind limits to keep solver work
   tractable.
+- `leta` was not stable in this workspace during this turn.
+  `Connection reset by peer` / `EOF while parsing a value` appeared, so the
+  implementation used direct file inspection instead of semantic navigation.
+- `cargo search kani-verifier` resolved `kani-verifier = "0.67.0"` during the
+  implementation turn, and the sidecar installer now pins that release unless
+  the environment overrides it explicitly.
+- The shared Verus installer needed one extra hardening step during validation:
+  Verus printed an ANSI-coloured `rustup install 1.94.0-x86_64-unknown-linux-gnu`
+  hint, so `scripts/install-verus.sh` had to strip ANSI escape codes before
+  extracting the fallback toolchain suggestion.
 
 ## Decision Log
 
@@ -219,6 +228,11 @@ Observable outcome:
   Kani target should be a practical local smoke gate with small bounds; any
   heavier `kani-full` style target should remain a future extension once 7.2.7
   and 7.2.8 add broader bounded checks. Date/Author: 2026-04-08 / Codex.
+- Decision: fix the shared Verus installer while implementing the clone-detector
+  proof workflow. Rationale: `make verus-clone-detector` and `make verus`
+  both depend on the same parser, so the ANSI-coloured toolchain hint had to
+  be normalized centrally rather than papered over in the new target.
+  Date/Author: 2026-04-09 / Codex.
 
 ## Context and orientation
 
@@ -566,8 +580,18 @@ all of the following from a fresh checkout after reading this ExecPlan:
 
 ## Outcomes & Retrospective
 
-This section is intentionally blank during the draft phase. At the end of the
-implementation turn, replace this paragraph with a concise retrospective that
-records what shipped, what changed from the draft, which tolerances were hit,
-which commands proved success, and any follow-on work that should be tracked in
-later roadmap items.
+Implemented the 7.2.4 and 7.2.5 scope as planned: the repository now has
+clone-detector-specific Verus and Kani sidecar targets, a new Verus proof for
+`LshConfig::new`, a bounded Kani harness module adjacent to the index code, and
+expanded unit plus `rstest-bdd` coverage for zero rows, invalid non-zero
+products, and overflow rejection. The only material change from the draft was a
+small shared-tooling fix in `scripts/install-verus.sh` after validation exposed
+ANSI escape codes in Verus's toolchain suggestion output.
+
+No tolerance gates were hit. Validation succeeded with:
+`make fmt`, `make markdownlint`, `make nixie`,
+`make verus-clone-detector`, `make kani-clone-detector`,
+`make check-fmt`, `make lint`, `make test`, `make verus`, and `make kani`.
+Later roadmap items 7.2.6, 7.2.7, and 7.2.8 remain intentionally untouched;
+the new proof sidecars and harness location are the intended base for that
+future work.

--- a/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
+++ b/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
@@ -203,6 +203,15 @@ Observable outcome:
   `rustup install 1.94.0-x86_64-unknown-linux-gnu` hint, so
   `scripts/install-verus.sh` had to strip ANSI escape codes before extracting
   the fallback toolchain suggestion.
+- A later proof review found that the first Verus file was too tautological to
+  count as implementation-shaped reasoning, and that the first Kani symbolic
+  harness did not cover the `checked_mul(None)` overflow path. The follow-up
+  change tightened the Verus model to mirror the constructor's real branch
+  order and added a dedicated overflow Kani harness.
+- In this repository shape, Verus cannot directly prove the compiled
+  `crates/whitaker_clones_core` implementation without trusted assumptions for
+  external code. That limitation needs to stay documented in the developer
+  guide rather than implied.
 
 ## Decision Log
 
@@ -234,6 +243,19 @@ Observable outcome:
   depend on the same parser, so the ANSI-coloured toolchain hint had to be
   normalized centrally rather than papered over in the new target. Date/Author:
   2026-04-09 / Codex.
+- Decision: keep the Verus artefact as a faithful branch-by-branch model of
+  `LshConfig::new` rather than adding trusted external-code assumptions.
+  Rationale: `assume_specification`, `external_fn_specification`, or
+  `external_body` would only document or trust the production function, not
+  prove it. The follow-up proof therefore mirrors the real constructor logic,
+  while Kani remains the implementation-executing proof. Date/Author:
+  2026-04-11 / Codex.
+- Decision: extend the Kani harness set with an overflow-specific proof for the
+  `checked_mul(None)` path. Rationale: the bounded `[0, 128]²` harness is still
+  useful for exhaustive local reasoning, but it cannot witness arithmetic
+  overflow by construction. A separate symbolic harness closes that coverage
+  gap without blowing up the state space of the bounded harness. Date/Author:
+  2026-04-11 / Codex.
 
 ## Context and orientation
 

--- a/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
+++ b/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
@@ -19,10 +19,10 @@ clone-detector constructor invariant: `LshConfig::new` must reject zero
 This work matters because roadmap item 7.2.2 already made `LshConfig` a hard
 runtime boundary for MinHash and locality-sensitive hashing (LSH). If that
 boundary drifts, every later proof and every later token-pass candidate check
-inherits the bug. ADR 002 explicitly assigns this constructor to Verus and
-reserves Kani for bounded behavioural checks over the same clone-detector
-crate, so 7.2.4 and 7.2.5 establish the proof split that later items 7.2.6,
-7.2.7, and 7.2.8 build on.
+inherits the bug. Architecture Decision Record (ADR) 002 explicitly assigns
+this constructor to Verus and reserves Kani for bounded behavioural checks over
+the same clone-detector crate, so 7.2.4 and 7.2.5 establish the proof split
+that later items 7.2.6, 7.2.7, and 7.2.8 build on.
 
 Observable outcome:
 
@@ -179,10 +179,10 @@ Observable outcome:
   `crates/whitaker_clones_core/tests/features/min_hash_lsh.feature` already
   exercises zero bands. The implementation should extend these tests rather
   than replace them.
-- `Makefile` currently exposes only a global `verus` target. If we want fast
-  clone-detector-only iteration without regressing the existing proof workflow,
-  the cleanest approach is to add clone-detector-specific targets alongside the
-  current umbrella target.
+- `Makefile` currently exposes only a global `verus` target. If fast
+  clone-detector-only iteration is desired without regressing the existing
+  proof workflow, the cleanest approach is to add clone-detector-specific
+  targets alongside the current umbrella target.
 - The workspace root pins `rstest-bdd = "0.5.0"`, matching the user's
   requirement, so the plan must keep that exact version in view even though
   some repository comments elsewhere still mention older text.
@@ -199,9 +199,10 @@ Observable outcome:
   implementation turn, and the sidecar installer now pins that release unless
   the environment overrides it explicitly.
 - The shared Verus installer needed one extra hardening step during validation:
-  Verus printed an ANSI-coloured `rustup install 1.94.0-x86_64-unknown-linux-gnu`
-  hint, so `scripts/install-verus.sh` had to strip ANSI escape codes before
-  extracting the fallback toolchain suggestion.
+  Verus printed an ANSI-coloured
+  `rustup install 1.94.0-x86_64-unknown-linux-gnu` hint, so
+  `scripts/install-verus.sh` had to strip ANSI escape codes before extracting
+  the fallback toolchain suggestion.
 
 ## Decision Log
 
@@ -229,10 +230,10 @@ Observable outcome:
   heavier `kani-full` style target should remain a future extension once 7.2.7
   and 7.2.8 add broader bounded checks. Date/Author: 2026-04-08 / Codex.
 - Decision: fix the shared Verus installer while implementing the clone-detector
-  proof workflow. Rationale: `make verus-clone-detector` and `make verus`
-  both depend on the same parser, so the ANSI-coloured toolchain hint had to
-  be normalized centrally rather than papered over in the new target.
-  Date/Author: 2026-04-09 / Codex.
+  proof workflow. Rationale: `make verus-clone-detector` and `make verus` both
+  depend on the same parser, so the ANSI-coloured toolchain hint had to be
+  normalized centrally rather than papered over in the new target. Date/Author:
+  2026-04-09 / Codex.
 
 ## Context and orientation
 
@@ -308,7 +309,7 @@ turn self-contained:
 - `docs/complexity-antipatterns-and-refactoring-strategies.md` for keeping
   helpers small and cohesive.
 - `docs/whitaker-dylint-suite-design.md` for repository-wide lint and
-  `unexpected_cfgs` considerations when introducing specialised build modes.
+  `unexpected_cfgs` considerations when introducing specialized build modes.
 
 ### Relevant learnings from `leynos/chutoro`
 
@@ -318,7 +319,7 @@ The most relevant implementation lessons are:
 1. Put Kani harnesses next to the internal modules they exercise so they can
    use `pub(crate)` seams instead of widening the public API.
 2. Keep harnesses behind `#[cfg(kani)]`, and explicitly allow that cfg in the
-   crate's `unexpected_cfgs` check list.
+   crate's `unexpected_cfgs` checklist.
 3. Keep the everyday Kani target small and practical. Chutoro's `make kani`
    runs only smoke-sized harnesses, while heavier exhaustive runs are reserved
    for `make kani-full`.
@@ -588,10 +589,9 @@ products, and overflow rejection. The only material change from the draft was a
 small shared-tooling fix in `scripts/install-verus.sh` after validation exposed
 ANSI escape codes in Verus's toolchain suggestion output.
 
-No tolerance gates were hit. Validation succeeded with:
-`make fmt`, `make markdownlint`, `make nixie`,
-`make verus-clone-detector`, `make kani-clone-detector`,
-`make check-fmt`, `make lint`, `make test`, `make verus`, and `make kani`.
-Later roadmap items 7.2.6, 7.2.7, and 7.2.8 remain intentionally untouched;
-the new proof sidecars and harness location are the intended base for that
-future work.
+No tolerance gates were hit. Validation succeeded with: `make fmt`,
+`make markdownlint`, `make nixie`, `make verus-clone-detector`,
+`make kani-clone-detector`, `make check-fmt`, `make lint`, `make test`,
+`make verus`, and `make kani`. Later roadmap items 7.2.6, 7.2.7, and 7.2.8
+remain intentionally untouched; the new proof sidecars and harness location are
+the intended base for that future work.

--- a/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
+++ b/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
@@ -4,7 +4,7 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: IN PROGRESS
+Status: COMPLETED
 
 This document must be maintained in accordance with `AGENTS.md`.
 

--- a/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
+++ b/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
@@ -212,7 +212,7 @@ Observable outcome:
   2026-04-08 / Codex.
 - Decision: keep proof workflows opt-in through `Makefile` targets and wrapper
   scripts, not through normal `cargo test` or build hooks. Rationale: ADR 002
-  explicitly requires sidecar proof tooling independent from ordinary Cargo
+  explicitly requires sidecar proof tooling independent of ordinary Cargo
   development. Date/Author: 2026-04-08 / Codex.
 - Decision: extend the existing `min_hash_lsh` unit and BDD coverage instead
   of creating a second test harness just for `LshConfig`. Rationale: the

--- a/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
+++ b/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
@@ -1,0 +1,509 @@
+# Add clone-detector proof sidecars and prove `LshConfig::new` invariants (roadmap 7.2.4 and 7.2.5)
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT (awaiting approval)
+
+Approval gate: this plan must be approved before implementation begins. Do not
+start Stage B until the user explicitly approves this document.
+
+This document must be maintained in accordance with `AGENTS.md`.
+
+## Purpose / big picture
+
+Roadmap item 7.2.4 adds the reusable proof plumbing for the clone-detector
+token pipeline. Roadmap item 7.2.5 then uses that plumbing to prove the first
+clone-detector constructor invariant: `LshConfig::new` must reject zero
+`bands`, reject zero `rows`, and accept only configurations whose
+`bands * rows` product equals the fixed `MINHASH_SIZE` of 128.
+
+This work matters because roadmap item 7.2.2 already made `LshConfig` a hard
+runtime boundary for MinHash and locality-sensitive hashing (LSH). If that
+boundary drifts, every later proof and every later token-pass candidate check
+inherits the bug. ADR 002 explicitly assigns this constructor to Verus and
+reserves Kani for bounded behavioural checks over the same clone-detector
+crate, so 7.2.4 and 7.2.5 establish the proof split that later items 7.2.6,
+7.2.7, and 7.2.8 build on.
+
+Observable outcome:
+
+1. The repository gains reproducible, sidecar proof entry points for the
+   clone detector: a Verus path and a Kani path, both driven by scripts and
+   `Makefile` targets rather than normal Cargo builds.
+2. `make verus-clone-detector` succeeds and runs a clone-detector Verus proof
+   file dedicated to `LshConfig::new`.
+3. `make kani-clone-detector` succeeds and runs a bounded clone-detector Kani
+   smoke harness so the Kani workflow is real and observable before 7.2.7 and
+   7.2.8 land.
+4. Unit tests in `crates/whitaker_clones_core/src/index/tests.rs` cover happy
+   paths, unhappy paths, and edge cases for `LshConfig::new`, including zero
+   `bands`, zero `rows`, invalid products, and a large-value overflow edge.
+5. Behaviour-driven development (BDD) coverage using workspace-pinned
+   `rstest-bdd` v0.5.0 extends
+   `crates/whitaker_clones_core/tests/min_hash_lsh_behaviour.rs` and
+   `crates/whitaker_clones_core/tests/features/min_hash_lsh.feature` with
+   scenario coverage for valid and invalid LSH configuration inputs.
+6. `docs/whitaker-clone-detector-design.md` records the new proof-workflow and
+   `LshConfig` decisions, and `docs/roadmap.md` marks 7.2.4 and 7.2.5 done only
+   after the implementation turn completes and all gates succeed.
+7. The implementation turn finishes with `make fmt`, `make markdownlint`,
+   `make nixie`, `make check-fmt`, `make lint`, and `make test` all passing,
+   plus the new proof targets passing.
+
+## Constraints
+
+- Scope only roadmap items 7.2.4 and 7.2.5. Do not mark 7.2.6, 7.2.7, or
+  7.2.8 done in this change, even if some scaffolding is intentionally shared.
+- Keep proof tooling in sidecar scripts and proof files, consistent with ADR
+  002. Normal Cargo builds and the default `make test` flow must remain
+  independent of proof execution.
+- Preserve the existing runtime API shape unless a small, crate-private proof
+  seam is genuinely needed to reduce drift or remove duplication. Do not widen
+  the public API solely for proof convenience.
+- Build on the existing clone-detector crate
+  `crates/whitaker_clones_core/`. Do not move `LshConfig` into a separate crate
+  or introduce CLI, filesystem, or `rustc_private` concerns here.
+- Keep each Rust source file below 400 lines. Add focused sibling modules if
+  proof harness code or test helpers would otherwise bloat one file.
+- Every new Rust module must begin with a `//!` module-level comment.
+- Every new public API or newly public helper must carry Rustdoc with examples
+  that compile under the normal doc-test flow.
+- Use workspace-pinned `rstest`, `rstest-bdd`, and `rstest-bdd-macros`
+  (`0.5.0`) for all unit and behavioural coverage.
+- Integration tests under `tests/` must avoid `unwrap()` and `expect()`
+  because the workspace denies them there.
+- Behaviour tests must stay within the workspace Clippy argument-count limit:
+  `world` plus at most three parsed values per step.
+- Preserve the runtime contract already documented in
+  `docs/whitaker-clone-detector-design.md`: `bands > 0`, `rows > 0`, and
+  `bands * rows == MINHASH_SIZE`.
+- Record all final design decisions in
+  `docs/whitaker-clone-detector-design.md`.
+- Do not mark roadmap items 7.2.4 and 7.2.5 done until the implementation,
+  proof targets, tests, and full quality gates succeed.
+
+## Tolerances (exception triggers)
+
+- Toolchain tolerance: if no Kani release can be pinned reproducibly against
+  the repository's current `nightly-2025-09-18` toolchain without changing
+  `rust-toolchain.toml`, stop and escalate before changing the pinned Rust
+  toolchain.
+- Scope tolerance: if the Kani workflow cannot be made observable without also
+  implementing substantive `MinHasher` or `LshIndex` proofs, stop and ask
+  whether 7.2.7 or 7.2.8 should be pulled forward deliberately.
+- API tolerance: if Verus proof drift cannot be managed without exporting a
+  new public helper, stop and ask before widening the clone-detector public
+  surface.
+- File-size tolerance: if the implementation would push a Rust source file
+  over 400 lines or touch more than 14 files, stop and refactor the plan into
+  smaller modules or ask whether the scope should be split.
+- Validation tolerance: if `make check-fmt`, `make lint`, or `make test` still
+  fail after three targeted fix iterations, stop and escalate with saved log
+  paths.
+- Proof-model tolerance: if the Verus model needs to reason about the internals
+  of `BTreeSet`, `BTreeMap`, or MinHash mixing logic to prove 7.2.5, stop and
+  narrow the proof back to constructor semantics only.
+- Harness tolerance: if `cfg(kani)` introduces unexpected lint or build noise
+  under normal Cargo workflows, move the Kani harness into a more isolated
+  module arrangement before proceeding, but do not disable lints broadly.
+
+## Risks
+
+- Kani compatibility risk: Kani versioning may lag the repository's pinned
+  nightly. Mitigation: treat compatible Kani pin selection as the first risky
+  milestone and escalate if it requires a toolchain bump.
+- Proof drift risk: a standalone Verus model can drift from the runtime
+  constructor semantics over time. Mitigation: keep the proof focused on the
+  exact constructor contract, mirror the same constant names, and add ordinary
+  unit and BDD regression tests around the runtime constructor.
+- Overscoping risk: sidecar plumbing can easily absorb later proof work.
+  Mitigation: add only the minimal Kani smoke harness needed to make the Kani
+  target real, and reserve `MinHasher`/`LshIndex` proof obligations for their
+  own roadmap items.
+- Regression-noise risk: proof scripts that modify global toolchains or caches
+  can make local development brittle. Mitigation: install proof tools into
+  repository-owned or XDG cache locations and keep sidecar scripts idempotent.
+- Test-coverage risk: the current BDD suite already covers zero bands but not
+  zero rows or a non-zero invalid product. Mitigation: extend the existing
+  `min_hash_lsh` behaviour file instead of creating a disconnected second
+  harness.
+- Overflow edge risk: `checked_mul` protects the runtime from large inputs, but
+  the proof must still preserve the semantic claim that only exact products of
+  128 are accepted. Mitigation: add a targeted large-value unit test and keep
+  the proof claim phrased in terms of acceptance semantics, not machine-width
+  overflow internals.
+
+## Progress
+
+- [x] Stage A: Gather repository context and draft this ExecPlan
+  (2026-04-08).
+- [ ] Stage B: Add clone-detector proof sidecar tooling and `Makefile`
+  targets.
+- [ ] Stage C: Add or extend failing unit tests for `LshConfig::new` happy,
+  unhappy, and edge cases.
+- [ ] Stage D: Extend `rstest-bdd` coverage for `LshConfig` configuration
+  outcomes.
+- [ ] Stage E: Add the Verus proof for `LshConfig::new` invariants.
+- [ ] Stage F: Add the minimal Kani smoke harness needed to make the
+  clone-detector Kani target observable.
+- [ ] Stage G: Update the clone-detector design document and mark roadmap
+  items 7.2.4 and 7.2.5 done.
+- [ ] Stage H: Run documentation, proof, lint, and test gates successfully.
+- [ ] Stage I: Finalize the living sections in this ExecPlan after the
+  implementation turn.
+
+## Surprises & Discoveries
+
+- The repository already has a pinned Verus sidecar workflow:
+  `scripts/install-verus.sh`, `scripts/run-verus.sh`, the top-level `verus/`
+  directory, and `make verus`. Clone-detector proof tooling should extend that
+  pattern rather than inventing a second Verus installation model.
+- The repository has no Kani tooling yet. There is no `make kani`, no Kani
+  install wrapper, and no existing `cfg(kani)` or Kani harness module.
+- `LshConfig::new` already enforces the exact 7.2.5 runtime contract in
+  `crates/whitaker_clones_core/src/index/types.rs`, so the first proof can be
+  narrowly scoped to constructor semantics instead of reshaping the runtime
+  code.
+- Existing unit coverage in
+  `crates/whitaker_clones_core/src/index/tests.rs` already exercises zero bands
+  and one invalid product case. Existing BDD coverage in
+  `crates/whitaker_clones_core/tests/features/min_hash_lsh.feature` already
+  exercises zero bands. The implementation should extend these tests rather
+  than replace them.
+- `Makefile` currently exposes only a global `verus` target. If we want fast
+  clone-detector-only iteration without regressing the existing proof workflow,
+  the cleanest approach is to add clone-detector-specific targets alongside the
+  current umbrella target.
+- The workspace root pins `rstest-bdd = "0.5.0"`, matching the user's
+  requirement, so the plan must keep that exact version in view even though
+  some repository comments elsewhere still mention older text.
+
+## Decision Log
+
+- Decision: plan 7.2.4 and 7.2.5 as one implementation turn. Rationale:
+  7.2.5 directly depends on 7.2.4, and splitting the sidecar plumbing from the
+  first proof would create extra doc churn without reducing risk. Date/Author:
+  2026-04-08 / Codex.
+- Decision: keep proof workflows opt-in through `Makefile` targets and wrapper
+  scripts, not through normal `cargo test` or build hooks. Rationale: ADR 002
+  explicitly requires sidecar proof tooling independent from ordinary Cargo
+  development. Date/Author: 2026-04-08 / Codex.
+- Decision: extend the existing `min_hash_lsh` unit and BDD coverage instead
+  of creating a second test harness just for `LshConfig`. Rationale: the
+  runtime contract already lives inside that feature area, and this keeps the
+  behavioural story coherent for a novice reader. Date/Author: 2026-04-08 /
+  Codex.
+- Decision: add a minimal Kani smoke harness around `LshConfig::new` so the
+  new Kani sidecar is demonstrably real, while still reserving substantive
+  `MinHasher` and `LshIndex` bounded proofs for roadmap items 7.2.7 and 7.2.8.
+  Rationale: 7.2.4 asks for clone-detector Kani checks, and a zero-harness
+  workflow would be difficult to validate. Date/Author: 2026-04-08 / Codex.
+
+## Context and orientation
+
+### Repository state
+
+The repository root is `/home/user/project`.
+
+Clone-detector runtime code already lives in
+`crates/whitaker_clones_core/src/index/`:
+
+- `mod.rs` wires the public index API.
+- `types.rs` defines `MINHASH_SIZE`, `FragmentId`, `CandidatePair`,
+  `MinHashSignature`, and `LshConfig`.
+- `error.rs` defines the typed `IndexError` values `ZeroBands`, `ZeroRows`,
+  `InvalidBandRowProduct`, and `EmptyFingerprintSet`.
+- `minhash.rs` and `lsh.rs` implement candidate-generation behaviour from
+  roadmap item 7.2.2.
+- `tests.rs` contains unit coverage for this area.
+
+Current behaviour coverage for this area already exists in:
+
+- `crates/whitaker_clones_core/tests/min_hash_lsh_behaviour.rs`
+- `crates/whitaker_clones_core/tests/features/min_hash_lsh.feature`
+
+Current proof infrastructure already exists only for the decomposition-advice
+area:
+
+- `scripts/install-verus.sh`
+- `scripts/run-verus.sh`
+- `verus/decomposition_cosine_threshold.rs`
+- `verus/decomposition_vector_algebra.rs`
+- `Makefile` target `verus`
+
+There is no existing Kani sidecar or Kani proof directory in the repository.
+
+### Runtime contract to preserve
+
+`LshConfig::new` currently does three things in order:
+
+1. Converts `bands` into `NonZeroUsize`, returning `IndexError::ZeroBands`
+   when the conversion fails.
+2. Converts `rows` into `NonZeroUsize`, returning `IndexError::ZeroRows` when
+   that conversion fails.
+3. Calls `validate_product` and accepts only when
+   `checked_mul(bands, rows) == Some(MINHASH_SIZE)`.
+
+That contract is already documented in `docs/whitaker-clone-detector-design.md`
+under `## Implementation decisions (7.2.2)`, which states that `bands` and
+`rows` must both be greater than zero and must multiply to the fixed
+`MINHASH_SIZE` of 128.
+
+### Relationship to ADR 002
+
+ADR 002 makes the proof split explicit:
+
+1. Verus owns local semantic invariants such as `LshConfig::new`.
+2. Kani owns bounded behavioural checks for real MinHash and LSH code.
+3. Ordinary tests remain the first regression net and are not replaced by
+   proofs.
+
+This plan follows that split literally. Verus proves the constructor contract.
+Kani gets only enough workflow and smoke coverage to make the sidecar real.
+Ordinary unit and BDD tests continue to guard the runtime API.
+
+### Local documentation and testing guides to follow
+
+Use these repository guides while implementing, but keep the implementation
+turn self-contained:
+
+- `docs/rstest-bdd-users-guide.md` for fixture-backed BDD scenarios.
+- `docs/rust-testing-with-rstest-fixtures.md` for `rstest` fixture patterns.
+- `docs/rust-doctest-dry-guide.md` for Rustdoc example style.
+- `docs/complexity-antipatterns-and-refactoring-strategies.md` for keeping
+  helpers small and cohesive.
+- `docs/whitaker-dylint-suite-design.md` for repository-wide lint and
+  `unexpected_cfgs` considerations when introducing specialised build modes.
+
+## Proposed implementation shape
+
+The change should stay narrowly focused and add exactly four kinds of artefact.
+
+First, extend proof tooling at the repository root:
+
+- Add `scripts/install-kani.sh` to install a pinned `kani-verifier` into a
+  cache directory, run the one-time Kani setup step idempotently, and print the
+  resolved tool path for callers.
+- Add `scripts/run-kani.sh` to run explicit clone-detector harness names in
+  `crates/whitaker_clones_core`, mirroring the existing `scripts/run-verus.sh`
+  wrapper style.
+- Extend `scripts/run-verus.sh` so it can run either the current decomposition
+  proofs, the new clone-detector proofs, or a caller-specified file path, while
+  preserving existing behaviour for `make verus`.
+- Update `Makefile` to add clone-detector-specific proof targets and an
+  umbrella Kani target. The intended shape is:
+
+  1. `make verus` runs all Verus proof files, including the new clone-detector
+     proof.
+  2. `make verus-clone-detector` runs only the clone-detector Verus proof set.
+  3. `make kani` runs all Kani sidecar harness sets currently registered.
+  4. `make kani-clone-detector` runs only the clone-detector Kani harness set.
+
+Second, add the first clone-detector Verus proof file:
+
+- `verus/clone_detector_lsh_config.rs`
+
+That file should model the `LshConfig::new` contract directly in terms of
+`bands`, `rows`, and `MINHASH_SIZE`. The proof goal is semantic, not
+implementation-detail-heavy: acceptance if and only if `bands > 0`, `rows > 0`,
+and `bands * rows == MINHASH_SIZE`, with explicit lemmas for zero bands, zero
+rows, a valid exact product, and an invalid non-zero product.
+
+Third, add the minimal Kani harness needed to make the new workflow concrete:
+
+- Prefer `crates/whitaker_clones_core/src/index/kani.rs`, compiled only under
+  Kani, with one proof harness that symbolically chooses bounded `bands` and
+  `rows`, calls the real `LshConfig::new`, and asserts the returned
+  `IndexError` or accepted config matches the documented runtime contract.
+
+This harness is deliberately narrow. It is a tooling smoke check and a future
+anchor point, not a substitute for roadmap items 7.2.7 and 7.2.8.
+
+Fourth, extend the existing test and documentation surfaces:
+
+- `crates/whitaker_clones_core/src/index/tests.rs`
+- `crates/whitaker_clones_core/tests/min_hash_lsh_behaviour.rs`
+- `crates/whitaker_clones_core/tests/features/min_hash_lsh.feature`
+- `docs/whitaker-clone-detector-design.md`
+- `docs/roadmap.md`
+
+## Implementation details
+
+### Stage B: add clone-detector proof sidecar tooling and `Makefile` targets
+
+Start with the proof workflow plumbing because 7.2.5 depends on it.
+
+1. Extend `scripts/run-verus.sh` so proof files are grouped by domain rather
+   than hard-coded as one flat list. Preserve the current default behaviour for
+   `make verus`, but make it possible to select a `clone-detector` group for
+   fast local iteration.
+2. Add `scripts/install-kani.sh` following the same operational style as the
+   Verus installer: strict shell flags, explicit cache directory, idempotent
+   installation, and a stable printed path. Use Kani's official installation
+   flow as the basis for the script. If pinning a compatible Kani release is
+   not possible against the current Rust toolchain, stop here and escalate.
+3. Add `scripts/run-kani.sh` to call the installed Kani tool with an explicit
+   manifest path and explicit harness list for the clone-detector crate.
+4. Update `Makefile` with the new proof targets. Keep the target names obvious
+   and parallel so a novice can discover them from `make help`.
+
+### Stage C: add failing unit tests first
+
+Extend `crates/whitaker_clones_core/src/index/tests.rs` before touching proof
+files.
+
+Keep the existing valid and invalid tests, then add focused cases for:
+
+1. `rows == 0` as a dedicated runtime rejection case.
+2. A non-zero invalid product such as `(16, 16)` or `(3, 42)`.
+3. A large-value overflow edge, such as `(usize::MAX, 2)`, proving that the
+   constructor rejects overflow rather than panicking.
+4. Additional valid products such as `(2, 64)` and `(32, 4)` if not already
+   covered by the final shape.
+
+If a helper would exceed the Clippy argument-count threshold, replace the
+helper signature with a small parameter object rather than silencing the lint.
+
+### Stage D: extend the `rstest-bdd` coverage
+
+Add or extend scenarios in the existing `min_hash_lsh` behaviour harness so a
+reader can observe the `LshConfig` contract without reading the unit tests.
+
+The behavioural suite should include at least:
+
+1. A happy-path scenario using a valid `(bands, rows)` pair that still yields a
+   candidate pair.
+2. An unhappy-path scenario for zero bands. This already exists and should be
+   kept.
+3. A new unhappy-path scenario for zero rows.
+4. A new unhappy-path scenario for a non-zero invalid product.
+
+Do not create a second feature file unless the existing one becomes hard to
+read. This change belongs in the current MinHash/LSH behaviour story.
+
+### Stage E: add the Verus proof for `LshConfig::new`
+
+Add `verus/clone_detector_lsh_config.rs`.
+
+Keep the proof small and explicit. A good starting shape is:
+
+```rust
+spec fn lsh_config_accepts(bands: int, rows: int) -> bool { ... }
+
+proof fn lemma_zero_bands_rejected(rows: int) { ... }
+proof fn lemma_zero_rows_rejected(bands: int) { ... }
+proof fn lemma_exact_product_is_accepted() { ... }
+proof fn lemma_invalid_product_is_rejected(bands: int, rows: int) { ... }
+```
+
+Use the same constant name `MINHASH_SIZE` inside the proof file so drift is
+harder to introduce. Prefer a direct semantic model of the constructor over a
+complex model of `NonZeroUsize` or machine-width overflow.
+
+If the proof becomes awkward because the runtime constructor duplicates logic
+in several branches, extract one crate-private runtime helper such as
+`validate_lsh_dimensions` and prove the semantics that helper expresses. Do not
+make the helper public unless the user explicitly approves widening the API.
+
+### Stage F: add the minimal Kani smoke harness
+
+Create the narrowest useful Kani harness that makes `make kani-clone-detector`
+meaningful.
+
+Recommended shape:
+
+1. Add `crates/whitaker_clones_core/src/index/kani.rs`.
+2. Compile it only when Kani runs.
+3. Symbolically choose small `bands` and `rows` values.
+4. Call the real `LshConfig::new` runtime constructor.
+5. Assert that:
+   - `Ok(config)` implies both values are non-zero and their product equals
+     `MINHASH_SIZE`.
+   - `Err(IndexError::ZeroBands)` implies `bands == 0`.
+   - `Err(IndexError::ZeroRows)` implies `rows == 0` and `bands != 0`.
+   - `Err(IndexError::InvalidBandRowProduct { .. })` implies both are non-zero
+     and the exact product is not `MINHASH_SIZE`.
+
+This harness is not the formal proof for 7.2.5. It is the minimal bounded
+runtime check that proves the Kani sidecar works and that future clone-detector
+Kani items have a stable place to live.
+
+### Stage G: update design and roadmap documents
+
+Update `docs/whitaker-clone-detector-design.md` with the final decisions from
+the implementation turn. Add explicit prose covering:
+
+1. The proof-workflow split: Verus for local constructor semantics, Kani for
+   bounded runtime checks.
+2. The chosen `Makefile` target names and sidecar script locations.
+3. Any proof seam introduced in runtime code, if one was required.
+4. Any Kani compatibility constraint discovered during the implementation.
+
+Only after all implementation work and quality gates succeed, mark roadmap
+items 7.2.4 and 7.2.5 done in `docs/roadmap.md`.
+
+## Validation and evidence
+
+During the implementation turn, run every relevant gate through `tee` with
+`set -o pipefail`, as required by `AGENTS.md`, and retain the logs for review.
+
+Use this exact command pattern:
+
+```sh
+set -o pipefail
+make fmt 2>&1 | tee /tmp/7-2-4-fmt.log
+make markdownlint 2>&1 | tee /tmp/7-2-4-markdownlint.log
+make nixie 2>&1 | tee /tmp/7-2-4-nixie.log
+make verus-clone-detector 2>&1 | tee /tmp/7-2-4-verus-clone-detector.log
+make kani-clone-detector 2>&1 | tee /tmp/7-2-4-kani-clone-detector.log
+make check-fmt 2>&1 | tee /tmp/7-2-4-check-fmt.log
+make lint 2>&1 | tee /tmp/7-2-4-lint.log
+make test 2>&1 | tee /tmp/7-2-4-test.log
+```
+
+If a broader proof smoke pass is useful after the clone-detector targets are
+green, also run:
+
+```sh
+set -o pipefail
+make verus 2>&1 | tee /tmp/7-2-4-verus.log
+make kani 2>&1 | tee /tmp/7-2-4-kani.log
+```
+
+The implementation turn is complete only when all of the following are true:
+
+1. Unit tests and BDD tests for `LshConfig::new` pass.
+2. The clone-detector Verus proof target passes.
+3. The clone-detector Kani target passes.
+4. `make check-fmt`, `make lint`, and `make test` pass.
+5. Documentation format and lint gates pass for the modified Markdown files.
+6. `docs/whitaker-clone-detector-design.md` and `docs/roadmap.md` reflect the
+   final state accurately.
+
+## Acceptance checklist for the implementation turn
+
+The implementation turn should be considered acceptable only if a novice can do
+all of the following from a fresh checkout after reading this ExecPlan:
+
+1. Discover the clone-detector proof entry points from `make help`.
+2. Run `make verus-clone-detector` and observe a successful proof of
+   `LshConfig::new` invariants.
+3. Run `make kani-clone-detector` and observe a successful bounded runtime
+   harness for the clone-detector crate.
+4. Read `crates/whitaker_clones_core/src/index/tests.rs` and the
+   `min_hash_lsh` feature file to understand the happy and unhappy runtime
+   cases without reverse-engineering the proof files.
+5. Read `docs/whitaker-clone-detector-design.md` and see the final 7.2.4 and
+   7.2.5 design choices recorded clearly.
+6. Open `docs/roadmap.md` and see both roadmap items marked done only after the
+   work is truly complete.
+
+## Outcomes & Retrospective
+
+This section is intentionally blank during the draft phase. At the end of the
+implementation turn, replace this paragraph with a concise retrospective that
+records what shipped, what changed from the draft, which tolerances were hit,
+which commands proved success, and any follow-on work that should be tracked in
+later roadmap items.

--- a/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
+++ b/docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
@@ -65,6 +65,9 @@ Observable outcome:
 - Build on the existing clone-detector crate
   `crates/whitaker_clones_core/`. Do not move `LshConfig` into a separate crate
   or introduce CLI, filesystem, or `rustc_private` concerns here.
+- If Kani harnesses use `#[cfg(kani)]`, register that cfg in the relevant
+  crate's `unexpected_cfgs` allowlist instead of accepting noisy warnings or
+  adding broad lint suppressions.
 - Keep each Rust source file below 400 lines. Add focused sibling modules if
   proof harness code or test helpers would otherwise bloat one file.
 - Every new Rust module must begin with a `//!` module-level comment.
@@ -134,6 +137,11 @@ Observable outcome:
   128 are accepted. Mitigation: add a targeted large-value unit test and keep
   the proof claim phrased in terms of acceptance semantics, not machine-width
   overflow internals.
+- State-explosion risk: even tiny Kani harnesses can become impractical if they
+  explore unconstrained symbolic inputs or use overly generous unwind bounds.
+  Mitigation: follow Chutoro's pattern of a deterministic smoke harness, small
+  explicit `#[kani::unwind(N)]` bounds, and `kani::assume` guards that mirror
+  production preconditions.
 
 ## Progress
 
@@ -179,6 +187,12 @@ Observable outcome:
 - The workspace root pins `rstest-bdd = "0.5.0"`, matching the user's
   requirement, so the plan must keep that exact version in view even though
   some repository comments elsewhere still mention older text.
+- Chutoro's Kani setup is directly relevant here. The useful patterns are:
+  keep harnesses adjacent to the internal modules they inspect, allow
+  `cfg(kani)` explicitly in crate lint configuration, separate a practical
+  local Kani target from heavier exhaustive runs, and use documented
+  `kani::assume` guards plus explicit unwind limits to keep solver work
+  tractable.
 
 ## Decision Log
 
@@ -200,6 +214,11 @@ Observable outcome:
   `MinHasher` and `LshIndex` bounded proofs for roadmap items 7.2.7 and 7.2.8.
   Rationale: 7.2.4 asks for clone-detector Kani checks, and a zero-harness
   workflow would be difficult to validate. Date/Author: 2026-04-08 / Codex.
+- Decision: borrow Chutoro's two-tier Kani shape conceptually, but keep the
+  Whitaker scope smaller for this roadmap slice. Rationale: the first Whitaker
+  Kani target should be a practical local smoke gate with small bounds; any
+  heavier `kani-full` style target should remain a future extension once 7.2.7
+  and 7.2.8 add broader bounded checks. Date/Author: 2026-04-08 / Codex.
 
 ## Context and orientation
 
@@ -277,6 +296,28 @@ turn self-contained:
 - `docs/whitaker-dylint-suite-design.md` for repository-wide lint and
   `unexpected_cfgs` considerations when introducing specialised build modes.
 
+### Relevant learnings from `leynos/chutoro`
+
+Chutoro uses Kani in a way that is directly applicable to this roadmap item.
+The most relevant implementation lessons are:
+
+1. Put Kani harnesses next to the internal modules they exercise so they can
+   use `pub(crate)` seams instead of widening the public API.
+2. Keep harnesses behind `#[cfg(kani)]`, and explicitly allow that cfg in the
+   crate's `unexpected_cfgs` check list.
+3. Keep the everyday Kani target small and practical. Chutoro's `make kani`
+   runs only smoke-sized harnesses, while heavier exhaustive runs are reserved
+   for `make kani-full`.
+4. Add module-level harness documentation with direct `cargo kani` and `make`
+   commands so the proof entry points remain discoverable.
+5. Use explicit `#[kani::unwind(N)]` bounds and `kani::assume` guards that
+   mirror production preconditions. This is how Chutoro keeps symbolic state
+   bounded without silently changing the runtime contract under test.
+
+Whitaker should adopt lessons 1, 2, 4, and 5 directly in 7.2.4. Lesson 3 should
+shape the interface design so the first target is practical locally, without
+forcing 7.2.4 to absorb future heavyweight harnesses now.
+
 ## Proposed implementation shape
 
 The change should stay narrowly focused and add exactly four kinds of artefact.
@@ -298,8 +339,14 @@ First, extend proof tooling at the repository root:
   1. `make verus` runs all Verus proof files, including the new clone-detector
      proof.
   2. `make verus-clone-detector` runs only the clone-detector Verus proof set.
-  3. `make kani` runs all Kani sidecar harness sets currently registered.
-  4. `make kani-clone-detector` runs only the clone-detector Kani harness set.
+  3. `make kani-clone-detector` runs only the practical clone-detector Kani
+     smoke harness set with intentionally small bounds.
+  4. `make kani` runs all practical Kani sidecar harness sets currently
+     registered. In this roadmap slice, that will effectively mean the
+     clone-detector set.
+  5. The script and target layout must leave room for a future heavier
+     `kani-full` style target once 7.2.7 and 7.2.8 introduce broader bounded
+     checks.
 
 Second, add the first clone-detector Verus proof file:
 
@@ -317,6 +364,9 @@ Third, add the minimal Kani harness needed to make the new workflow concrete:
   Kani, with one proof harness that symbolically chooses bounded `bands` and
   `rows`, calls the real `LshConfig::new`, and asserts the returned
   `IndexError` or accepted config matches the documented runtime contract.
+- Mirror Chutoro's local style by giving this module a `//!` comment that
+  documents the direct `cargo kani` invocation and the `make` target that wraps
+  it.
 
 This harness is deliberately narrow. It is a tooling smoke check and a future
 anchor point, not a substitute for roadmap items 7.2.7 and 7.2.8.
@@ -345,8 +395,12 @@ Start with the proof workflow plumbing because 7.2.5 depends on it.
    flow as the basis for the script. If pinning a compatible Kani release is
    not possible against the current Rust toolchain, stop here and escalate.
 3. Add `scripts/run-kani.sh` to call the installed Kani tool with an explicit
-   manifest path and explicit harness list for the clone-detector crate.
-4. Update `Makefile` with the new proof targets. Keep the target names obvious
+   manifest path, explicit harness list, and explicit unwind defaults for the
+   practical clone-detector harnesses.
+4. If the harness module uses `#[cfg(kani)]`, update
+   `crates/whitaker_clones_core/Cargo.toml` with an `unexpected_cfgs` allowlist
+   entry for `cfg(kani)`, following Chutoro's pattern.
+5. Update `Makefile` with the new proof targets. Keep the target names obvious
    and parallel so a novice can discover them from `make help`.
 
 ### Stage C: add failing unit tests first
@@ -416,9 +470,19 @@ Recommended shape:
 
 1. Add `crates/whitaker_clones_core/src/index/kani.rs`.
 2. Compile it only when Kani runs.
-3. Symbolically choose small `bands` and `rows` values.
-4. Call the real `LshConfig::new` runtime constructor.
-5. Assert that:
+3. Give it a module-level `//!` comment with the direct `cargo kani` command
+   and the corresponding `make` target, mirroring Chutoro's discoverability
+   pattern.
+4. Add one deterministic smoke harness first, then one symbolic harness only
+   if the deterministic harness alone is too weak to prove the workflow is
+   wired correctly.
+5. Use an explicit small unwind bound, such as `#[kani::unwind(4)]`, unless a
+   tighter value is enough.
+6. Symbolically choose small `bands` and `rows` values and constrain them with
+   `kani::assume` only where those assumptions match real production
+   preconditions or bound the search space transparently.
+7. Call the real `LshConfig::new` runtime constructor.
+8. Assert that:
    - `Ok(config)` implies both values are non-zero and their product equals
      `MINHASH_SIZE`.
    - `Err(IndexError::ZeroBands)` implies `bands == 0`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -343,10 +343,10 @@
   fingerprints and spans. See
   [clone detector design](whitaker-clone-detector-design.md) §SARIF emission
   (Run 0). Requires 7.1.1.
-- [ ] 7.2.4. Add sidecar proof workflows and Makefile targets for clone-detector
+- [x] 7.2.4. Add sidecar proof workflows and Makefile targets for clone-detector
   Verus and Kani checks. Requires 7.2.2. See
   [ADR 003](adr-003-formal-proof-strategy-for-clone-detector-pipeline.md).
-- [ ] 7.2.5. Use Verus to prove `LshConfig::new` rejects zero `bands` and
+- [x] 7.2.5. Use Verus to prove `LshConfig::new` rejects zero `bands` and
   `rows`, and enforces `bands * rows == MINHASH_SIZE`. Requires 7.2.4. See
   [ADR 003](adr-003-formal-proof-strategy-for-clone-detector-pipeline.md) and
   [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.

--- a/docs/whitaker-clone-detector-design.md
+++ b/docs/whitaker-clone-detector-design.md
@@ -518,6 +518,39 @@ cargo whitaker clones report --in target/whitaker/clones.refined.sarif --html
    and repeated collisions across multiple bands still produce one stable
    `CandidatePair`.
 
+## Implementation decisions (7.2.4 and 7.2.5)
+
+1. **Split proof workflow by responsibility.** Clone-detector constructor
+   semantics use Verus, while bounded runtime smoke checks use Kani. Ordinary
+   unit tests and `rstest-bdd` scenarios remain the first regression net for
+   `LshConfig::new`.
+
+2. **Sidecar proof entry points stay outside the default Cargo path.** The
+   repository now exposes `make verus-clone-detector` and
+   `make kani-clone-detector`, backed by `scripts/run-verus.sh`,
+   `scripts/install-kani.sh`, and `scripts/run-kani.sh`. The umbrella
+   `make verus` target runs all Verus proofs, while `make kani` currently runs
+   the practical clone-detector Kani harness set and leaves room for future
+   bounded checks.
+
+3. **`LshConfig::new` contract is proved semantically, not by modelling
+   internals.** The Verus proof file models acceptance directly as `bands > 0`,
+   `rows > 0`, and `bands * rows == MINHASH_SIZE`. This avoids coupling the
+   proof to `NonZeroUsize` representation details while keeping the contract
+   aligned with the runtime constructor.
+
+4. **Kani harnesses stay adjacent to the index code under `cfg(kani)`.**
+   `crates/whitaker_clones_core/src/index/kani.rs` calls the real
+   `LshConfig::new` constructor, uses small bounded symbolic inputs, and
+   asserts the returned configuration or typed `IndexError` matches the same
+   runtime contract documented above. The crate explicitly allows `cfg(kani)`
+   in its `unexpected_cfgs` configuration so normal builds stay quiet.
+
+5. **Overflow remains an invalid-product rejection, not a special public API.**
+   Runtime validation still relies on `checked_mul`; large values such as
+   `usize::MAX` with `rows = 2` return `IndexError::InvalidBandRowProduct`
+   rather than panicking or widening the public API with proof-specific helpers.
+
 ## Minimal code skeletons (selected)
 
 ### Token to fingerprints to candidates

--- a/docs/whitaker-clone-detector-design.md
+++ b/docs/whitaker-clone-detector-design.md
@@ -547,7 +547,7 @@ cargo whitaker clones report --in target/whitaker/clones.refined.sarif --html
    `crates/whitaker_clones_core/src/index/kani.rs` calls the real
    `LshConfig::new` constructor, uses one concrete smoke harness, one bounded
    symbolic harness over `[0, 128]²`, and one overflow-specific harness that
-   forces the `checked_mul(None)` branch. Together these harnesses assert the
+   forces the `checked_mul(None)` branch. Together, these harnesses assert the
    returned configuration or typed `IndexError` matches the same runtime
    contract documented above. The crate explicitly allows `cfg(kani)` in its
    `unexpected_cfgs` configuration so normal builds stay quiet.

--- a/docs/whitaker-clone-detector-design.md
+++ b/docs/whitaker-clone-detector-design.md
@@ -533,18 +533,24 @@ cargo whitaker clones report --in target/whitaker/clones.refined.sarif --html
    the practical clone-detector Kani harness set and leaves room for future
    bounded checks.
 
-3. **`LshConfig::new` contract is proved semantically, not by modelling
-   internals.** The Verus proof file models acceptance directly as `bands > 0`,
-   `rows > 0`, and `bands * rows == MINHASH_SIZE`. This avoids coupling the
-   proof to `NonZeroUsize` representation details while keeping the contract
-   aligned with the runtime constructor.
+3. **Verus proves an implementation-shaped model, not the compiled Rust body.**
+   The clone-detector Verus file now mirrors the real branch order in
+   `LshConfig::new` and `validate_product`: zero-band rejection, then zero-row
+   rejection, then `checked_mul`-based acceptance or invalid-product rejection.
+   This keeps the proof aligned with runtime control flow, including overflow
+   rejection, without pretending that the sidecar file has directly verified
+   the production Rust function. Direct linkage would require trusted Verus
+   assumptions for external code, so the repository records that limitation
+   explicitly and relies on Kani for implementation execution.
 
 4. **Kani harnesses stay adjacent to the index code under `cfg(kani)`.**
    `crates/whitaker_clones_core/src/index/kani.rs` calls the real
-   `LshConfig::new` constructor, uses small bounded symbolic inputs, and
-   asserts the returned configuration or typed `IndexError` matches the same
-   runtime contract documented above. The crate explicitly allows `cfg(kani)`
-   in its `unexpected_cfgs` configuration so normal builds stay quiet.
+   `LshConfig::new` constructor, uses one concrete smoke harness, one bounded
+   symbolic harness over `[0, 128]²`, and one overflow-specific harness that
+   forces the `checked_mul(None)` branch. Together these harnesses assert the
+   returned configuration or typed `IndexError` matches the same runtime
+   contract documented above. The crate explicitly allows `cfg(kani)` in its
+   `unexpected_cfgs` configuration so normal builds stay quiet.
 
 5. **Overflow remains an invalid-product rejection, not a special public API.**
    Runtime validation still relies on `checked_mul`; large values such as

--- a/scripts/install-verus.sh
+++ b/scripts/install-verus.sh
@@ -72,6 +72,7 @@ import re
 import sys
 
 contents = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+contents = re.sub(r"\x1b\[[0-9;]*m", "", contents)
 match = re.search(r"rustup install ([^\s]+)", contents)
 if match is not None:
     print(match.group(1))

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -68,6 +68,7 @@ run_decomposition_harnesses() {
 
 if [ $# -eq 0 ]; then
     run_decomposition_harnesses
+    run_clone_detector_harnesses
     exit 0
 fi
 

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -55,7 +55,6 @@ run_clone_detector_harnesses() {
             "$@"
     done
 }
-}
 
 run_decomposition_harnesses() {
     cd "${REPO_ROOT}/common"

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -55,6 +55,7 @@ run_clone_detector_harnesses() {
             "$@"
     done
 }
+}
 
 run_decomposition_harnesses() {
     cd "${REPO_ROOT}/common"

--- a/scripts/run-kani.sh
+++ b/scripts/run-kani.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
-# run-kani.sh — Run the pinned Kani bounded model checker against the common
-# crate.
+# run-kani.sh — Run the pinned Kani bounded model checker against Whitaker's
+# sidecar proof harnesses.
 #
 # Usage:
+#   scripts/run-kani.sh
+#   scripts/run-kani.sh clone-detector [EXTRA_KANI_FLAGS...]
+#   scripts/run-kani.sh decomposition [HARNESS_FILTER]
 #   scripts/run-kani.sh [HARNESS_FILTER]
 #
 # Arguments:
-#   HARNESS_FILTER  Optional. When provided, passed as --harness <filter> to
-#                   cargo-kani. When omitted, all harnesses are run.
+#   clone-detector  Run the explicit clone-detector harness list.
+#   decomposition   Run the existing decomposition/common harnesses.
+#   HARNESS_FILTER  When no group is given, treat the first positional
+#                   argument as a decomposition/common harness filter.
 #
 # Installs Kani via install-kani.sh if not already cached, then configures
 # PATH, RUSTUP_TOOLCHAIN, and the appropriate dynamic-library search path
@@ -19,6 +24,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
 KANI_INSTALL_DIR=$("${SCRIPT_DIR}/install-kani.sh")
 CARGO_KANI_BIN="${KANI_INSTALL_DIR}/bin/cargo-kani"
+CLONE_DETECTOR_MANIFEST="${REPO_ROOT}/crates/whitaker_clones_core/Cargo.toml"
 
 # kani-compiler is dynamically linked against the toolchain's libLLVM.
 # On macOS use DYLD_LIBRARY_PATH, on Linux use LD_LIBRARY_PATH.
@@ -36,13 +42,44 @@ export RUSTUP_TOOLCHAIN="${TOOLCHAIN}"
 # goto-cc invokes the C preprocessor (gcc) via execvp.
 export CC="${CC:-gcc}"
 
-HARNESS_FILTER="${1:-}"
+run_clone_detector_harnesses() {
+    for harness in \
+        verify_lsh_config_new_smoke \
+        verify_lsh_config_new_symbolic \
+        verify_lsh_config_new_overflow_product
+    do
+        "${CARGO_KANI_BIN}" kani \
+            --manifest-path "${CLONE_DETECTOR_MANIFEST}" \
+            --default-unwind 4 \
+            --harness "${harness}" \
+            "$@"
+    done
+}
 
-cd "${REPO_ROOT}/common"
+run_decomposition_harnesses() {
+    cd "${REPO_ROOT}/common"
+    if [ $# -gt 0 ]; then
+        "${CARGO_KANI_BIN}" kani --harness "$1"
+    else
+        "${CARGO_KANI_BIN}" kani
+    fi
+}
 
-if [ -n "${HARNESS_FILTER}" ]; then
-    "${CARGO_KANI_BIN}" kani --harness "${HARNESS_FILTER}"
-else
-    # Run all harnesses (no --harness filter)
-    "${CARGO_KANI_BIN}" kani
+if [ $# -eq 0 ]; then
+    run_decomposition_harnesses
+    exit 0
 fi
+
+case "$1" in
+    common|decomposition)
+        shift
+        run_decomposition_harnesses "$@"
+        ;;
+    clone-detector)
+        shift
+        run_clone_detector_harnesses "$@"
+        ;;
+    *)
+        run_decomposition_harnesses "$@"
+        ;;
+esac

--- a/scripts/run-verus.sh
+++ b/scripts/run-verus.sh
@@ -30,12 +30,25 @@ proof_files_for_group() {
     esac
 }
 
-mapfile -t PROOF_FILES < <(proof_files_for_group all)
+set_proof_files_for_group() {
+    local group proof_file proof_files_output
+    group=$1
+    proof_files_output=$(proof_files_for_group "${group}")
+    PROOF_FILES=()
+    while IFS= read -r proof_file; do
+        [ -n "${proof_file}" ] || continue
+        PROOF_FILES+=("${proof_file}")
+    done <<EOF
+${proof_files_output}
+EOF
+}
+
+set_proof_files_for_group all
 
 if [ $# -gt 0 ] && [ "${1:0:1}" != "-" ]; then
     case "$1" in
         all|decomposition|clone-detector)
-            mapfile -t PROOF_FILES < <(proof_files_for_group "$1")
+            set_proof_files_for_group "$1"
             shift
             ;;
         *)

--- a/scripts/run-verus.sh
+++ b/scripts/run-verus.sh
@@ -30,12 +30,12 @@ proof_files_for_group() {
     esac
 }
 
-PROOF_FILES=($(proof_files_for_group all))
+mapfile -t PROOF_FILES < <(proof_files_for_group all)
 
 if [ $# -gt 0 ] && [ "${1:0:1}" != "-" ]; then
     case "$1" in
         all|decomposition|clone-detector)
-            PROOF_FILES=($(proof_files_for_group "$1"))
+            mapfile -t PROOF_FILES < <(proof_files_for_group "$1")
             shift
             ;;
         *)

--- a/scripts/run-verus.sh
+++ b/scripts/run-verus.sh
@@ -5,14 +5,44 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
 VERUS_INSTALL_DIR=$("${SCRIPT_DIR}/install-verus.sh")
 VERUS_BIN="${VERUS_INSTALL_DIR}/verus"
-PROOF_FILES=(
-    "${REPO_ROOT}/verus/decomposition_cosine_threshold.rs"
-    "${REPO_ROOT}/verus/decomposition_vector_algebra.rs"
-)
+
+proof_files_for_group() {
+    case "$1" in
+        decomposition)
+            printf '%s\n' \
+                "${REPO_ROOT}/verus/decomposition_cosine_threshold.rs" \
+                "${REPO_ROOT}/verus/decomposition_vector_algebra.rs"
+            ;;
+        clone-detector)
+            printf '%s\n' \
+                "${REPO_ROOT}/verus/clone_detector_lsh_config.rs"
+            ;;
+        all)
+            printf '%s\n' \
+                "${REPO_ROOT}/verus/decomposition_cosine_threshold.rs" \
+                "${REPO_ROOT}/verus/decomposition_vector_algebra.rs" \
+                "${REPO_ROOT}/verus/clone_detector_lsh_config.rs"
+            ;;
+        *)
+            printf 'unknown Verus proof group: %s\n' "$1" >&2
+            exit 1
+            ;;
+    esac
+}
+
+PROOF_FILES=($(proof_files_for_group all))
 
 if [ $# -gt 0 ] && [ "${1:0:1}" != "-" ]; then
-    PROOF_FILES=("$1")
-    shift
+    case "$1" in
+        all|decomposition|clone-detector)
+            PROOF_FILES=($(proof_files_for_group "$1"))
+            shift
+            ;;
+        *)
+            PROOF_FILES=("$1")
+            shift
+            ;;
+    esac
 fi
 
 for proof_file in "${PROOF_FILES[@]}"; do

--- a/verus/clone_detector_lsh_config.rs
+++ b/verus/clone_detector_lsh_config.rs
@@ -1,0 +1,59 @@
+//! Verus proof for the `LshConfig::new` constructor contract.
+//!
+//! This module models the clone-detector LSH configuration boundary
+//! semantically: both dimensions must be positive and their product must equal
+//! the fixed MinHash sketch width of 128.
+
+use vstd::prelude::*;
+
+verus! {
+
+spec fn minhash_size() -> int {
+    128
+}
+
+spec fn lsh_config_accepts(bands: int, rows: int) -> bool {
+    bands > 0 && rows > 0 && bands * rows == minhash_size()
+}
+
+proof fn lemma_zero_bands_rejected(rows: int)
+    ensures
+        !lsh_config_accepts(0, rows),
+{
+}
+
+proof fn lemma_zero_rows_rejected(bands: int)
+    ensures
+        !lsh_config_accepts(bands, 0),
+{
+}
+
+proof fn lemma_exact_product_is_accepted()
+    ensures
+        lsh_config_accepts(32, 4),
+        lsh_config_accepts(1, 128),
+{
+    assert(lsh_config_accepts(32, 4)) by (compute);
+    assert(lsh_config_accepts(1, 128)) by (compute);
+}
+
+proof fn lemma_invalid_non_zero_product_is_rejected()
+    ensures
+        !lsh_config_accepts(16, 16),
+        !lsh_config_accepts(3, 42),
+{
+    assert(!lsh_config_accepts(16, 16)) by (compute);
+    assert(!lsh_config_accepts(3, 42)) by (compute);
+}
+
+proof fn lemma_acceptance_matches_documented_contract(bands: int, rows: int)
+    ensures
+        lsh_config_accepts(bands, rows)
+            <==> (bands > 0 && rows > 0 && bands * rows == minhash_size()),
+{
+}
+
+fn main() {
+}
+
+} // verus!

--- a/verus/clone_detector_lsh_config.rs
+++ b/verus/clone_detector_lsh_config.rs
@@ -1,56 +1,179 @@
 //! Verus proof for the `LshConfig::new` constructor contract.
 //!
-//! This module models the clone-detector LSH configuration boundary
-//! semantically: both dimensions must be positive and their product must equal
-//! the fixed MinHash sketch width of 128.
+//! This module mirrors the runtime branch structure in `LshConfig::new` and
+//! `validate_product`: reject zero bands first, reject zero rows second, and
+//! then accept only non-zero inputs whose `checked_mul` product is exactly the
+//! fixed MinHash sketch width of 128.
+//!
+//! The sidecar proof still does not verify the compiled Rust body directly.
+//! In the current repository setup, linking this file to the production
+//! function would require trusted Verus assumptions for external code. The
+//! proof therefore stays honest about its scope: it proves a faithful model of
+//! the constructor logic, while Kani executes the real implementation.
 
 use vstd::prelude::*;
 
 verus! {
 
-spec fn minhash_size() -> int {
-    128
+enum LshConfigOutcome {
+    Ok(nat, nat),
+    ZeroBands,
+    ZeroRows,
+    InvalidBandRowProduct(nat, nat),
 }
 
-spec fn lsh_config_accepts(bands: int, rows: int) -> bool {
-    bands > 0 && rows > 0 && bands * rows == minhash_size()
+spec fn minhash_size() -> nat {
+    128nat
 }
 
-proof fn lemma_zero_bands_rejected(rows: int)
+spec fn usize_max() -> nat {
+    usize::MAX as nat
+}
+
+spec fn checked_product(bands: nat, rows: nat) -> Option<nat> {
+    let product = bands * rows;
+    if product <= usize_max() {
+        Option::Some(product)
+    } else {
+        Option::None
+    }
+}
+
+spec fn validate_product_accepts(bands: nat, rows: nat) -> bool {
+    match checked_product(bands, rows) {
+        Option::Some(product) => product == minhash_size(),
+        Option::None => false,
+    }
+}
+
+spec fn lsh_config_new_result(bands: nat, rows: nat) -> LshConfigOutcome {
+    if bands == 0 {
+        LshConfigOutcome::ZeroBands
+    } else if rows == 0 {
+        LshConfigOutcome::ZeroRows
+    } else if validate_product_accepts(bands, rows) {
+        LshConfigOutcome::Ok(bands, rows)
+    } else {
+        LshConfigOutcome::InvalidBandRowProduct(bands, rows)
+    }
+}
+
+spec fn constructor_accepts(bands: nat, rows: nat) -> bool {
+    match lsh_config_new_result(bands, rows) {
+        LshConfigOutcome::Ok(_, _) => true,
+        _ => false,
+    }
+}
+
+proof fn lemma_minhash_size_fits_usize()
     ensures
-        !lsh_config_accepts(0, rows),
+        minhash_size() <= usize_max(),
+{
+    assert(minhash_size() == 128nat) by (compute);
+}
+
+proof fn lemma_zero_bands_rejected(rows: nat)
+    ensures
+        lsh_config_new_result(0, rows) == LshConfigOutcome::ZeroBands,
+        !constructor_accepts(0, rows),
 {
 }
 
-proof fn lemma_zero_rows_rejected(bands: int)
+proof fn lemma_zero_rows_rejected(bands: nat)
+    requires
+        bands > 0,
     ensures
-        !lsh_config_accepts(bands, 0),
+        lsh_config_new_result(bands, 0) == LshConfigOutcome::ZeroRows,
+        !constructor_accepts(bands, 0),
 {
 }
 
-proof fn lemma_exact_product_is_accepted()
+#[verifier::nonlinear]
+proof fn lemma_exact_product_is_accepted(bands: nat, rows: nat)
+    requires
+        bands > 0,
+        rows > 0,
+        bands * rows == minhash_size(),
     ensures
-        lsh_config_accepts(32, 4),
-        lsh_config_accepts(1, 128),
+        checked_product(bands, rows) == Option::Some(minhash_size()),
+        validate_product_accepts(bands, rows),
+        lsh_config_new_result(bands, rows) == LshConfigOutcome::Ok(bands, rows),
+        constructor_accepts(bands, rows),
 {
-    assert(lsh_config_accepts(32, 4)) by (compute);
-    assert(lsh_config_accepts(1, 128)) by (compute);
+    lemma_minhash_size_fits_usize();
+    assert(bands * rows <= usize_max());
+    assert(checked_product(bands, rows) == Option::Some(bands * rows));
+    assert(bands * rows == minhash_size());
 }
 
-proof fn lemma_invalid_non_zero_product_is_rejected()
+#[verifier::nonlinear]
+proof fn lemma_invalid_non_zero_product_is_rejected(bands: nat, rows: nat)
+    requires
+        bands > 0,
+        rows > 0,
+        bands * rows <= usize_max(),
+        bands * rows != minhash_size(),
     ensures
-        !lsh_config_accepts(16, 16),
-        !lsh_config_accepts(3, 42),
+        checked_product(bands, rows) == Option::Some(bands * rows),
+        !validate_product_accepts(bands, rows),
+        lsh_config_new_result(bands, rows)
+            == LshConfigOutcome::InvalidBandRowProduct(bands, rows),
+        !constructor_accepts(bands, rows),
 {
-    assert(!lsh_config_accepts(16, 16)) by (compute);
-    assert(!lsh_config_accepts(3, 42)) by (compute);
+    assert(checked_product(bands, rows) == Option::Some(bands * rows));
 }
 
-proof fn lemma_acceptance_matches_documented_contract(bands: int, rows: int)
+#[verifier::nonlinear]
+proof fn lemma_overflow_product_is_rejected(bands: nat, rows: nat)
+    requires
+        bands > 0,
+        rows > 0,
+        bands * rows > usize_max(),
     ensures
-        lsh_config_accepts(bands, rows)
+        checked_product(bands, rows) == Option::<nat>::None,
+        !validate_product_accepts(bands, rows),
+        lsh_config_new_result(bands, rows)
+            == LshConfigOutcome::InvalidBandRowProduct(bands, rows),
+        !constructor_accepts(bands, rows),
+{
+    assert(checked_product(bands, rows) == Option::<nat>::None);
+}
+
+#[verifier::nonlinear]
+proof fn lemma_acceptance_matches_runtime_contract(bands: nat, rows: nat)
+    ensures
+        constructor_accepts(bands, rows)
             <==> (bands > 0 && rows > 0 && bands * rows == minhash_size()),
 {
+    if bands == 0 {
+        lemma_zero_bands_rejected(rows);
+    } else if rows == 0 {
+        lemma_zero_rows_rejected(bands);
+    } else if bands * rows == minhash_size() {
+        lemma_exact_product_is_accepted(bands, rows);
+    } else if bands * rows <= usize_max() {
+        lemma_invalid_non_zero_product_is_rejected(bands, rows);
+    } else {
+        lemma_overflow_product_is_rejected(bands, rows);
+    }
+}
+
+proof fn lemma_documented_examples()
+    ensures
+        lsh_config_new_result(32, 4) == LshConfigOutcome::Ok(32, 4),
+        lsh_config_new_result(1, 128) == LshConfigOutcome::Ok(1, 128),
+        lsh_config_new_result(16, 16)
+            == LshConfigOutcome::InvalidBandRowProduct(16, 16),
+        lsh_config_new_result(3, 42)
+            == LshConfigOutcome::InvalidBandRowProduct(3, 42),
+        lsh_config_new_result(usize::MAX as nat, 2)
+            == LshConfigOutcome::InvalidBandRowProduct(usize::MAX as nat, 2),
+{
+    lemma_exact_product_is_accepted(32, 4);
+    lemma_exact_product_is_accepted(1, 128);
+    lemma_invalid_non_zero_product_is_rejected(16, 16);
+    lemma_invalid_non_zero_product_is_rejected(3, 42);
+    lemma_overflow_product_is_rejected(usize::MAX as nat, 2);
 }
 
 fn main() {


### PR DESCRIPTION
## Summary
- Adds a concrete Verus/Kani proof workflow for the clone-detector LSH invariants and accompanying tests; wires ExecPlan for 7.2.4/7.2.5 and updates documentation and tooling. This implements Stages B–I while preserving the runtime API.

## What this PR adds
- Verus proof: verus/clone_detector_lsh_config.rs (semantic model of LshConfig::new)
- Kani harness: crates/whitaker_clones_core/src/index/kani.rs (crate-private, bounded smoke harness)
- Proof tooling and wiring:
  - Makefile targets: verus-clone-detector, kani-clone-detector (in addition to existing verus and kani scaffolding)
  - Script scaffolding: scripts/install-kani.sh, scripts/run-kani.sh, scripts/run-verus.sh updated for grouped proof entry points
- ExecPlan documentation and wiring:
  - ExecPlan: docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
- Documentation and test surface:
  - Documentation updates: docs/whitaker-clone-detector-design.md, docs/roadmap.md updates, and docs/developers-guide.md
  - Tests: extended unit tests and BDD coverage in min_hash_lsh feature area (zero bands, zero rows, invalid product, overflow edge)
  - Feature tests updated to cover new edge cases
- Artefacts this plan creates:
  - Verus proof: verus/clone_detector_lsh_config.rs
  - Kani harness: crates/whitaker_clones_core/src/index/kani.rs
  - Makefile and scripts: verus and Kani targets, install/run helpers
  - ExecPlan: docs/execplans/7-2-4-verus-proofs-for-lsh-config-new-invariants.md
  - Documentation updates: docs/whitaker-clone-detector-design.md, docs/roadmap.md, docs/developers-guide.md updates
  - Tests: extended unit tests and BDD coverage in min_hash_lsh feature area

## Scope and constraints
- Strict focus on roadmap items 7.2.4 and 7.2.5. Do not mark 7.2.6–7.2.8 as done in this change.
- Proof tooling remains sidecar-based (Verus for semantic invariants; Kani for bounded checks) per ADR 002.
- Preserve the existing runtime API shape; only crate-private proof seams may be introduced if needed.
- Build on the existing clone-detector crate (`crates/whitaker_clones_core`). Do not move `LshConfig` into a separate crate.
- If Kani Harnesses use `#[cfg(kani)]`, register that cfg in the crate's `unexpected_cfgs` allowlist.
- Keep each Rust source file focused and importable; avoid large monolithic files.
- Workspace-wide lint/version constraints maintained (e.g., `rstest-bdd` version).

## Implementation plan (highlights)
- Stage B: Add clone-detector proof sidecar tooling and Makefile targets
  - Extend scripts/run-verus.sh to group proofs by domain (clone-detector group)
  - Add install-kani.sh and run-kani.sh for Kani harnesses
  - Update Makefile with verus-clone-detector and kani-clone-detector targets
- Stage C: Extend unit tests (ZeroBands, ZeroRows, InvalidBandRowProduct, overflow edge)
- Stage D: Extend rstest-bdd coverage for min_hash_lsh config outcomes
- Stage E: Add Verus proof for LshConfig::new (verus/clone_detector_lsh_config.rs)
- Stage F: Add minimal Kani smoke harness (crates/whitaker_clones_core/src/index/kani.rs)
- Stage G: Update clone-detector design/roadmap docs
- Stage H: Gatekeeping and quality checks (fmt, lint, tests, docs)
- Stage I: Finalize ExecPlan after implementation

## Validation plan (evidence to collect)
- Run gates:
  - make fmt, make markdownlint, make nixie
  - make verus-clone-detector
  - make kani-clone-detector
  - make check-fmt, make lint, make test
- Optional broader proof smoke: make verus, make kani

## Acceptance criteria
- The ExecPlan document is added and clearly references 7.2.4 and 7.2.5.
- Stage B–I milestones are defined and traceable in the plan.
- Provisions for new proof tooling, targets, and tests are described (without changing runtime API yet).
- Design decisions are captured in the ExecPlan and related docs updated.

## Rationale
This change provides a concrete path to Verus-based proofs for LshConfig::new with a minimal Kani smoke harness, preserving API stability and keeping proof tooling separate from normal cargo/test flows as guided by ADR 002 and the roadmap.

## Related guidance
- ADR 002 on proof-workflow separation (Verus for semantic invariants; Kani for bounded checks).
- Existing LshConfig runtime contract constraints: bands > 0, rows > 0, bands * rows == MINHASH_SIZE (128).

## Progress
- Stage A–I completed for this turn; gates to be re-run in CI.

## Surprises & Discoveries
- The repository already includes a pinned Verus sidecar workflow; Kani harnesses are introduced here as a first-stage smoke gate.

## Task
- https://www.devboxer.com/task/8141455b-138d-4d5c-becb-8d6a210ecbad