### PR TITLE
Refine module_has_harness_descriptor for accuracy

### DIFF
--- a/common/src/attributes/mod.rs
+++ b/common/src/attributes/mod.rs
@@ -15,6 +15,8 @@ pub(super) const TEST_LIKE_PATHS: &[&[&str]] = &[
     &["gpui", "test"],
     &["rstest"],
     &["rstest", "rstest"],
+    &["rstest_parametrize"],
+    &["rstest", "rstest_parametrize"],
     &["case"],
     &["rstest", "case"],
 ];

--- a/common/src/attributes/tests.rs
+++ b/common/src/attributes/tests.rs
@@ -57,6 +57,8 @@ fn path_is_doc(#[case] path: AttributePath, #[case] expected: bool) {
 #[case::gpui_test("gpui::test", true)]
 #[case::rstest("rstest", true)]
 #[case::rstest_qualified("rstest::rstest", true)]
+#[case::rstest_parametrize("rstest_parametrize", true)]
+#[case::rstest_parametrize_qualified("rstest::rstest_parametrize", true)]
 #[case::case_imported("case", true)]
 #[case::case_qualified("rstest::case", true)]
 #[case::core_prelude_test("core::prelude::v1::test", true)]

--- a/common/src/attributes/tests.rs
+++ b/common/src/attributes/tests.rs
@@ -59,6 +59,8 @@ fn path_is_doc(#[case] path: AttributePath, #[case] expected: bool) {
 #[case::rstest_qualified("rstest::rstest", true)]
 #[case::rstest_parametrize("rstest_parametrize", true)]
 #[case::rstest_parametrize_qualified("rstest::rstest_parametrize", true)]
+#[case::other_rstest_parametrize("other::rstest_parametrize", false)]
+#[case::global_rstest_parametrize("::rstest_parametrize", false)]
 #[case::case_imported("case", true)]
 #[case::case_qualified("rstest::case", true)]
 #[case::core_prelude_test("core::prelude::v1::test", true)]

--- a/crates/no_expect_outside_tests/examples/fail_expect_in_rstest_non_test_module.rs
+++ b/crates/no_expect_outside_tests/examples/fail_expect_in_rstest_non_test_module.rs
@@ -1,0 +1,28 @@
+//! Negative regression example for rstest harness detection.
+//!
+//! The real rstest expansion in this crate is covered by
+//! `pass_expect_in_rstest_harness`. This example keeps an unrelated same-named
+//! companion module next to ordinary code to ensure arbitrary const-only
+//! modules are not mistaken for rstest harness descriptors during `--test`
+//! builds.
+
+use rstest::rstest;
+
+#[allow(dead_code)]
+fn parse() {
+    let parsed = std::iter::once("value").next();
+    let _ = parsed.expect("ordinary code must not inherit rstest harness status");
+}
+
+#[allow(dead_code)]
+mod parse {
+    pub const VERSION: &str = "1";
+}
+
+#[rstest]
+#[case("value")]
+fn unrelated_rstest_harness(#[case] value: &str) {
+    assert_eq!(value, "value");
+}
+
+fn main() {}

--- a/crates/no_expect_outside_tests/examples/fail_expect_in_rstest_non_test_module.stderr
+++ b/crates/no_expect_outside_tests/examples/fail_expect_in_rstest_non_test_module.stderr
@@ -1,0 +1,12 @@
+error: Avoid calling expect on `std::option::Option<&str>` outside test-only code.
+  --> $DIR/fail_expect_in_rstest_non_test_module.rs:14:13
+   |
+LL |     let _ = parsed.expect("ordinary code must not inherit rstest harness status");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: The call originates within function `parse` which is not recognised as a test.
+   = help: Handle the `None` variant of `std::option::Option<&str>` or move the code into a test.
+   = note: requested on the command line with `-D no-expect-outside-tests`
+
+error: aborting due to 1 previous error
+

--- a/crates/no_expect_outside_tests/examples/pass_expect_in_rstest_harness.rs
+++ b/crates/no_expect_outside_tests/examples/pass_expect_in_rstest_harness.rs
@@ -1,0 +1,22 @@
+//! Regression example covering real `#[rstest]` test harness lowering for
+//! `no_expect_outside_tests`.
+//!
+//! The case-driven test exercises the proc-macro expansion shape that keeps the
+//! original function body separate from the generated harness descriptors.
+
+use rstest::rstest;
+
+#[rstest]
+fn pass_expect_in_plain_rstest_harness() {
+    let parsed = Some(1).expect("plain rstest functions should count as tests");
+    assert_eq!(parsed, 1);
+}
+
+#[rstest]
+#[case(1)]
+fn pass_expect_in_parametrized_rstest_harness(#[case] value: i32) {
+    let parsed = Some(value).expect("case-driven rstest functions should count as tests");
+    assert_eq!(parsed, 1);
+}
+
+fn main() {}

--- a/crates/no_expect_outside_tests/src/driver/mod.rs
+++ b/crates/no_expect_outside_tests/src/driver/mod.rs
@@ -282,7 +282,7 @@ fn collect_harness_marked_test_functions_in_group<'tcx>(
                 function_name,
                 function_span,
                 sibling,
-            )
+            ) || has_companion_test_module(cx, function_hir_id, function_name, sibling)
         }) {
             harness_marked.insert(function_hir_id);
         }
@@ -317,6 +317,36 @@ fn is_matching_harness_test_descriptor(
         && sibling.kind.ident().is_some_and(|ident| {
             ident.name == function_name && sibling.span.source_equal(function_span)
         })
+}
+
+fn has_companion_test_module<'tcx>(
+    cx: &LateContext<'tcx>,
+    function_hir_id: hir::HirId,
+    function_name: Symbol,
+    sibling: &'tcx hir::Item<'tcx>,
+) -> bool {
+    sibling.hir_id() != function_hir_id
+        && sibling
+            .kind
+            .ident()
+            .is_some_and(|ident| ident.name == function_name)
+        && matches!(sibling.kind, hir::ItemKind::Mod(..))
+        && module_has_harness_descriptor(cx, sibling)
+}
+
+fn module_has_harness_descriptor<'tcx>(
+    cx: &LateContext<'tcx>,
+    module_item: &'tcx hir::Item<'tcx>,
+) -> bool {
+    let hir::ItemKind::Mod(_, module) = module_item.kind else {
+        return false;
+    };
+
+    module
+        .item_ids
+        .iter()
+        .map(|item_id| cx.tcx.hir_item(*item_id))
+        .any(|item| matches!(item.kind, hir::ItemKind::Const(..)))
 }
 
 // Check if any attribute is #[test].

--- a/crates/no_expect_outside_tests/src/driver/mod.rs
+++ b/crates/no_expect_outside_tests/src/driver/mod.rs
@@ -342,11 +342,33 @@ fn module_has_harness_descriptor<'tcx>(
         return false;
     };
 
-    module
+    let items = module
         .item_ids
         .iter()
         .map(|item_id| cx.tcx.hir_item(*item_id))
-        .any(|item| matches!(item.kind, hir::ItemKind::Const(..)))
+        .collect::<Vec<_>>();
+
+    items
+        .iter()
+        .copied()
+        .filter(|item| matches!(item.kind, hir::ItemKind::Fn { .. }))
+        .any(|item| {
+            let Some(function_ident) = item.kind.ident() else {
+                return false;
+            };
+
+            let function_hir_id = item.hir_id();
+            let function_name = function_ident.name;
+            let function_span = item.span;
+            items.iter().copied().any(|sibling| {
+                is_matching_harness_test_descriptor(
+                    function_hir_id,
+                    function_name,
+                    function_span,
+                    sibling,
+                )
+            })
+        })
 }
 
 // Check if any attribute is #[test].

--- a/crates/no_expect_outside_tests/src/lib_ui_tests.rs
+++ b/crates/no_expect_outside_tests/src/lib_ui_tests.rs
@@ -2,21 +2,29 @@
 //! support beyond the basic `ui/` source fixtures.
 
 use dylint_testing::ui::Test;
+use rstest::rstest;
 use temp_env::with_vars_unset;
 use whitaker_common::test_support::{env_test_guard, run_test_runner};
 
-#[test]
-fn tokio_example_compiles_under_test_harness() {
+fn run_example_under_test_harness(example_name: &str, label: &str) {
+    run_example_under_test_harness_with_flags(example_name, label, &["--test"]);
+}
+
+fn run_example_under_test_harness_with_flags(
+    example_name: &str,
+    label: &str,
+    rustc_flags: &[&str],
+) {
     let crate_name = env!("CARGO_PKG_NAME");
     let directory = "examples";
     whitaker::testing::ui::run_with_runner(crate_name, directory, |crate_name, _| {
-        run_test_runner("pass_expect_in_tokio_test_harness", || {
+        run_test_runner(example_name, || {
             let _guard = env_test_guard();
             with_vars_unset(
                 ["RUSTC_WRAPPER", "RUSTC_WORKSPACE_WRAPPER", "CARGO_BUILD_RUSTC_WRAPPER"],
                 || {
-                    let mut test = Test::example(crate_name, "pass_expect_in_tokio_test_harness");
-                    test.rustc_flags(["--test"]);
+                    let mut test = Test::example(crate_name, example_name);
+                    test.rustc_flags(rustc_flags);
                     test.run();
                 },
             );
@@ -24,31 +32,23 @@ fn tokio_example_compiles_under_test_harness() {
     })
     .unwrap_or_else(|error| {
         panic!(
-            "Tokio example regression should execute without diffs: RunnerFailure {{ crate_name: \"{crate_name}\", directory: \"{directory}\", message: {error:?} }}"
+            "{label} example regression should execute without diffs: RunnerFailure {{ crate_name: \"{crate_name}\", directory: \"{directory}\", message: {error:?} }}"
         )
     });
 }
 
+#[rstest]
+#[case("pass_expect_in_tokio_test_harness", "Tokio")]
+#[case("pass_expect_in_rstest_harness", "rstest")]
+fn example_compiles_under_test_harness(#[case] example_name: &str, #[case] label: &str) {
+    run_example_under_test_harness(example_name, label);
+}
+
 #[test]
-fn rstest_example_compiles_under_test_harness() {
-    let crate_name = env!("CARGO_PKG_NAME");
-    let directory = "examples";
-    whitaker::testing::ui::run_with_runner(crate_name, directory, |crate_name, _| {
-        run_test_runner("pass_expect_in_rstest_harness", || {
-            let _guard = env_test_guard();
-            with_vars_unset(
-                ["RUSTC_WRAPPER", "RUSTC_WORKSPACE_WRAPPER", "CARGO_BUILD_RUSTC_WRAPPER"],
-                || {
-                    let mut test = Test::example(crate_name, "pass_expect_in_rstest_harness");
-                    test.rustc_flags(["--test"]);
-                    test.run();
-                },
-            );
-        })
-    })
-    .unwrap_or_else(|error| {
-        panic!(
-            "rstest example regression should execute without diffs: RunnerFailure {{ crate_name: \"{crate_name}\", directory: \"{directory}\", message: {error:?} }}"
-        )
-    });
+fn rstest_expect_outside_tests_still_fails_in_non_harness_code() {
+    run_example_under_test_harness_with_flags(
+        "fail_expect_in_rstest_non_test_module",
+        "rstest non-harness",
+        &["--test", "-D", "no_expect_outside_tests"],
+    );
 }

--- a/crates/no_expect_outside_tests/src/lib_ui_tests.rs
+++ b/crates/no_expect_outside_tests/src/lib_ui_tests.rs
@@ -28,3 +28,27 @@ fn tokio_example_compiles_under_test_harness() {
         )
     });
 }
+
+#[test]
+fn rstest_example_compiles_under_test_harness() {
+    let crate_name = env!("CARGO_PKG_NAME");
+    let directory = "examples";
+    whitaker::testing::ui::run_with_runner(crate_name, directory, |crate_name, _| {
+        run_test_runner("pass_expect_in_rstest_harness", || {
+            let _guard = env_test_guard();
+            with_vars_unset(
+                ["RUSTC_WRAPPER", "RUSTC_WORKSPACE_WRAPPER", "CARGO_BUILD_RUSTC_WRAPPER"],
+                || {
+                    let mut test = Test::example(crate_name, "pass_expect_in_rstest_harness");
+                    test.rustc_flags(["--test"]);
+                    test.run();
+                },
+            );
+        })
+    })
+    .unwrap_or_else(|error| {
+        panic!(
+            "rstest example regression should execute without diffs: RunnerFailure {{ crate_name: \"{crate_name}\", directory: \"{directory}\", message: {error:?} }}"
+        )
+    });
+}

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -306,10 +306,10 @@ Detect test attributes correctly so `no_expect_outside_tests` can allow
 
 Whitaker recognizes `#[test]`, prelude-qualified `#[test]` forms,
 `#[tokio::test]`, `#[async_std::test]`, `#[gpui::test]`, `#[rstest]`,
-`#[rstest::rstest]`, `#[case]`, and `#[rstest::case]` by default. The
-`additional_test_attributes` setting extends that matching list with
-project-specific markers, so the lint treats those annotated functions as tests
-too.
+`#[rstest::rstest]`, `#[rstest_parametrize]`, `#[rstest::rstest_parametrize]`,
+`#[case]`, and `#[rstest::case]` by default. The `additional_test_attributes`
+setting extends that matching list with project-specific markers, so the lint
+treats those annotated functions as tests too.
 
 #### Configuration
 
@@ -326,8 +326,8 @@ for example `my_framework::test` or `wasm_bindgen_test`.
 
 - Default markers such as `#[test]`, `#[::test]`,
   `#[::std::prelude::v1::test]`, `#[tokio::test]`, `#[async_std::test]`,
-  `#[gpui::test]`, `#[rstest]`, `#[rstest::rstest]`, `#[case]`, and
-  `#[rstest::case]`
+  `#[gpui::test]`, `#[rstest]`, `#[rstest::rstest]`, `#[rstest_parametrize]`,
+  `#[rstest::rstest_parametrize]`, `#[case]`, and `#[rstest::case]`
 - Project-specific markers listed in `additional_test_attributes`, such as
   `#[wasm_bindgen_test]`
 
@@ -344,7 +344,8 @@ not in Whitaker's default list and is not listed in
 - Change the attribute usage to a recognized form such as `#[test]`,
   `#[::test]`, `#[::std::prelude::v1::test]`, `#[tokio::test]`,
   `#[async_std::test]`, `#[gpui::test]`, `#[rstest]`, `#[rstest::rstest]`,
-  `#[case]`, or `#[rstest::case]` where appropriate
+  `#[rstest_parametrize]`, `#[rstest::rstest_parametrize]`, `#[case]`, or
+  `#[rstest::case]` where appropriate
 - If the function is not test-only code, replace `.expect()` with explicit error
   handling such as `?` or `map_err`
 


### PR DESCRIPTION
## Summary
- Extend test-like attribute detection to include rstest_parametrize and qualified forms
- Add regression example and harness-detection logic to ensure rstest harness is treated as tests by no_expect_outside_tests
- Add UI test to verify rstest example compiles under test harness

## Changes

### Attributes detection
- Update common/src/attributes/mod.rs TEST_LIKE_PATHS to include:
  - `&["rstest_parametrize"]`
  - `&["rstest", "rstest_parametrize"]`

### Tests
- Extend common/src/attributes/tests.rs to cover:
  - `#[case::rstest_parametrize("rstest_parametrize", true)]`
  - `#[case::rstest_parametrize_qualified("rstest::rstest_parametrize", true)]`

### Regression examples
- Add new example demonstrating rstest harness behavior:
  - crates/no_expect_outside_tests/examples/pass_expect_in_rstest_harness.rs
  - Shows pass expectations inside plain rstest harness and parametrized harness cases

### Harness integration
- Enhance no_expect_outside_tests driver (crates/no_expect_outside_tests/src/driver/mod.rs) with:
  - `has_companion_test_module` to detect companion modules that share the same name as the test function
  - `module_has_harness_descriptor` to detect a module containing a harness descriptor (via a const)
- Reason: treat companion modules that host rstest harness descriptors as test sources for no-expect-outside-tests

### UI tests
- Add UI regression test (crates/no_expect_outside_tests/src/lib_ui_tests.rs) to ensure rstest example compiles under the test harness:
  - `rstest_example_compiles_under_test_harness` runs the example in a controlled environment and asserts no diffs

## Example
- New regression example file added:
  - crates/no_expect_outside_tests/examples/pass_expect_in_rstest_harness.rs
  - Includes usage of `#[rstest]` and `#[case(...)]` to demonstrate harness lowering without emitting no-expect failures

## Test plan
- [x] Build and run no-expect-outside-tests with rstest_parametrize attributes
- [x] Validate the new tests for rstest_parametrize paths are recognized as test-like
- [x] Ensure the new harness regression example compiles under the test harness
- [x] Verify UI test coverage for the rstest harness regression scenario



📎 **Task**: https://www.devboxer.com/task/782a58b1-c776-4074-984f-e68331b391a4