### PR TITLE
Declare explicit installer binaries and add workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -61,6 +61,73 @@ make check-fmt  # Verify formatting
 make fmt        # Apply formatting
 ```
 
+## Installer release helper binaries
+
+The `whitaker-installer` crate exposes several internal release-helper binaries
+used by GitHub workflows and packaging scripts. These are part of the build
+contract even though they are not user-facing CLI entry points.
+
+### Why `autobins = false` is required
+
+`installer/Cargo.toml` sets `autobins = false` and declares every binary target
+explicitly. This is required because the release workflows invoke specific bin
+names that do not always match Cargo's filename-derived defaults.
+
+Current explicit targets:
+
+- `whitaker-installer` from `src/main.rs`
+- `whitaker-package-lints` from `src/bin/package_lints.rs`
+- `whitaker-package-installer` from `src/bin/package_installer_bin.rs`
+- `whitaker-package-dependency-binary` from
+  `src/bin/package_dependency_binary.rs`
+
+Without explicit declarations, Cargo would infer fallback names such as
+`package_lints` and `package_installer_bin`. Those names do not match the
+workflow invocations, so release and rolling-release builds would fail even
+though the source files exist.
+
+### Validation coverage and purpose
+
+Workflow validation in `tests/workflows/` protects this contract from drift:
+
+- `test_installer_packaging_bins_match_release_workflow_contract` asserts that
+  the workflow-facing binary names exist in workspace metadata.
+- The same test also asserts that filename-derived fallback target names are
+  absent, proving the crate still relies on explicit target declarations rather
+  than accidental Cargo defaults.
+- `workflow_test_helpers.py` centralizes the `cargo metadata --no-deps` lookup
+  used by these contract tests so packaging changes fail with one clear error
+  path.
+
+When modifying release helpers, keep the workflow YAML, `installer/Cargo.toml`,
+and the metadata-based tests in lock-step.
+
+### Worked example: adding another packaging binary
+
+When adding a new internal helper binary, make all of the following changes in
+one patch:
+
+1. Add the Rust entry point under `installer/src/bin/`.
+2. Add a matching `[[bin]]` stanza in `installer/Cargo.toml`.
+3. Keep `autobins = false` so Cargo does not expose unexpected fallback names.
+4. Update any workflow or script that invokes the helper to use the explicit
+   bin name.
+5. Extend the workflow contract test so the new target is asserted alongside
+   the existing helpers.
+
+Example `Cargo.toml` entry:
+
+```toml
+[[bin]]
+name = "whitaker-package-example"
+path = "src/bin/package_example.rs"
+```
+
+If the workflow should invoke that helper, add an assertion to
+`test_installer_packaging_bins_match_release_workflow_contract` before relying
+on it in release automation. That keeps the breakage in unit-style Python tests
+instead of the rolling-release pipeline.
+
 ## Dependency binary packaging
 
 Whitaker publishes repository-hosted copies of `cargo-dylint` and `dylint-link`

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -8,6 +8,19 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true
+autobins = false
+
+[[bin]]
+name = "whitaker-installer"
+path = "src/main.rs"
+
+[[bin]]
+name = "whitaker-package-lints"
+path = "src/bin/package_lints.rs"
+
+[[bin]]
+name = "whitaker-package-installer"
+path = "src/bin/package_installer_bin.rs"
 
 [[bin]]
 name = "whitaker-package-dependency-binary"

--- a/installer/tests/behaviour_docs.rs
+++ b/installer/tests/behaviour_docs.rs
@@ -74,7 +74,7 @@ fn given_revision_pinning_metadata(toml_world: &TomlWorld) {
 
 #[given("a workspace metadata example with pre-built path")]
 fn given_prebuilt_path_metadata(toml_world: &TomlWorld) {
-    let block = find_block_containing("path = ");
+    let block = find_block_containing("/whitaker/lints/");
     set_toml_content(toml_world, &block);
 }
 

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -35,6 +35,7 @@ from tests.workflows.workflow_test_helpers import (
     install_components_script,
     lint_crates_from_resolution_constants,
     lint_crates_from_workflow,
+    package_binary_target_names,
     run_act_build_lints,
     workflow_runtime_is_ready,
     workspace_package_names,
@@ -62,6 +63,28 @@ def test_workflow_lint_crates_match_installer_constants() -> None:
         "rolling-release workflow LINT_CRATES drifted from installer constants:\n"
         f"workflow={workflow_crates}\n"
         f"installer={canonical_crates}"
+    )
+
+
+def test_installer_packaging_bins_match_release_workflow_contract() -> None:
+    """Ensure workflow-invoked packaging helpers are real Cargo bin targets."""
+    binary_targets = package_binary_target_names("whitaker-installer")
+
+    assert "whitaker-package-lints" in binary_targets, (
+        "rolling-release workflow builds --bin whitaker-package-lints, but the "
+        "installer package does not declare that binary target"
+    )
+    assert "whitaker-package-installer" in binary_targets, (
+        "release workflow builds --bin whitaker-package-installer, but the "
+        "installer package does not declare that binary target"
+    )
+    assert "package_lints" not in binary_targets, (
+        "installer packaging bins must use the workflow-facing target name, "
+        "not the source filename-derived fallback"
+    )
+    assert "package_installer_bin" not in binary_targets, (
+        "installer packaging bins must use the workflow-facing target name, "
+        "not the source filename-derived fallback"
     )
 
 

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -70,6 +70,10 @@ def test_installer_packaging_bins_match_release_workflow_contract() -> None:
     """Ensure workflow-invoked packaging helpers are real Cargo bin targets."""
     binary_targets = package_binary_target_names("whitaker-installer")
 
+    assert "whitaker-installer" in binary_targets, (
+        "installer package must expose primary whitaker-installer binary target "
+        "to satisfy release workflow contract"
+    )
     assert "whitaker-package-lints" in binary_targets, (
         "rolling-release workflow builds --bin whitaker-package-lints, but the "
         "installer package does not declare that binary target"

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -82,6 +82,11 @@ def test_installer_packaging_bins_match_release_workflow_contract() -> None:
         "release workflow builds --bin whitaker-package-installer, but the "
         "installer package does not declare that binary target"
     )
+    assert "whitaker-package-dependency-binary" in binary_targets, (
+        "release and rolling-release workflows build --bin "
+        "whitaker-package-dependency-binary, but the installer package does "
+        "not declare that binary target"
+    )
     assert "package_lints" not in binary_targets, (
         "installer packaging bins must use the workflow-facing target name, "
         "not the source filename-derived fallback"

--- a/tests/workflows/test_workflow_test_helpers.py
+++ b/tests/workflows/test_workflow_test_helpers.py
@@ -1,0 +1,166 @@
+"""Unit tests for workflow test helper metadata lookups.
+
+This module exercises the private Cargo metadata helpers directly so workflow
+contract tests fail with clear messages when metadata resolution changes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from tests.workflows import workflow_test_helpers
+
+
+class TestCargoMetadata:
+    """Tests for `_cargo_metadata()` error handling and edge cases."""
+
+    def test_requires_cargo_on_path(self) -> None:
+        """The helper fails fast when `cargo` cannot be resolved."""
+        with (
+            patch.object(workflow_test_helpers.shutil, "which", return_value=None),
+            pytest.raises(
+                AssertionError,
+                match="cargo executable must be available in PATH",
+            ),
+        ):
+            workflow_test_helpers._cargo_metadata()
+
+    def test_reports_subprocess_failure(self) -> None:
+        """The helper surfaces `cargo metadata` stderr on failure."""
+        completed = subprocess.CompletedProcess(
+            args=["/usr/bin/cargo", "metadata"],
+            returncode=1,
+            stdout="",
+            stderr="metadata broke",
+        )
+
+        with (
+            patch.object(
+                workflow_test_helpers.shutil, "which", return_value="/usr/bin/cargo"
+            ),
+            patch.object(
+                workflow_test_helpers.subprocess, "run", return_value=completed
+            ),
+            pytest.raises(
+                AssertionError,
+                match="cargo metadata failed while resolving workspace metadata",
+            ),
+        ):
+            workflow_test_helpers._cargo_metadata()
+
+    @pytest.mark.parametrize(
+        ("stdout", "expected_type_name"),
+        [
+            (json.dumps([]), "list"),
+            (json.dumps("workspace"), "str"),
+        ],
+        ids=["json-list", "json-string"],
+    )
+    def test_rejects_non_mapping_json(
+        self, stdout: str, expected_type_name: str
+    ) -> None:
+        """The helper accepts only object-shaped `cargo metadata` output."""
+        completed = subprocess.CompletedProcess(
+            args=["/usr/bin/cargo", "metadata"],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+
+        with (
+            patch.object(
+                workflow_test_helpers.shutil, "which", return_value="/usr/bin/cargo"
+            ),
+            patch.object(
+                workflow_test_helpers.subprocess, "run", return_value=completed
+            ),
+            pytest.raises(
+                AssertionError,
+                match="cargo metadata must return a JSON object",
+            ),
+        ):
+            workflow_test_helpers._cargo_metadata()
+
+        parsed = json.loads(stdout)
+        assert type(parsed).__name__ == expected_type_name
+
+    def test_returns_parsed_workspace_metadata(self) -> None:
+        """The helper returns parsed JSON for successful metadata calls."""
+        payload = {"packages": [{"name": "whitaker-installer"}]}
+        completed = subprocess.CompletedProcess(
+            args=["/usr/bin/cargo", "metadata"],
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+        with (
+            patch.object(
+                workflow_test_helpers.shutil, "which", return_value="/usr/bin/cargo"
+            ),
+            patch.object(
+                workflow_test_helpers.subprocess, "run", return_value=completed
+            ) as run_mock,
+        ):
+            metadata = workflow_test_helpers._cargo_metadata()
+
+        assert metadata == payload
+        run_mock.assert_called_once_with(
+            ["/usr/bin/cargo", "metadata", "--format-version", "1", "--no-deps"],
+            cwd=workflow_test_helpers.REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=workflow_test_helpers.CARGO_METADATA_TIMEOUT_SECONDS,
+        )
+
+
+class TestWorkspacePackageMetadata:
+    """Tests for `_workspace_package_metadata()` lookups."""
+
+    @pytest.mark.parametrize(
+        ("return_value", "expected_match"),
+        [
+            (
+                {"packages": "not-a-list"},
+                "cargo metadata must include a packages list",
+            ),
+            (
+                {"packages": [{"name": "whitaker-common"}]},
+                "workspace package 'whitaker-installer' is missing",
+            ),
+        ],
+        ids=["non-list-packages", "missing-package"],
+    )
+    def test_rejects_invalid_metadata(
+        self, return_value: dict, expected_match: str
+    ) -> None:
+        """The helper rejects non-list packages and absent package names."""
+        with (
+            patch.object(
+                workflow_test_helpers, "_cargo_metadata", return_value=return_value
+            ),
+            pytest.raises(AssertionError, match=expected_match),
+        ):
+            workflow_test_helpers._workspace_package_metadata("whitaker-installer")
+
+    def test_returns_matching_package_and_ignores_non_dict_entries(self) -> None:
+        """The helper skips malformed entries and returns the matching package."""
+        package = {
+            "name": "whitaker-installer",
+            "targets": [{"name": "whitaker-installer", "kind": ["bin"]}],
+        }
+        with patch.object(
+            workflow_test_helpers,
+            "_cargo_metadata",
+            return_value={"packages": ["invalid", {"name": 42}, package]},
+        ):
+            metadata = workflow_test_helpers._workspace_package_metadata(
+                "whitaker-installer"
+            )
+
+        assert metadata == package

--- a/tests/workflows/test_workflow_test_helpers.py
+++ b/tests/workflows/test_workflow_test_helpers.py
@@ -86,7 +86,10 @@ class TestCargoMetadata:
             workflow_test_helpers._cargo_metadata()
 
         parsed = json.loads(stdout)
-        assert type(parsed).__name__ == expected_type_name
+        assert type(parsed).__name__ == expected_type_name, (
+            f"parsed type {type(parsed).__name__} != expected "
+            f"{expected_type_name}"
+        )
 
     def test_returns_parsed_workspace_metadata(self) -> None:
         """The helper returns parsed JSON for successful metadata calls."""
@@ -108,7 +111,9 @@ class TestCargoMetadata:
         ):
             metadata = workflow_test_helpers._cargo_metadata()
 
-        assert metadata == payload
+        assert metadata == payload, (
+            f"metadata {metadata!r} != payload {payload!r}"
+        )
         run_mock.assert_called_once_with(
             ["/usr/bin/cargo", "metadata", "--format-version", "1", "--no-deps"],
             cwd=workflow_test_helpers.REPO_ROOT,
@@ -137,7 +142,7 @@ class TestWorkspacePackageMetadata:
         ids=["non-list-packages", "missing-package"],
     )
     def test_rejects_invalid_metadata(
-        self, return_value: dict, expected_match: str
+        self, return_value: dict[str, object], expected_match: str
     ) -> None:
         """The helper rejects non-list packages and absent package names."""
         with (
@@ -163,4 +168,6 @@ class TestWorkspacePackageMetadata:
                 "whitaker-installer"
             )
 
-        assert metadata == package
+        assert metadata == package, (
+            f"metadata {metadata!r} != package {package!r}"
+        )

--- a/tests/workflows/workflow_test_helpers.py
+++ b/tests/workflows/workflow_test_helpers.py
@@ -48,7 +48,7 @@ def _cargo_metadata() -> dict[str, object]:
     cargo_executable = shutil.which("cargo")
     assert cargo_executable is not None, "cargo executable must be available in PATH"
 
-    completed = subprocess.run(  # noqa: S603  # FIXME: uses trusted test-only tool
+    completed = subprocess.run(  # noqa: S603  # FIXME: https://github.com/leynos/whitaker/issues/101 uses trusted test-only tool
         [cargo_executable, "metadata", "--format-version", "1", "--no-deps"],
         cwd=REPO_ROOT,
         check=False,
@@ -335,7 +335,7 @@ def run_act_build_lints(*, artefact_dir: Path) -> tuple[int, str]:
         "--env",
         f"LINT_CRATES={lint_crates}",
     ]
-    completed = subprocess.run(  # noqa: S603,S607  # FIXME: uses trusted test-only PATH-resolved tool
+    completed = subprocess.run(  # noqa: S603,S607  # FIXME: https://github.com/leynos/whitaker/issues/101 uses trusted test-only PATH-resolved tool
         command,
         cwd=REPO_ROOT,
         check=False,
@@ -359,7 +359,7 @@ def workflow_runtime_is_ready() -> bool:
     if shutil.which("act") is None:
         return False
 
-    completed = subprocess.run(  # noqa: S603,S607  # FIXME: uses trusted test-only PATH-resolved tool
+    completed = subprocess.run(  # noqa: S603,S607  # FIXME: https://github.com/leynos/whitaker/issues/101 uses trusted test-only PATH-resolved tool
         [
             "act",
             "workflow_dispatch",

--- a/tests/workflows/workflow_test_helpers.py
+++ b/tests/workflows/workflow_test_helpers.py
@@ -43,6 +43,50 @@ ACT_LIST_TIMEOUT_SECONDS = 60
 ACT_RUN_TIMEOUT_SECONDS = 900
 
 
+def _cargo_metadata() -> dict[str, object]:
+    """Return parsed workspace metadata from `cargo metadata --no-deps`.
+
+    Returns
+    -------
+    dict[str, object]
+        Parsed metadata mapping emitted by Cargo.
+    """
+    completed = subprocess.run(  # noqa: S603,S607  # FIXME: uses trusted test-only PATH-resolved tool
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=CARGO_METADATA_TIMEOUT_SECONDS,
+    )
+    assert completed.returncode == 0, (
+        "cargo metadata failed while resolving workspace metadata:\n"
+        f"{completed.stderr}"
+    )
+
+    metadata = json.loads(completed.stdout)
+    assert isinstance(metadata, dict), "cargo metadata must return a JSON object"
+    return metadata
+
+
+def _workspace_package_metadata(package_name: str) -> dict[str, object]:
+    """Return Cargo metadata for a named workspace package."""
+    metadata = _cargo_metadata()
+    packages = metadata.get("packages")
+    assert isinstance(packages, list), "cargo metadata must include a packages list"
+
+    package = next(
+        (
+            package
+            for package in packages
+            if isinstance(package, dict) and package.get("name") == package_name
+        ),
+        None,
+    )
+    assert package is not None, f"workspace package '{package_name}' is missing"
+    return package
+
+
 def _find_lint_crates_value(parsed: dict[str, object]) -> str | list[str] | None:
     """Return the raw `LINT_CRATES` value from workflow or build-lints env."""
     workflow_env = None
@@ -197,20 +241,14 @@ def workspace_package_names() -> set[str]:
     set[str]
         Package names reported by `cargo metadata --no-deps`.
     """
-    completed = subprocess.run(  # noqa: S603,S607  # FIXME: uses trusted test-only PATH-resolved tool
-        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
-        cwd=REPO_ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=CARGO_METADATA_TIMEOUT_SECONDS,
-    )
-    assert completed.returncode == 0, (
-        "cargo metadata failed while resolving workspace packages:\n"
-        f"{completed.stderr}"
-    )
-    metadata = json.loads(completed.stdout)
-    return {package["name"] for package in metadata["packages"]}
+    metadata = _cargo_metadata()
+    packages = metadata.get("packages")
+    assert isinstance(packages, list), "cargo metadata must include a packages list"
+    return {
+        package["name"]
+        for package in packages
+        if isinstance(package, dict) and isinstance(package.get("name"), str)
+    }
 
 
 def package_binary_target_names(package_name: str) -> set[str]:
@@ -236,32 +274,17 @@ def package_binary_target_names(package_name: str) -> set[str]:
     >>> "whitaker-installer" in package_binary_target_names("whitaker-installer")
     True
     """
-    completed = subprocess.run(  # noqa: S603,S607  # FIXME: uses trusted test-only PATH-resolved tool
-        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
-        cwd=REPO_ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=CARGO_METADATA_TIMEOUT_SECONDS,
+    package = _workspace_package_metadata(package_name)
+    targets = package.get("targets")
+    assert isinstance(targets, list), (
+        f"workspace package '{package_name}' must include a targets list"
     )
-    assert completed.returncode == 0, (
-        "cargo metadata failed while resolving package binary targets:\n"
-        f"{completed.stderr}"
-    )
-    metadata = json.loads(completed.stdout)
-    package = next(
-        (
-            package
-            for package in metadata["packages"]
-            if package["name"] == package_name
-        ),
-        None,
-    )
-    assert package is not None, f"workspace package '{package_name}' is missing"
     return {
         target["name"]
-        for target in package["targets"]
-        if "bin" in target["kind"]
+        for target in targets
+        if isinstance(target, dict)
+        and isinstance(target.get("name"), str)
+        and target.get("kind") == ["bin"]
     }
 
 

--- a/tests/workflows/workflow_test_helpers.py
+++ b/tests/workflows/workflow_test_helpers.py
@@ -213,6 +213,58 @@ def workspace_package_names() -> set[str]:
     return {package["name"] for package in metadata["packages"]}
 
 
+def package_binary_target_names(package_name: str) -> set[str]:
+    """Return explicit Cargo binary target names for a workspace package.
+
+    Parameters
+    ----------
+    package_name : str
+        Cargo package name to inspect in workspace metadata.
+
+    Returns
+    -------
+    set[str]
+        Binary target names declared for the package.
+
+    Raises
+    ------
+    AssertionError
+        Raised when Cargo metadata fails or the package is missing.
+
+    Examples
+    --------
+    >>> "whitaker-installer" in package_binary_target_names("whitaker-installer")
+    True
+    """
+    completed = subprocess.run(  # noqa: S603,S607  # FIXME: uses trusted test-only PATH-resolved tool
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=CARGO_METADATA_TIMEOUT_SECONDS,
+    )
+    assert completed.returncode == 0, (
+        "cargo metadata failed while resolving package binary targets:\n"
+        f"{completed.stderr}"
+    )
+    metadata = json.loads(completed.stdout)
+    package = next(
+        (
+            package
+            for package in metadata["packages"]
+            if package["name"] == package_name
+        ),
+        None,
+    )
+    assert package is not None, f"workspace package '{package_name}' is missing"
+    return {
+        target["name"]
+        for target in package["targets"]
+        if "bin" in target["kind"]
+    }
+
+
 def run_act_build_lints(*, artefact_dir: Path) -> tuple[int, str]:
     """Run the workflow `build-lints` job through `act`.
 

--- a/tests/workflows/workflow_test_helpers.py
+++ b/tests/workflows/workflow_test_helpers.py
@@ -44,15 +44,12 @@ ACT_RUN_TIMEOUT_SECONDS = 900
 
 
 def _cargo_metadata() -> dict[str, object]:
-    """Return parsed workspace metadata from `cargo metadata --no-deps`.
+    """Return parsed workspace metadata from `cargo metadata --no-deps`."""
+    cargo_executable = shutil.which("cargo")
+    assert cargo_executable is not None, "cargo executable must be available in PATH"
 
-    Returns
-    -------
-    dict[str, object]
-        Parsed metadata mapping emitted by Cargo.
-    """
-    completed = subprocess.run(  # noqa: S603,S607  # FIXME: uses trusted test-only PATH-resolved tool
-        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+    completed = subprocess.run(  # noqa: S603  # FIXME: uses trusted test-only tool
+        [cargo_executable, "metadata", "--format-version", "1", "--no-deps"],
         cwd=REPO_ROOT,
         check=False,
         capture_output=True,


### PR DESCRIPTION
## Summary
- Align installer packaging binaries with the rolling-release workflow by declaring explicit binary targets and updating tests to validate them.

## Changes
- installer/Cargo.toml
  - Declared explicit binaries to match workflow expectations:
    - whitaker-installer (path = "src/main.rs")
    - whitaker-package-lints (path = "src/bin/package_lints.rs")
    - whitaker-package-installer (path = "src/bin/package_installer_bin.rs")
- tests/workflows/test_rolling_release_workflow.py
  - Imported `package_binary_target_names(package_name)` and added
    `test_installer_packaging_bins_match_release_workflow_contract` to ensure
    packaging bins align with the workflow contract:
      - Verifies `whitaker-package-lints` and `whitaker-package-installer` appear in the binary targets for `whitaker-installer`.
      - Ensures fallback names `package_lints` and `package_installer_bin` are not used.
- tests/workflows/workflow_test_helpers.py
  - Added `package_binary_target_names(package_name)` to derive explicit Cargo binary target names for a workspace package via `cargo metadata`.
- tests/workflows/test_workflow_test_helpers.py
  - New file containing unit tests for cargo-metadata helpers used by workflow tests.
- docs/developers-guide.md
  - Expanded installer release helper binaries section to document explicit binary targets, why autobins = false is required, and how workflow contract tests validate these targets. Includes worked example and guidance for adding new binaries.
- installer/tests/behaviour_docs.rs
  - Updated prebuilt-path handling to reflect workspace structure changes (new explicit binary targets and location expectations).

## Why
- Prevents build/test failures caused by mismatches between expected packaging binaries in CI/workflows and the actual Cargo targets declared in the installer crate.
- Ensures the packaging workflow uses well-defined, workflow-facing binary targets rather than source-derived fallback names.

## How to test
- Run the workflow tests for packaging binaries and metadata resolution:
  - Ensure `cargo metadata` returns bin targets for the `whitaker-installer` package that include:
    - `whitaker-installer`, `whitaker-package-lints`, `whitaker-package-installer`.
  - Confirm the tests in `tests/workflows/test_rolling_release_workflow.py` pass with the new contract.

## Additional notes
- This change is additive and only affects build/packaging metadata and tests; runtime behavior remains unchanged.
- No user-facing configuration changes.


📎 **Task**: https://www.devboxer.com/task/ade4b7ad-b1d1-40cb-9141-2e89550f891e