### PR TITLE
Complete: Shared user-editable span recovery helpers (8.1.2)

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -56,7 +56,8 @@ pub use lcom4::{MethodInfo, MethodInfoBuilder, cohesion_components, collect_meth
 pub use path::SimplePath;
 pub use rstest::{
     ExpansionTrace, ParameterBinding, RstestDetectionOptions, RstestParameter, RstestParameterKind,
-    classify_rstest_parameter, fixture_local_names, is_rstest_fixture, is_rstest_fixture_with,
-    is_rstest_test, is_rstest_test_with,
+    SpanRecoveryFrame, UserEditableSpan, classify_rstest_parameter, fixture_local_names,
+    is_rstest_fixture, is_rstest_fixture_with, is_rstest_test, is_rstest_test_with,
+    recover_user_editable_span,
 };
 pub use span::{SourceLocation, SourceSpan, SpanError, span_line_count, span_to_lines};

--- a/common/src/rstest/mod.rs
+++ b/common/src/rstest/mod.rs
@@ -1,4 +1,13 @@
-//! Shared helpers for strict `rstest` test, fixture, and parameter detection.
+//! Shared helpers for strict `rstest` detection, parameter analysis, and span
+//! recovery.
+//!
+//! The module exports detection helpers such as [`ExpansionTrace`],
+//! [`RstestDetectionOptions`], [`is_rstest_fixture`], and [`is_rstest_test`];
+//! parameter helpers such as [`ParameterBinding`], [`RstestParameter`],
+//! [`RstestParameterKind`], [`classify_rstest_parameter`], and
+//! [`fixture_local_names`]; and span-recovery helpers such as
+//! [`SpanRecoveryFrame`], [`UserEditableSpan`], and
+//! [`recover_user_editable_span`].
 
 mod detection;
 mod parameter;

--- a/common/src/rstest/mod.rs
+++ b/common/src/rstest/mod.rs
@@ -2,6 +2,7 @@
 
 mod detection;
 mod parameter;
+mod span;
 
 pub use detection::{
     ExpansionTrace, RstestDetectionOptions, is_rstest_fixture, is_rstest_fixture_with,
@@ -11,6 +12,7 @@ pub use parameter::{
     ParameterBinding, RstestParameter, RstestParameterKind, classify_rstest_parameter,
     fixture_local_names,
 };
+pub use span::{SpanRecoveryFrame, UserEditableSpan, recover_user_editable_span};
 
 #[cfg(test)]
 mod tests;

--- a/common/src/rstest/span.rs
+++ b/common/src/rstest/span.rs
@@ -1,0 +1,125 @@
+//! Pure helpers for recovering user-editable spans from macro-heavy frame chains.
+
+/// A single span-recovery frame and whether it still comes from macro expansion.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpanRecoveryFrame<T> {
+    value: T,
+    from_expansion: bool,
+}
+
+impl<T> SpanRecoveryFrame<T> {
+    /// Builds a recovery frame from a value and expansion flag.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whitaker_common::rstest::SpanRecoveryFrame;
+    /// use whitaker_common::span::{SourceLocation, SourceSpan};
+    ///
+    /// let span = SourceSpan::new(SourceLocation::new(3, 1), SourceLocation::new(3, 8))
+    ///     .expect("example span should be valid");
+    /// let frame = SpanRecoveryFrame::new(span, true);
+    ///
+    /// assert!(frame.from_expansion());
+    /// ```
+    #[must_use]
+    pub const fn new(value: T, from_expansion: bool) -> Self {
+        Self {
+            value,
+            from_expansion,
+        }
+    }
+
+    /// Returns the stored frame value.
+    #[must_use]
+    pub const fn value(&self) -> &T {
+        &self.value
+    }
+
+    /// Consumes the frame and returns the stored value.
+    #[must_use]
+    pub fn into_value(self) -> T {
+        self.value
+    }
+
+    /// Returns whether the frame still originates from macro expansion.
+    #[must_use]
+    pub const fn from_expansion(&self) -> bool {
+        self.from_expansion
+    }
+}
+
+/// The result of recovering a user-editable span from an ordered frame chain.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UserEditableSpan<T> {
+    /// The original frame was already user-editable.
+    Direct(T),
+    /// A later frame recovered a user-editable span.
+    Recovered(T),
+    /// No frame in the chain pointed at user-editable code.
+    MacroOnly,
+}
+
+impl<T> UserEditableSpan<T> {
+    /// Converts the recovery result into an optional recovered value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use whitaker_common::rstest::UserEditableSpan;
+    /// use whitaker_common::span::{SourceLocation, SourceSpan};
+    ///
+    /// let span = SourceSpan::new(SourceLocation::new(5, 1), SourceLocation::new(5, 7))
+    ///     .expect("example span should be valid");
+    ///
+    /// assert_eq!(UserEditableSpan::Recovered(span).into_option(), Some(span));
+    /// assert_eq!(UserEditableSpan::<SourceSpan>::MacroOnly.into_option(), None);
+    /// ```
+    #[must_use]
+    pub fn into_option(self) -> Option<T> {
+        match self {
+            Self::Direct(value) | Self::Recovered(value) => Some(value),
+            Self::MacroOnly => None,
+        }
+    }
+}
+
+/// Recovers the first user-editable frame from an ordered recovery chain.
+///
+/// The first frame represents the original location. Later frames are fallback
+/// candidates such as macro invocation sites or expansion call-sites.
+///
+/// # Examples
+///
+/// ```
+/// use whitaker_common::rstest::{SpanRecoveryFrame, UserEditableSpan, recover_user_editable_span};
+/// use whitaker_common::span::{SourceLocation, SourceSpan};
+///
+/// let macro_span = SourceSpan::new(SourceLocation::new(2, 1), SourceLocation::new(2, 5))
+///     .expect("example span should be valid");
+/// let user_span = SourceSpan::new(SourceLocation::new(10, 1), SourceLocation::new(10, 12))
+///     .expect("example span should be valid");
+///
+/// let recovered = recover_user_editable_span(&[
+///     SpanRecoveryFrame::new(macro_span, true),
+///     SpanRecoveryFrame::new(user_span, false),
+/// ]);
+///
+/// assert_eq!(recovered, UserEditableSpan::Recovered(user_span));
+/// ```
+#[must_use]
+pub fn recover_user_editable_span<T: Clone>(
+    frames: &[SpanRecoveryFrame<T>],
+) -> UserEditableSpan<T> {
+    frames
+        .iter()
+        .enumerate()
+        .find(|(_, frame)| !frame.from_expansion())
+        .map_or(UserEditableSpan::MacroOnly, |(index, frame)| {
+            if index == 0 {
+                UserEditableSpan::Direct(frame.value().clone())
+            } else {
+                UserEditableSpan::Recovered(frame.value().clone())
+            }
+        })
+}

--- a/common/src/rstest/tests.rs
+++ b/common/src/rstest/tests.rs
@@ -206,14 +206,22 @@ fn source_span(line: usize, start: usize, end: usize) -> SourceSpan {
     .expect("test spans should always be valid")
 }
 
+fn assert_span_recovery(
+    frame_specs: impl IntoIterator<Item = (SourceSpan, bool)>,
+    expected: UserEditableSpan<SourceSpan>,
+) {
+    let frames: Vec<SpanRecoveryFrame<SourceSpan>> = frame_specs
+        .into_iter()
+        .map(|(span, is_macro)| SpanRecoveryFrame::new(span, is_macro))
+        .collect();
+    assert_eq!(recover_user_editable_span(&frames), expected);
+}
+
 #[rstest]
 fn keeps_direct_user_editable_span() {
     let span = source_span(1, 1, 8);
 
-    assert_eq!(
-        recover_user_editable_span(&[SpanRecoveryFrame::new(span, false)]),
-        UserEditableSpan::Direct(span)
-    );
+    assert_span_recovery([(span, false)], UserEditableSpan::Direct(span));
 }
 
 #[rstest]
@@ -221,11 +229,8 @@ fn recovers_macro_frame_to_first_user_span() {
     let macro_span = source_span(2, 1, 8);
     let user_span = source_span(10, 1, 12);
 
-    assert_eq!(
-        recover_user_editable_span(&[
-            SpanRecoveryFrame::new(macro_span, true),
-            SpanRecoveryFrame::new(user_span, false),
-        ]),
+    assert_span_recovery(
+        [(macro_span, true), (user_span, false)],
         UserEditableSpan::Recovered(user_span)
     );
 }
@@ -237,25 +242,20 @@ fn recovers_first_user_span_from_nested_macro_chain() {
     let user_span = source_span(14, 1, 6);
     let later_user_span = source_span(20, 1, 9);
 
-    assert_eq!(
-        recover_user_editable_span(&[
-            SpanRecoveryFrame::new(outer_macro, true),
-            SpanRecoveryFrame::new(inner_macro, true),
-            SpanRecoveryFrame::new(user_span, false),
-            SpanRecoveryFrame::new(later_user_span, false),
-        ]),
+    assert_span_recovery(
+        [
+            (outer_macro, true),
+            (inner_macro, true),
+            (user_span, false),
+            (later_user_span, false),
+        ],
         UserEditableSpan::Recovered(user_span)
     );
 }
 
 #[rstest]
 fn treats_empty_frame_list_as_macro_only() {
-    let frames: Vec<SpanRecoveryFrame<SourceSpan>> = Vec::new();
-
-    assert_eq!(
-        recover_user_editable_span(&frames),
-        UserEditableSpan::MacroOnly
-    );
+    assert_span_recovery([], UserEditableSpan::MacroOnly);
 }
 
 #[rstest]
@@ -263,11 +263,5 @@ fn treats_all_expansion_frames_as_macro_only() {
     let first = source_span(4, 1, 4);
     let second = source_span(5, 1, 6);
 
-    assert_eq!(
-        recover_user_editable_span(&[
-            SpanRecoveryFrame::new(first, true),
-            SpanRecoveryFrame::new(second, true),
-        ]),
-        UserEditableSpan::MacroOnly
-    );
+    assert_span_recovery([(first, true), (second, true)], UserEditableSpan::MacroOnly);
 }

--- a/common/src/rstest/tests.rs
+++ b/common/src/rstest/tests.rs
@@ -231,7 +231,7 @@ fn recovers_macro_frame_to_first_user_span() {
 
     assert_span_recovery(
         [(macro_span, true), (user_span, false)],
-        UserEditableSpan::Recovered(user_span)
+        UserEditableSpan::Recovered(user_span),
     );
 }
 
@@ -249,7 +249,7 @@ fn recovers_first_user_span_from_nested_macro_chain() {
             (user_span, false),
             (later_user_span, false),
         ],
-        UserEditableSpan::Recovered(user_span)
+        UserEditableSpan::Recovered(user_span),
     );
 }
 

--- a/common/src/rstest/tests.rs
+++ b/common/src/rstest/tests.rs
@@ -218,50 +218,31 @@ fn assert_span_recovery(
 }
 
 #[rstest]
-fn keeps_direct_user_editable_span() {
-    let span = source_span(1, 1, 8);
-
-    assert_span_recovery([(span, false)], UserEditableSpan::Direct(span));
-}
-
-#[rstest]
-fn recovers_macro_frame_to_first_user_span() {
-    let macro_span = source_span(2, 1, 8);
-    let user_span = source_span(10, 1, 12);
-
-    assert_span_recovery(
-        [(macro_span, true), (user_span, false)],
-        UserEditableSpan::Recovered(user_span),
-    );
-}
-
-#[rstest]
-fn recovers_first_user_span_from_nested_macro_chain() {
-    let outer_macro = source_span(2, 1, 4);
-    let inner_macro = source_span(3, 1, 5);
-    let user_span = source_span(14, 1, 6);
-    let later_user_span = source_span(20, 1, 9);
-
-    assert_span_recovery(
-        [
-            (outer_macro, true),
-            (inner_macro, true),
-            (user_span, false),
-            (later_user_span, false),
-        ],
-        UserEditableSpan::Recovered(user_span),
-    );
-}
-
-#[rstest]
-fn treats_empty_frame_list_as_macro_only() {
-    assert_span_recovery([], UserEditableSpan::MacroOnly);
-}
-
-#[rstest]
-fn treats_all_expansion_frames_as_macro_only() {
-    let first = source_span(4, 1, 4);
-    let second = source_span(5, 1, 6);
-
-    assert_span_recovery([(first, true), (second, true)], UserEditableSpan::MacroOnly);
+#[case::keeps_direct_user_editable_span(
+    vec![(source_span(1, 1, 8), false)],
+    UserEditableSpan::Direct(source_span(1, 1, 8)),
+)]
+#[case::recovers_macro_frame_to_first_user_span(
+    vec![(source_span(2, 1, 8), true), (source_span(10, 1, 12), false)],
+    UserEditableSpan::Recovered(source_span(10, 1, 12)),
+)]
+#[case::recovers_first_user_span_from_nested_macro_chain(
+    vec![
+        (source_span(2, 1, 4), true),
+        (source_span(3, 1, 5), true),
+        (source_span(14, 1, 6), false),
+        (source_span(20, 1, 9), false),
+    ],
+    UserEditableSpan::Recovered(source_span(14, 1, 6)),
+)]
+#[case::treats_empty_frame_list_as_macro_only(vec![], UserEditableSpan::MacroOnly)]
+#[case::treats_all_expansion_frames_as_macro_only(
+    vec![(source_span(4, 1, 4), true), (source_span(5, 1, 6), true)],
+    UserEditableSpan::MacroOnly,
+)]
+fn recovers_user_editable_span_from_frame_sequences(
+    #[case] frames: Vec<(SourceSpan, bool)>,
+    #[case] expected: UserEditableSpan<SourceSpan>,
+) {
+    assert_span_recovery(frames, expected);
 }

--- a/common/src/rstest/tests.rs
+++ b/common/src/rstest/tests.rs
@@ -2,10 +2,12 @@
 
 use super::{
     ExpansionTrace, ParameterBinding, RstestDetectionOptions, RstestParameter, RstestParameterKind,
-    classify_rstest_parameter, fixture_local_names, is_rstest_fixture, is_rstest_fixture_with,
-    is_rstest_test, is_rstest_test_with,
+    SpanRecoveryFrame, UserEditableSpan, classify_rstest_parameter, fixture_local_names,
+    is_rstest_fixture, is_rstest_fixture_with, is_rstest_test, is_rstest_test_with,
+    recover_user_editable_span,
 };
 use crate::attributes::{Attribute, AttributeKind, AttributePath};
+use crate::span::{SourceLocation, SourceSpan};
 use rstest::rstest;
 use std::collections::BTreeSet;
 
@@ -193,5 +195,79 @@ fn collects_supported_fixture_local_names_in_order() {
     assert_eq!(
         fixture_local_names(&parameters, &RstestDetectionOptions::default()),
         BTreeSet::from(["clock".to_string(), "db".to_string()])
+    );
+}
+
+fn source_span(line: usize, start: usize, end: usize) -> SourceSpan {
+    SourceSpan::new(
+        SourceLocation::new(line, start),
+        SourceLocation::new(line, end),
+    )
+    .expect("test spans should always be valid")
+}
+
+#[rstest]
+fn keeps_direct_user_editable_span() {
+    let span = source_span(1, 1, 8);
+
+    assert_eq!(
+        recover_user_editable_span(&[SpanRecoveryFrame::new(span, false)]),
+        UserEditableSpan::Direct(span)
+    );
+}
+
+#[rstest]
+fn recovers_macro_frame_to_first_user_span() {
+    let macro_span = source_span(2, 1, 8);
+    let user_span = source_span(10, 1, 12);
+
+    assert_eq!(
+        recover_user_editable_span(&[
+            SpanRecoveryFrame::new(macro_span, true),
+            SpanRecoveryFrame::new(user_span, false),
+        ]),
+        UserEditableSpan::Recovered(user_span)
+    );
+}
+
+#[rstest]
+fn recovers_first_user_span_from_nested_macro_chain() {
+    let outer_macro = source_span(2, 1, 4);
+    let inner_macro = source_span(3, 1, 5);
+    let user_span = source_span(14, 1, 6);
+    let later_user_span = source_span(20, 1, 9);
+
+    assert_eq!(
+        recover_user_editable_span(&[
+            SpanRecoveryFrame::new(outer_macro, true),
+            SpanRecoveryFrame::new(inner_macro, true),
+            SpanRecoveryFrame::new(user_span, false),
+            SpanRecoveryFrame::new(later_user_span, false),
+        ]),
+        UserEditableSpan::Recovered(user_span)
+    );
+}
+
+#[rstest]
+fn treats_empty_frame_list_as_macro_only() {
+    let frames: Vec<SpanRecoveryFrame<SourceSpan>> = Vec::new();
+
+    assert_eq!(
+        recover_user_editable_span(&frames),
+        UserEditableSpan::MacroOnly
+    );
+}
+
+#[rstest]
+fn treats_all_expansion_frames_as_macro_only() {
+    let first = source_span(4, 1, 4);
+    let second = source_span(5, 1, 6);
+
+    assert_eq!(
+        recover_user_editable_span(&[
+            SpanRecoveryFrame::new(first, true),
+            SpanRecoveryFrame::new(second, true),
+        ]),
+        UserEditableSpan::MacroOnly
     );
 }

--- a/common/tests/features/rstest_span_recovery.feature
+++ b/common/tests/features/rstest_span_recovery.feature
@@ -1,0 +1,26 @@
+Feature: Shared rstest span recovery
+
+  Scenario: A direct user-editable span is kept
+    Given a direct user-editable span at line 10
+    When I recover the user-editable span
+    Then the recovery result keeps the direct span at line 10
+
+  Scenario: A nested macro chain recovers the invocation site
+    Given a macro frame at line 2
+    And a macro frame at line 3
+    And a user-editable frame at line 12
+    When I recover the user-editable span
+    Then the recovery result uses a recovered span at line 12
+
+  Scenario: Macro-only glue is skipped
+    Given a macro frame at line 4
+    And a macro frame at line 5
+    When I recover the user-editable span
+    Then the recovery result is macro-only
+
+  Scenario: The first non-expansion frame wins even when later frames also qualify
+    Given a macro frame at line 6
+    And a user-editable frame at line 20
+    And a user-editable frame at line 30
+    When I recover the user-editable span
+    Then the recovery result uses a recovered span at line 20

--- a/common/tests/rstest_span_recovery_behaviour.rs
+++ b/common/tests/rstest_span_recovery_behaviour.rs
@@ -55,7 +55,7 @@ fn when_recover(world: &SpanRecoveryWorld) {
 fn source_span(line: usize) -> SourceSpan {
     match SourceSpan::new(SourceLocation::new(line, 1), SourceLocation::new(line, 8)) {
         Ok(span) => span,
-        Err(error) => panic!("behaviour test spans should be valid: {error:?}"),
+        Err(error) => panic!("behaviour test span invalid for line {line}: {error:?}"),
     }
 }
 

--- a/common/tests/rstest_span_recovery_behaviour.rs
+++ b/common/tests/rstest_span_recovery_behaviour.rs
@@ -55,7 +55,7 @@ fn when_recover(world: &SpanRecoveryWorld) {
 fn source_span(line: usize) -> SourceSpan {
     match SourceSpan::new(SourceLocation::new(line, 1), SourceLocation::new(line, 8)) {
         Ok(span) => span,
-        Err(error) => panic!("behaviour test span invalid for line {line}: {error:?}"),
+        Err(error) => panic!("behaviour test spans should be valid (line {line}): {error:?}"),
     }
 }
 

--- a/common/tests/rstest_span_recovery_behaviour.rs
+++ b/common/tests/rstest_span_recovery_behaviour.rs
@@ -1,0 +1,105 @@
+//! Behaviour-driven tests for shared `rstest` span recovery helpers.
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use std::cell::RefCell;
+use whitaker_common::rstest::{SpanRecoveryFrame, UserEditableSpan, recover_user_editable_span};
+use whitaker_common::span::{SourceLocation, SourceSpan};
+
+#[derive(Default)]
+struct SpanRecoveryWorld {
+    frames: RefCell<Vec<SpanRecoveryFrame<SourceSpan>>>,
+    result: RefCell<Option<UserEditableSpan<SourceSpan>>>,
+}
+
+impl SpanRecoveryWorld {
+    fn push_frame(&self, line: usize, from_expansion: bool) {
+        let span = source_span(line);
+        self.frames
+            .borrow_mut()
+            .push(SpanRecoveryFrame::new(span, from_expansion));
+    }
+
+    fn evaluate(&self) {
+        let frames = self.frames.borrow();
+        self.result
+            .replace(Some(recover_user_editable_span(frames.as_slice())));
+    }
+}
+
+#[fixture]
+fn world() -> SpanRecoveryWorld {
+    SpanRecoveryWorld::default()
+}
+
+#[given("a direct user-editable span at line {line}")]
+fn given_direct_span(world: &SpanRecoveryWorld, line: usize) {
+    world.push_frame(line, false);
+}
+
+#[given("a macro frame at line {line}")]
+fn given_macro_frame(world: &SpanRecoveryWorld, line: usize) {
+    world.push_frame(line, true);
+}
+
+#[given("a user-editable frame at line {line}")]
+fn given_user_frame(world: &SpanRecoveryWorld, line: usize) {
+    world.push_frame(line, false);
+}
+
+#[when("I recover the user-editable span")]
+fn when_recover(world: &SpanRecoveryWorld) {
+    world.evaluate();
+}
+
+fn source_span(line: usize) -> SourceSpan {
+    match SourceSpan::new(SourceLocation::new(line, 1), SourceLocation::new(line, 8)) {
+        Ok(span) => span,
+        Err(error) => panic!("behaviour test spans should be valid: {error:?}"),
+    }
+}
+
+#[then("the recovery result keeps the direct span at line {line}")]
+fn then_direct(world: &SpanRecoveryWorld, line: usize) {
+    let expected = source_span(line);
+
+    assert_eq!(
+        *world.result.borrow(),
+        Some(UserEditableSpan::Direct(expected))
+    );
+}
+
+#[then("the recovery result uses a recovered span at line {line}")]
+fn then_recovered(world: &SpanRecoveryWorld, line: usize) {
+    let expected = source_span(line);
+
+    assert_eq!(
+        *world.result.borrow(),
+        Some(UserEditableSpan::Recovered(expected))
+    );
+}
+
+#[then("the recovery result is macro-only")]
+fn then_macro_only(world: &SpanRecoveryWorld) {
+    assert_eq!(*world.result.borrow(), Some(UserEditableSpan::MacroOnly));
+}
+
+#[scenario(path = "tests/features/rstest_span_recovery.feature", index = 0)]
+fn scenario_direct_span_is_kept(world: SpanRecoveryWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_span_recovery.feature", index = 1)]
+fn scenario_nested_macro_chain_recovers(world: SpanRecoveryWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_span_recovery.feature", index = 2)]
+fn scenario_macro_only_is_skipped(world: SpanRecoveryWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/rstest_span_recovery.feature", index = 3)]
+fn scenario_first_user_frame_wins(world: SpanRecoveryWorld) {
+    let _ = world;
+}

--- a/crates/function_attrs_follow_docs/src/driver.rs
+++ b/crates/function_attrs_follow_docs/src/driver.rs
@@ -11,7 +11,7 @@ use rustc_hir::attrs::AttributeKind;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_span::Span;
 use std::borrow::Cow;
-use whitaker::SharedConfig;
+use whitaker::{SharedConfig, recover_user_editable_hir_span};
 use whitaker_common::i18n::{
     Arguments, BundleLookup, DiagnosticMessageSet, FluentValue, Localizer, MessageKey,
     MessageResolution, get_localizer_for_lint, noop_reporter, safe_resolve_message_set,
@@ -120,6 +120,7 @@ impl FunctionKind {
 
 struct AttrInfo {
     span: Span,
+    user_editable_span: Option<Span>,
     is_doc: bool,
     is_outer: bool,
 }
@@ -163,9 +164,11 @@ impl AttrInfo {
         let is_outer = attr
             .doc_resolution_scope()
             .is_none_or(|style| matches!(style, AttrStyle::Outer));
+        let user_editable_span = recover_user_editable_hir_span(span);
 
         Some(Self {
             span,
+            user_editable_span,
             is_doc,
             is_outer,
         })
@@ -176,8 +179,12 @@ impl AttrInfo {
     /// This normalises the locations so reordered HIR attributes sort by the
     /// original source positions.
     fn source_order_key(&self) -> (rustc_span::BytePos, rustc_span::BytePos) {
-        let span = self.span.source_callsite();
+        let span = self.user_editable_span.unwrap_or(self.span);
         (span.lo(), span.hi())
+    }
+
+    fn user_editable_span(&self) -> Option<Span> {
+        self.user_editable_span
     }
 }
 
@@ -205,12 +212,19 @@ struct FunctionAttributeCheck<'tcx, 'a> {
 }
 
 fn check_function_attributes(check: FunctionAttributeCheck<'_, '_>) {
+    let item_user_editable_span = recover_user_editable_hir_span(check.item_span);
     let mut infos: Vec<AttrInfo> = check
         .attrs
         .iter()
         .filter_map(AttrInfo::try_from_hir)
         .collect();
-    infos.retain(|info| attribute_within_item(info.span(), check.item_span));
+    infos.retain(|info| {
+        attribute_within_item(
+            info.user_editable_span(),
+            item_user_editable_span,
+            check.item_span,
+        )
+    });
     // Attribute macros can reorder attributes in HIR; rely on source order instead.
     infos.sort_by_key(|info| info.source_order_key());
 
@@ -230,15 +244,25 @@ fn check_function_attributes(check: FunctionAttributeCheck<'_, '_>) {
 
 /// Returns true when the attribute span falls within the item span.
 ///
-/// Dummy spans are treated as in-bounds, and callsite spans are used to
-/// normalise macro expansion locations.
-fn attribute_within_item(attribute_span: Span, item_span: Span) -> bool {
-    if item_span.is_dummy() {
+/// Dummy item spans are treated as in-bounds. Attributes with no recoverable
+/// user-editable span are discarded so the lint never compares macro-only glue.
+fn attribute_within_item(
+    attribute_span: Option<Span>,
+    item_span: Option<Span>,
+    raw_item_span: Span,
+) -> bool {
+    let Some(attribute_span) = attribute_span else {
+        return false;
+    };
+
+    if raw_item_span.is_dummy() {
         return true;
     }
 
-    let attribute_span = attribute_span.source_callsite();
-    let item_span = item_span.source_callsite();
+    let Some(item_span) = item_span else {
+        return false;
+    };
+
     attribute_span.lo() >= item_span.lo() && attribute_span.hi() <= item_span.hi()
 }
 

--- a/crates/function_attrs_follow_docs/src/driver.rs
+++ b/crates/function_attrs_follow_docs/src/driver.rs
@@ -246,6 +246,8 @@ fn check_function_attributes(check: FunctionAttributeCheck<'_, '_>) {
 ///
 /// Dummy item spans are treated as in-bounds. Attributes with no recoverable
 /// user-editable span are discarded so the lint never compares macro-only glue.
+/// When item-span recovery fails, the raw item span remains the containment
+/// fallback for user-authored items.
 fn attribute_within_item(
     attribute_span: Option<Span>,
     item_span: Option<Span>,
@@ -259,9 +261,7 @@ fn attribute_within_item(
         return true;
     }
 
-    let Some(item_span) = item_span else {
-        return false;
-    };
+    let item_span = item_span.unwrap_or(raw_item_span);
 
     attribute_span.lo() >= item_span.lo() && attribute_span.hi() <= item_span.hi()
 }

--- a/crates/function_attrs_follow_docs/src/driver.rs
+++ b/crates/function_attrs_follow_docs/src/driver.rs
@@ -259,7 +259,9 @@ fn attribute_within_item(
         return true;
     }
 
-    let item_span = item_span.unwrap_or(raw_item_span);
+    let Some(item_span) = item_span else {
+        return false;
+    };
 
     attribute_span.lo() >= item_span.lo() && attribute_span.hi() <= item_span.hi()
 }

--- a/crates/function_attrs_follow_docs/src/driver.rs
+++ b/crates/function_attrs_follow_docs/src/driver.rs
@@ -259,9 +259,7 @@ fn attribute_within_item(
         return true;
     }
 
-    let Some(item_span) = item_span else {
-        return false;
-    };
+    let item_span = item_span.unwrap_or(raw_item_span);
 
     attribute_span.lo() >= item_span.lo() && attribute_span.hi() <= item_span.hi()
 }

--- a/crates/function_attrs_follow_docs/src/tests/order_detection.rs
+++ b/crates/function_attrs_follow_docs/src/tests/order_detection.rs
@@ -121,15 +121,21 @@ fn macro_only_attributes_are_dropped_from_item_comparison() {
 fn raw_item_span_bounds_attribute_when_item_recovery_fails() {
     let raw_item_span = test_span(10, 40);
     let attribute_span = test_span(12, 20);
-    let out_of_bounds_attribute_span = test_span(41, 45);
 
     assert!(attribute_within_item(
         Some(attribute_span),
         None,
         raw_item_span,
     ));
+}
+
+#[rstest]
+fn raw_item_span_rejects_out_of_bounds_attribute_when_item_recovery_fails() {
+    let raw_item_span = test_span(10, 40);
+    let attribute_span = test_span(12, 45);
+
     assert!(!attribute_within_item(
-        Some(out_of_bounds_attribute_span),
+        Some(attribute_span),
         None,
         raw_item_span,
     ));

--- a/crates/function_attrs_follow_docs/src/tests/order_detection.rs
+++ b/crates/function_attrs_follow_docs/src/tests/order_detection.rs
@@ -118,6 +118,18 @@ fn macro_only_attributes_are_dropped_from_item_comparison() {
 }
 
 #[rstest]
+fn none_item_span_drops_attribute_when_raw_item_span_is_not_dummy() {
+    let raw_item_span = test_span(10, 40);
+    let attribute_span = test_span(12, 20);
+
+    assert!(!attribute_within_item(
+        Some(attribute_span),
+        None,
+        raw_item_span,
+    ));
+}
+
+#[rstest]
 fn recovered_attribute_spans_stay_in_item_bounds() {
     let item_span = test_span(10, 40);
     let attribute_span = test_span(12, 20);
@@ -134,18 +146,6 @@ fn dummy_item_spans_accept_recovered_attributes() {
     let attribute_span = test_span(12, 20);
 
     assert!(attribute_within_item(Some(attribute_span), None, DUMMY_SP));
-}
-
-#[rstest]
-fn raw_item_span_is_used_when_recovery_fails() {
-    let raw_item_span = test_span(10, 40);
-    let attribute_span = test_span(12, 20);
-
-    assert!(attribute_within_item(
-        Some(attribute_span),
-        None,
-        raw_item_span
-    ));
 }
 
 #[rstest]

--- a/crates/function_attrs_follow_docs/src/tests/order_detection.rs
+++ b/crates/function_attrs_follow_docs/src/tests/order_detection.rs
@@ -3,10 +3,11 @@
 //! These scenarios exercise `detect_misordered_doc` to ensure doc comments
 //! continue to precede other outer attributes across common layouts.
 
-use super::{OrderedAttribute, detect_misordered_doc};
+use super::{AttrInfo, OrderedAttribute, attribute_within_item, detect_misordered_doc};
 use rstest::fixture;
+use rstest::rstest;
 use rstest_bdd_macros::{given, scenario, then, when};
-use rustc_span::{DUMMY_SP, Span};
+use rustc_span::{BytePos, DUMMY_SP, Span};
 use std::cell::RefCell;
 use whitaker_common::attributes::{Attribute, AttributeKind, AttributePath};
 
@@ -89,6 +90,43 @@ fn order_ok(result: &Option<(usize, usize)>) {
 #[then("the order is rejected")]
 fn order_rejected(result: &Option<(usize, usize)>) {
     assert!(result.is_some());
+}
+
+fn test_span(lo: u32, hi: u32) -> Span {
+    Span::with_root_ctxt(BytePos(lo), BytePos(hi))
+}
+
+#[rstest]
+fn recovered_user_span_drives_source_ordering() {
+    let original = test_span(100, 110);
+    let recovered = test_span(10, 20);
+    let info = AttrInfo {
+        span: original,
+        user_editable_span: Some(recovered),
+        is_doc: false,
+        is_outer: true,
+    };
+
+    assert_eq!(info.source_order_key(), (recovered.lo(), recovered.hi()));
+}
+
+#[rstest]
+fn macro_only_attributes_are_dropped_from_item_comparison() {
+    let item_span = test_span(10, 40);
+
+    assert!(!attribute_within_item(None, Some(item_span), item_span));
+}
+
+#[rstest]
+fn recovered_attribute_spans_stay_in_item_bounds() {
+    let item_span = test_span(10, 40);
+    let attribute_span = test_span(12, 20);
+
+    assert!(attribute_within_item(
+        Some(attribute_span),
+        Some(item_span),
+        item_span
+    ));
 }
 
 #[scenario(path = "tests/features/function_doc_order.feature", index = 0)]

--- a/crates/function_attrs_follow_docs/src/tests/order_detection.rs
+++ b/crates/function_attrs_follow_docs/src/tests/order_detection.rs
@@ -118,11 +118,11 @@ fn macro_only_attributes_are_dropped_from_item_comparison() {
 }
 
 #[rstest]
-fn none_item_span_drops_attribute_when_raw_item_span_is_not_dummy() {
+fn raw_item_span_bounds_attribute_when_item_recovery_fails() {
     let raw_item_span = test_span(10, 40);
     let attribute_span = test_span(12, 20);
 
-    assert!(!attribute_within_item(
+    assert!(attribute_within_item(
         Some(attribute_span),
         None,
         raw_item_span,

--- a/crates/function_attrs_follow_docs/src/tests/order_detection.rs
+++ b/crates/function_attrs_follow_docs/src/tests/order_detection.rs
@@ -129,6 +129,37 @@ fn recovered_attribute_spans_stay_in_item_bounds() {
     ));
 }
 
+#[rstest]
+fn dummy_item_spans_accept_recovered_attributes() {
+    let attribute_span = test_span(12, 20);
+
+    assert!(attribute_within_item(Some(attribute_span), None, DUMMY_SP));
+}
+
+#[rstest]
+fn raw_item_span_is_used_when_recovery_fails() {
+    let raw_item_span = test_span(10, 40);
+    let attribute_span = test_span(12, 20);
+
+    assert!(attribute_within_item(
+        Some(attribute_span),
+        None,
+        raw_item_span
+    ));
+}
+
+#[rstest]
+fn recovered_attribute_spans_outside_item_are_rejected() {
+    let item_span = test_span(10, 40);
+    let attribute_span = test_span(12, 45);
+
+    assert!(!attribute_within_item(
+        Some(attribute_span),
+        Some(item_span),
+        item_span
+    ));
+}
+
 #[scenario(path = "tests/features/function_doc_order.feature", index = 0)]
 fn scenario_accepts_doc_first(world: AttributeWorld, result: Option<(usize, usize)>) {
     let _ = (world, result);

--- a/crates/function_attrs_follow_docs/src/tests/order_detection.rs
+++ b/crates/function_attrs_follow_docs/src/tests/order_detection.rs
@@ -121,9 +121,15 @@ fn macro_only_attributes_are_dropped_from_item_comparison() {
 fn raw_item_span_bounds_attribute_when_item_recovery_fails() {
     let raw_item_span = test_span(10, 40);
     let attribute_span = test_span(12, 20);
+    let out_of_bounds_attribute_span = test_span(41, 45);
 
     assert!(attribute_within_item(
         Some(attribute_span),
+        None,
+        raw_item_span,
+    ));
+    assert!(!attribute_within_item(
+        Some(out_of_bounds_attribute_span),
         None,
         raw_item_span,
     ));

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -770,6 +770,76 @@ To add a new scenario:
   `DependencyBinaryInstaller` with configurable success or failure behaviour
   for scenario isolation.
 
+## Shared Span Recovery Helpers
+
+Whitaker provides reusable, macro-aware span recovery utilities split across
+two layers.
+
+### Policy layer — `whitaker-common`
+
+`whitaker_common::rstest` exports a pure, `rustc`-independent policy:
+
+| Symbol                                                        | Description                                                                                                                                                 |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SpanRecoveryFrame<T>`                                        | A single frame in an ordered span chain, carrying the frame value and a `from_expansion: bool` flag.                                                        |
+| `UserEditableSpan<T>`                                         | Enum result: `Direct(T)` — first frame is user-editable; `Recovered(T)` — a later frame is user-editable; `MacroOnly` — no user-editable frame found.       |
+| `recover_user_editable_span(frames: &[SpanRecoveryFrame<T>])` | Scans the ordered frame chain and returns the first non-expansion frame as `Direct` or `Recovered`.                                                         |
+
+The policy layer has no dependency on `rustc_span` and can be unit-tested with
+any `Clone + PartialEq` span type (e.g., `miette::SourceSpan`).
+
+### Adapter layer — `whitaker` (feature `dylint-driver`)
+
+`whitaker::hir` provides a thin adapter over `rustc_span::Span`:
+
+| Symbol                                                             | Description                                                                                                                                                   |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `span_recovery_frames(span: Span) -> Vec<SpanRecoveryFrame<Span>>` | Walks `source_callsite()` from `span`, building an ordered frame list. Stops on dummy spans, non-expansion frames, or when the walk makes no progress.        |
+| `recover_user_editable_hir_span(span: Span) -> Option<Span>`       | Calls `span_recovery_frames` then delegates to `recover_user_editable_span`, returning the inner value of `Direct` or `Recovered`, or `None` for `MacroOnly`. |
+
+Both functions are re-exported from `whitaker` under
+`#[cfg(feature = "dylint-driver")]`.
+
+### Consuming the helpers in a lint
+
+```rust
+use whitaker::recover_user_editable_hir_span;
+
+// Recover a user-editable span for an attribute.
+let user_span: Option<Span> = recover_user_editable_hir_span(attr.span);
+
+// Discard macro-only glue — the user has no source location to edit.
+if user_span.is_none() {
+    return;
+}
+```
+
+Use `recover_user_editable_hir_span` for both attribute spans and item spans.
+When the item span itself is macro-only, treat any attribute comparison on that
+item as vacuously in-bounds rather than emitting a spurious diagnostic.
+
+### Extending the policy
+
+To handle a new `T` (e.g., a custom span type in a test harness):
+
+1. Implement `Clone` on `T`.
+2. Construct `SpanRecoveryFrame<T>` values with
+   `SpanRecoveryFrame::new(value, from_expansion)`.
+3. Pass the ordered slice to `recover_user_editable_span`.
+
+No adapter code is needed unless `T` is `rustc_span::Span`.
+
+### Test coverage
+
+- **Unit tests** for the pure policy live in `common/src/rstest/tests.rs`.
+- **BDD scenarios** live in
+  `common/tests/rstest_span_recovery_behaviour.rs` and are driven by
+  `common/tests/features/rstest_span_recovery.feature`.
+- **Adapter tests** for `span_recovery_frames` and
+  `recover_user_editable_hir_span` live in `src/hir.rs` under `#[cfg(test)]`.
+- **Integration tests** for the first consumer are in
+  `crates/function_attrs_follow_docs/src/tests/order_detection.rs`.
+
 ## Regression infrastructure
 
 Two recent regression families rely on infrastructure that is easy to miss when

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -770,7 +770,7 @@ To add a new scenario:
   `DependencyBinaryInstaller` with configurable success or failure behaviour
   for scenario isolation.
 
-## Shared Span Recovery Helpers
+## Shared span recovery helpers
 
 Whitaker provides reusable, macro-aware span recovery utilities split across
 two layers.
@@ -778,6 +778,9 @@ two layers.
 ### Policy layer — `whitaker-common`
 
 `whitaker_common::rstest` exports a pure, `rustc`-independent policy:
+
+The following table lists the reusable policy symbols exported from
+`whitaker_common::rstest`.
 
 | Symbol                                                        | Description                                                                                                                                                 |
 | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -791,6 +794,9 @@ any `Clone + PartialEq` span type (e.g., `miette::SourceSpan`).
 ### Adapter layer — `whitaker` (feature `dylint-driver`)
 
 `whitaker::hir` provides a thin adapter over `rustc_span::Span`:
+
+The following table lists the `whitaker::hir` adapter functions that bridge
+from `rustc_span::Span` into the shared recovery policy.
 
 | Symbol                                                             | Description                                                                                                                                                   |
 | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -836,7 +842,8 @@ No adapter code is needed unless `T` is `rustc_span::Span`.
   `common/tests/rstest_span_recovery_behaviour.rs` and are driven by
   `common/tests/features/rstest_span_recovery.feature`.
 - **Adapter tests** for `span_recovery_frames` and
-  `recover_user_editable_hir_span` live in `src/hir.rs` under `#[cfg(test)]`.
+  `recover_user_editable_hir_span` live in `src/hir/tests.rs`, loaded by
+  `src/hir/mod.rs` under `#[cfg(test)]`.
 - **Integration tests** for the first consumer are in
   `crates/function_attrs_follow_docs/src/tests/order_detection.rs`.
 

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -413,7 +413,7 @@ Include these sections as appropriate to the decision's complexity:
 
 ### ADR template
 
-```markdown
+```text
 # Architectural decision record (ADR) NNN: <title>
 
 ## Status
@@ -641,7 +641,7 @@ This hierarchy should align with the GIST framework:
 
 ### Roadmap example
 
-```markdown
+```text
 ## 1. Core infrastructure
 
 ### 1.1. Logging subsystem
@@ -660,6 +660,7 @@ This hierarchy should align with the GIST framework:
   - Define role hierarchy. See design-doc.md §4.3.
   - Add RBAC middleware to API endpoints.
   - Write integration tests for permission boundaries.
+
 ```
 
 ### Writing GIST-aligned steps

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -413,7 +413,7 @@ Include these sections as appropriate to the decision's complexity:
 
 ### ADR template
 
-```text
+```plaintext
 # Architectural decision record (ADR) NNN: <title>
 
 ## Status
@@ -641,7 +641,7 @@ This hierarchy should align with the GIST framework:
 
 ### Roadmap example
 
-```text
+```plaintext
 ## 1. Core infrastructure
 
 ### 1.1. Logging subsystem

--- a/docs/execplans/8-1-2-shared-user-editable-span-recovery-helpers.md
+++ b/docs/execplans/8-1-2-shared-user-editable-span-recovery-helpers.md
@@ -1,0 +1,438 @@
+# Add shared user-editable span recovery helpers for macro-heavy `rstest` code paths
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+This document must be maintained in accordance with `AGENTS.md`. The canonical
+plan file is
+`docs/execplans/8-1-2-shared-user-editable-span-recovery-helpers.md`.
+
+This draft must be approved before implementation begins. Do not start code
+changes for roadmap item 8.1.2 until the user explicitly approves this plan.
+
+## Purpose / big picture
+
+Roadmap item 8.1.2 fills the gap between strict `rstest` detection (implemented
+in 8.1.1) and later diagnostic-emitting lints. After this change, Whitaker will
+have a shared way to answer a new question for macro-heavy test code paths:
+
+1. Is this span already user-editable?
+2. If not, can a call-site or expansion-chain fallback recover a span the user
+   can actually edit?
+3. If every candidate is still macro-generated glue, should the lint skip the
+   diagnostic instead of pointing at compiler-generated code?
+
+Success is observable when:
+
+1. `whitaker-common` exposes a pure, deterministic span-recovery policy that
+   can be tested without `rustc_private`.
+2. The `whitaker` crate exposes a `rustc_span::Span` adapter that walks source
+   call-sites and feeds that policy.
+3. At least one existing macro-aware lint path uses the shared helper instead
+   of crate-local `source_callsite()` logic or unconditional `from_expansion()`
+   skipping.
+4. Unit tests and `rstest-bdd` v0.5.0 behavioural tests cover happy paths,
+   unhappy paths, and edge cases.
+5. `docs/lints-for-rstest-fixtures-and-test-hygiene.md` records the final
+   8.1.2 design decisions.
+6. `docs/roadmap.md` marks 8.1.2 done only after implementation, docs, and all
+   gates succeed.
+7. `make check-fmt`, `make lint`, and `make test` pass at the end of the
+   implementation turn, with the documentation gates also passing because this
+   work touches Markdown.
+
+## Constraints
+
+- Scope only roadmap item 8.1.2. Do not implement lint A, lint B, lint C,
+  argument fingerprinting, call-site aggregation, or paragraph detection in
+  this change.
+- Keep the policy layer pure and shareable. The recovery decision should live
+  in `whitaker-common`, while any `rustc_span::Span` walking stays in the
+  `whitaker` crate behind the existing `dylint-driver` feature.
+- Treat macro-only glue as a skip condition, not a best-effort diagnostic
+  target. If no user-editable span can be recovered, the helper must report
+  that outcome explicitly so callers can suppress the lint.
+- Preserve the conservative posture from
+  `docs/lints-for-rstest-fixtures-and-test-hygiene.md`: recover user-editable
+  spans where possible, but do not guess when the expansion chain stays fully
+  synthetic.
+- Keep public APIs small and documented. New public items need Rustdoc
+  examples that compile under the doctest model described in
+  `docs/rust-doctest-dry-guide.md`.
+- Keep every source file under 400 lines. Split modules early if tests or
+  helper logic start to crowd a single file.
+- Use workspace-pinned `rstest`, `rstest-bdd`, and `rstest-bdd-macros`
+  versions. The BDD coverage for this task must use `rstest-bdd` v0.5.0.
+- Do not mark roadmap item 8.1.2 done until the shared helpers, adopter,
+  design-doc updates, and all quality gates succeed.
+- Because this work adds or changes Markdown, the implementation turn must run
+  `make fmt`, `make markdownlint`, and `make nixie` in addition to the normal
+  Rust gates.
+
+## Tolerances
+
+- Scope: if implementation needs more than 12 touched files or roughly 1,000
+  net new lines, stop and escalate before continuing.
+- API shape: if the pure policy cannot stay `rustc_private`-free without
+  introducing a large abstraction stack, stop and escalate with the competing
+  designs.
+- Consumer breadth: if adopting the helper in one existing lint would require
+  semantic changes in multiple unrelated lint crates, stop and escalate rather
+  than broadening the blast radius.
+- Span fidelity: if `source_callsite()` and related span APIs cannot
+  distinguish a user-editable location from macro-only glue for the selected
+  adopter, stop and escalate with concrete failing fixtures before adding
+  heuristics.
+- Validation: if `make check-fmt`, `make lint`, or `make test` still fail
+  after three targeted fix iterations, stop and escalate with the captured logs.
+
+## Risks
+
+- Recovery risk: `source_callsite()` can recover the macro invocation site, but
+  nested `rstest` expansions may still land on generated companion modules or
+  harness constants. Mitigation: model the outcome as `direct`, `recovered`, or
+  `macro-only` rather than always returning a span.
+- Drift risk: a pure policy in `whitaker-common` and a `rustc` adapter in
+  `whitaker` can diverge if the adapter builds the frame list incorrectly.
+  Mitigation: keep the adapter thin and give the pure policy the bulk of the
+  branch logic.
+- Overreach risk: adding a brand-new shared span module in the wrong crate
+  could blur the current architecture. Mitigation: keep the pure rule with
+  `common::rstest` and keep the compiler-aware adapter in `src/hir.rs`, which
+  already hosts shared `rustc`-aware helpers.
+- Test ergonomics risk: BDD feature-file-only edits can look stale on targeted
+  reruns because the binary may not rebuild. Mitigation: touch the `.rs`
+  harness when a targeted rerun appears stale and rely on the full `make test`
+  gate before concluding.
+- Adoption risk: replacing the existing local `source_callsite()` usage in
+  `function_attrs_follow_docs` could change ordering behaviour for existing
+  proc-macro fixtures. Mitigation: add a regression test around the current
+  proc-macro aux fixture before switching the driver over.
+
+## Progress
+
+- [x] (2026-04-10 00:00Z) Stage A: Inspect the roadmap, the design doc, the
+      prior 8.1.1 ExecPlan, the current `common::rstest` module, and existing
+      macro-span handling patterns.
+- [ ] Stage B: Add failing unit tests and `rstest-bdd` scenarios that define
+      the 8.1.2 recovery contract.
+- [ ] Stage C: Implement the pure shared recovery policy in
+      `whitaker-common`.
+- [ ] Stage D: Implement the `rustc_span::Span` adapter and public re-exports
+      in the `whitaker` crate.
+- [ ] Stage E: Replace one crate-local macro-span workaround with the shared
+      helper and add adopter regression coverage.
+- [ ] Stage F: Record implementation decisions in
+      `docs/lints-for-rstest-fixtures-and-test-hygiene.md`.
+- [ ] Stage G: Mark roadmap item 8.1.2 done.
+- [ ] Stage H: Run `make fmt`, `make markdownlint`, `make nixie`,
+      `make check-fmt`, `make lint`, and `make test`.
+- [ ] Stage I: Finalize the living sections in this document.
+
+## Surprises & Discoveries
+
+- `common::rstest` currently stops at strict test, fixture, and parameter
+  classification. It has no span-recovery surface yet.
+- The only shared pure span abstraction today is `common::span::SourceSpan`,
+  which is useful for modelling doctestable examples but does not recover
+  `rustc_span::Span` values on its own.
+- `src/hir.rs` is already the shared `rustc_private`-aware home for span-ish
+  helpers such as `module_body_span`, so extending it is less disruptive than
+  inventing a new top-level feature gate just for 8.1.2.
+- `crates/function_attrs_follow_docs/src/driver.rs` already uses
+  `source_callsite()` locally to normalize macro-expanded attribute positions.
+  That is the clearest in-repo precedent for a first shared adopter.
+- Several other lints still take the coarse path shown below, so 8.1.2 should
+  stay narrow and avoid promising a repository-wide cleanup in one turn.
+
+  ```plaintext
+  if span.from_expansion() {
+      return;
+  }
+  ```
+
+- The workspace already contains root-level `rstest-bdd` harnesses in `tests/`,
+  so compiler-adjacent shared helper tests do not need to invent a new test
+  style.
+
+## Decision Log
+
+- Decision: split the feature into a pure policy in `whitaker-common` and a
+  thin `rustc_span::Span` adapter in `whitaker`. Rationale: this matches the
+  8.1.1 pattern and keeps most tests free of `rustc_private`. Date/Author:
+  2026-04-10 / Codex.
+- Decision: extend `src/hir.rs` instead of creating a new top-level module.
+  Rationale: `src/hir.rs` already hosts shared compiler-aware helpers and has
+  ample headroom before hitting the 400-line limit. Date/Author: 2026-04-10 /
+  Codex.
+- Decision: the recovery API should distinguish a usable span from a
+  macro-only outcome, not just return `Option`. Rationale: future lint drivers
+  need to know whether to emit nothing because the code is generated, not
+  because the helper forgot to inspect a fallback. Date/Author: 2026-04-10 /
+  Codex.
+- Decision: the first concrete adopter should be
+  `function_attrs_follow_docs`. Rationale: it already contains local
+  `source_callsite()` logic, already exercises proc-macro-based `#[fixture]`
+  fixtures, and can validate the shared helper without prematurely implementing
+  lint A. Date/Author: 2026-04-10 / Codex.
+
+## Context and orientation
+
+### Repository state
+
+The relevant code already lives in four clusters.
+
+- `common/src/rstest/` contains the pure 8.1.1 detection and parameter
+  classification helpers.
+- `common/src/span.rs` contains the existing pure span value objects used by
+  the diagnostic builder and doctest examples.
+- `src/hir.rs` contains shared `rustc_private`-aware helpers used by lint
+  crates via the `whitaker` facade.
+- `crates/function_attrs_follow_docs/src/driver.rs` contains the current local
+  `source_callsite()` normalization precedent.
+
+The relevant docs already exist.
+
+- `docs/roadmap.md` defines 8.1.2 as “shared user-editable span recovery
+  helpers for macro-heavy test code paths”.
+- `docs/lints-for-rstest-fixtures-and-test-hygiene.md` adds the design rule
+  that diagnostics should recover user-editable spans where possible and avoid
+  macro-only glue.
+- `docs/execplans/8-1-1-shared-rstest-test-and-fixture-detection-helpers.md`
+  shows the repository’s preferred split between pure shared logic and later
+  compiler-aware consumers.
+
+### What 8.1.2 must provide
+
+The task is not “general macro span recovery for every lint in the workspace”.
+It is the narrower foundation that later `rstest` hygiene lints will reuse.
+That foundation needs three concrete capabilities.
+
+1. A pure rule that receives an ordered chain of span candidates and returns
+   the first user-editable one, or reports that the chain is macro-only.
+2. A `rustc` adapter that can turn a `Span` plus its successive
+   `source_callsite()` fallbacks into that ordered chain.
+3. One real consumer that proves the helper replaces crate-local span
+   normalization and suppresses diagnostics on synthetic glue instead of
+   pointing at generated code.
+
+## Proposed implementation shape
+
+Create one new pure shared module and extend two existing integration points.
+
+- `common/src/rstest/span.rs`
+- `common/src/rstest/mod.rs`
+- `common/src/rstest/tests.rs`
+- `common/tests/rstest_span_recovery_behaviour.rs`
+- `common/tests/features/rstest_span_recovery.feature`
+- `common/src/lib.rs`
+- `src/hir.rs`
+- `src/lib.rs`
+- `crates/function_attrs_follow_docs/src/driver.rs`
+- `crates/function_attrs_follow_docs/src/tests/order_detection.rs`
+- `docs/lints-for-rstest-fixtures-and-test-hygiene.md`
+- `docs/roadmap.md`
+
+The public surface should look close to this, even if the exact names change
+slightly during implementation.
+
+```plaintext
+// common/src/rstest/span.rs
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpanRecoveryFrame<T> {
+    value: T,
+    from_expansion: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UserEditableSpan<T> {
+    Direct(T),
+    Recovered(T),
+    MacroOnly,
+}
+
+pub fn recover_user_editable_span<T: Clone>(
+    frames: &[SpanRecoveryFrame<T>],
+) -> UserEditableSpan<T>;
+
+// src/hir.rs
+
+pub fn span_recovery_frames(span: Span) -> Vec<SpanRecoveryFrame<Span>>;
+
+pub fn recover_user_editable_hir_span(span: Span) -> Option<Span>;
+```
+
+The pure policy should stay deliberately small. The
+`recover_user_editable_span` function should not know anything about
+`rustc_span::Span`, `LateContext`, or `rstest`; it should only care about the
+ordered frame list and whether each frame still comes from an expansion.
+
+The adapter in `src/hir.rs` should build that ordered frame list by walking the
+source-callsite chain until one of these stop conditions occurs:
+
+1. the next span is dummy,
+2. the next span is identical to the current span, or
+3. the chain has already reached a non-expansion user span and no more
+   fallbacks are needed.
+
+The first adopter should switch from direct `source_callsite()` usage to the
+shared adapter. For `function_attrs_follow_docs`, that means:
+
+1. use the shared helper in `source_order_key`,
+2. use the shared helper in `attribute_within_item`, and
+3. drop attributes from the comparison set when the helper reports
+   `MacroOnly`.
+
+That adoption keeps the task grounded without prematurely implementing 8.2.3’s
+call-site diagnostics.
+
+## Implementation stages
+
+### Stage B: define the contract with tests first
+
+Start with failing tests, not helper code.
+
+In `common/src/rstest/tests.rs`, add unit cases for:
+
+- a direct non-expansion frame returning `Direct`,
+- a macro frame followed by a user frame returning `Recovered`,
+- multiple nested macro frames still recovering the first user frame,
+- an empty frame list returning `MacroOnly`,
+- an all-expansion frame list returning `MacroOnly`.
+
+In `common/tests/rstest_span_recovery_behaviour.rs` plus
+`common/tests/features/rstest_span_recovery.feature`, add `rstest-bdd` v0.5.0
+scenarios that describe the same contract in user terms:
+
+- “a direct user-editable span is kept”,
+- “a nested macro chain recovers the invocation site”,
+- “macro-only glue is skipped”,
+- “the first non-expansion frame wins even when later frames also qualify”.
+
+Keep the world pure. The behavioural harness should use simple structs or
+`SourceSpan` values rather than real `rustc` spans.
+
+### Stage C: implement the pure shared policy
+
+Add `common/src/rstest/span.rs`, re-export it from `common/src/rstest/mod.rs`,
+and surface the new types from `common/src/lib.rs`.
+
+The algorithm should be intentionally boring.
+
+1. Walk the frame slice from left to right.
+2. Return `Direct` for the first frame if it is not from expansion.
+3. Return `Recovered` for the first later frame that is not from expansion.
+4. Return `MacroOnly` when no such frame exists.
+
+Document the API with Rustdoc examples that mirror the unit tests. Keep the
+examples short and use the existing `SourceSpan` helpers where that improves
+clarity.
+
+### Stage D: implement the `rustc` adapter
+
+Extend `src/hir.rs` with helpers that convert a `rustc_span::Span` into the
+ordered frame list expected by the pure policy.
+
+The adapter should:
+
+1. skip dummy spans instead of pushing invalid frames,
+2. record whether each frame still originates from expansion,
+3. stop when `source_callsite()` stops making progress, and
+4. expose a single convenience function that returns `Option<Span>` for lint
+   drivers that only need “emit or skip”.
+
+Re-export the adapter from `src/lib.rs` behind the `dylint-driver` feature so
+lint crates can call it through the existing `whitaker` facade.
+
+### Stage E: adopt the helper in one real consumer
+
+Update `crates/function_attrs_follow_docs/src/driver.rs` to use the shared
+adapter.
+
+The driver currently normalizes spans with raw `source_callsite()` calls in two
+places. Replace those with the shared helper so the lint:
+
+- still sorts real attributes by user source order,
+- still checks whether an attribute belongs to the current item, and
+- now drops macro-only synthetic attributes instead of trying to compare them.
+
+Add a regression test in
+`crates/function_attrs_follow_docs/src/tests/order_detection.rs` or a nearby
+test file that exercises the proc-macro fixture path already used by that
+crate. The test should prove that a recoverable call-site still participates in
+ordering, while purely synthetic glue does not trigger a false diagnostic.
+
+### Stage F: update design docs and roadmap
+
+Once code and tests pass, append an “Implementation decisions (8.1.2)” section
+to `docs/lints-for-rstest-fixtures-and-test-hygiene.md`.
+
+Capture at least these decisions if they remain true after implementation:
+
+- the pure/common versus `rustc` adapter split,
+- the explicit `macro-only` outcome,
+- the stop conditions used for the call-site walk, and
+- the chosen early adopter.
+
+Then mark 8.1.2 done in `docs/roadmap.md`. Do not do that earlier.
+
+## Validation and evidence
+
+Use targeted commands during development, then run the full gates before the
+turn ends. Because command output is truncated in this environment, always use
+`tee` plus `set -o pipefail`.
+
+Targeted inner-loop commands:
+
+```plaintext
+set -o pipefail
+cargo test -p whitaker-common rstest:: 2>&1 | tee /tmp/8-1-2-common-unit.log
+
+set -o pipefail
+cargo test -p whitaker-common --test rstest_span_recovery_behaviour \
+  2>&1 | tee /tmp/8-1-2-common-bdd.log
+
+set -o pipefail
+cargo test -p function_attrs_follow_docs --all-features \
+  2>&1 | tee /tmp/8-1-2-function-attrs.log
+```
+
+Required end-of-turn gates:
+
+```plaintext
+set -o pipefail
+make fmt 2>&1 | tee /tmp/8-1-2-fmt.log
+
+set -o pipefail
+make markdownlint 2>&1 | tee /tmp/8-1-2-markdownlint.log
+
+set -o pipefail
+make nixie 2>&1 | tee /tmp/8-1-2-nixie.log
+
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/8-1-2-check-fmt.log
+
+set -o pipefail
+make lint 2>&1 | tee /tmp/8-1-2-lint.log
+
+set -o pipefail
+make test 2>&1 | tee /tmp/8-1-2-test.log
+```
+
+Success criteria for the full validation step:
+
+- `make markdownlint`, `make nixie`, and `make check-fmt` exit cleanly,
+- `make lint` produces no warnings promoted to errors,
+- `make test` finishes with zero failed tests, and
+- the new unit and behavioural tests would fail on the pre-change code and
+  pass after the helper lands.
+
+## Outcomes & Retrospective
+
+Not yet implemented. This section must be rewritten during execution with the
+final result, the validation evidence, any scope adjustments, and the lessons
+that future roadmap items 8.2.x, 8.3.x, and 8.4.x should inherit.

--- a/docs/execplans/8-1-2-shared-user-editable-span-recovery-helpers.md
+++ b/docs/execplans/8-1-2-shared-user-editable-span-recovery-helpers.md
@@ -4,7 +4,7 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 This document must be maintained in accordance with `AGENTS.md`. The canonical
 plan file is
@@ -117,20 +117,25 @@ Success is observable when:
 - [x] (2026-04-10 00:00Z) Stage A: Inspect the roadmap, the design doc, the
       prior 8.1.1 ExecPlan, the current `common::rstest` module, and existing
       macro-span handling patterns.
-- [ ] Stage B: Add failing unit tests and `rstest-bdd` scenarios that define
+- [x] (2026-04-10 11:39Z) Stage B: Add failing unit tests and `rstest-bdd`
+      scenarios that define
       the 8.1.2 recovery contract.
-- [ ] Stage C: Implement the pure shared recovery policy in
+- [x] (2026-04-10 11:39Z) Stage C: Implement the pure shared recovery policy
+      in
       `whitaker-common`.
-- [ ] Stage D: Implement the `rustc_span::Span` adapter and public re-exports
+- [x] (2026-04-10 11:39Z) Stage D: Implement the `rustc_span::Span` adapter
+      and public re-exports
       in the `whitaker` crate.
-- [ ] Stage E: Replace one crate-local macro-span workaround with the shared
+- [x] (2026-04-10 11:39Z) Stage E: Replace one crate-local macro-span
+      workaround with the shared
       helper and add adopter regression coverage.
-- [ ] Stage F: Record implementation decisions in
+- [x] (2026-04-10 11:40Z) Stage F: Record implementation decisions in
       `docs/lints-for-rstest-fixtures-and-test-hygiene.md`.
-- [ ] Stage G: Mark roadmap item 8.1.2 done.
-- [ ] Stage H: Run `make fmt`, `make markdownlint`, `make nixie`,
-      `make check-fmt`, `make lint`, and `make test`.
-- [ ] Stage I: Finalize the living sections in this document.
+- [x] (2026-04-10 11:48Z) Stage G: Mark roadmap item 8.1.2 done.
+- [x] (2026-04-10 11:48Z) Stage H: Run `make fmt`, `make markdownlint`,
+      `make nixie`, `make check-fmt`, `make lint`, and `make test`.
+- [x] (2026-04-10 11:48Z) Stage I: Finalize the living sections in this
+      document.
 
 ## Surprises & Discoveries
 
@@ -145,6 +150,17 @@ Success is observable when:
 - `crates/function_attrs_follow_docs/src/driver.rs` already uses
   `source_callsite()` locally to normalize macro-expanded attribute positions.
   That is the clearest in-repo precedent for a first shared adopter.
+- The targeted development loop from the plan now passes:
+  `cargo test -p whitaker-common rstest::`,
+  `cargo test -p whitaker-common --test rstest_span_recovery_behaviour`, and
+  `cargo test -p function_attrs_follow_docs --all-features`.
+- The first adopter stayed within the file-size limit after the refactor:
+  `crates/function_attrs_follow_docs/src/driver.rs` is now 389 lines, so the
+  400-line guardrail did not require an additional split.
+- `make lint` initially failed because the new BDD harness used `.expect()`,
+  which violates the workspace-wide Clippy deny settings even in tests. The fix
+  was to switch the helper to the repository-standard `match` plus `panic!`
+  pattern before rerunning the full gate.
 - Several other lints still take the coarse path shown below, so 8.1.2 should
   stay narrow and avoid promising a repository-wide cleanup in one turn.
 
@@ -433,6 +449,26 @@ Success criteria for the full validation step:
 
 ## Outcomes & Retrospective
 
-Not yet implemented. This section must be rewritten during execution with the
-final result, the validation evidence, any scope adjustments, and the lessons
-that future roadmap items 8.2.x, 8.3.x, and 8.4.x should inherit.
+Implemented as planned, without broadening the scope beyond 8.1.2.
+
+- Result:
+  `whitaker-common` now exposes `SpanRecoveryFrame`, `UserEditableSpan`, and
+  `recover_user_editable_span`; `whitaker` exposes `span_recovery_frames` and
+  `recover_user_editable_hir_span`; and `function_attrs_follow_docs` now relies
+  on the shared recovery helper instead of raw `source_callsite()`
+  normalization.
+- Validation:
+  Targeted checks passed for the new common unit tests, the new BDD harness,
+  and the adopter crate. End-of-turn gates all passed: `make fmt`,
+  `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, and
+  `make test`. The final test summary was
+  `1297 tests run: 1297 passed, 2 skipped`.
+- Scope adjustments:
+  None. The implementation touched the planned code and documentation areas
+  only, and did not spill into future roadmap items 8.2.x, 8.3.x, or 8.4.x.
+- Lessons:
+  Future lint drivers should use the shared helper as an emit-or-skip boundary
+  rather than inventing local `source_callsite()` heuristics. If a diagnostic
+  path needs to distinguish "direct" from "recovered", the pure common enum
+  already carries that information without pulling `rustc_private` into the
+  policy layer.

--- a/docs/execplans/8-1-2-shared-user-editable-span-recovery-helpers.md
+++ b/docs/execplans/8-1-2-shared-user-editable-span-recovery-helpers.md
@@ -1,8 +1,9 @@
 # Add shared user-editable span recovery helpers for macro-heavy `rstest` code paths
 
-This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
-`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
-`Outcomes & Retrospective` must be kept up to date as work proceeds.
+This Execution Plan (ExecPlan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
 
 Status: COMPLETE
 

--- a/docs/lints-for-rstest-fixtures-and-test-hygiene.md
+++ b/docs/lints-for-rstest-fixtures-and-test-hygiene.md
@@ -381,3 +381,26 @@ standard lints.
 - `common/Cargo.toml` now describes the current `rstest-bdd` 0.5.x workspace
   pin rather than the stale 0.2.x comment. That was documentation hygiene, not
   a behavioural change.
+
+## Implementation decisions (8.1.2)
+
+- Shared user-editable span recovery is now split between a pure
+  `whitaker_common::rstest` policy and a thin `whitaker::hir` adapter. The
+  common layer owns the ordered-frame policy, while the compiler-aware layer
+  converts `rustc_span::Span` call-site chains into those frames.
+- The recovery result is explicit rather than boolean. Callers now receive
+  `UserEditableSpan::{Direct, Recovered, MacroOnly}` so lint drivers can
+  distinguish "emit on the original span", "emit on a recovered invocation
+  site", and "skip because every frame is synthetic glue".
+- The `rustc` adapter walks `source_callsite()` frames until one of four
+  conditions holds: the current span is dummy, the current frame is already
+  user-editable, the next call-site is dummy, or `source_callsite()` stops
+  making progress by returning the same span again.
+- `function_attrs_follow_docs` is the first adopter. It now uses recovered
+  user-editable spans for attribute ordering and item-bound checks, while
+  dropping attributes whose recovery result is `MacroOnly` so compiler- or
+  macro-generated glue does not participate in comparisons.
+- The shared policy is covered twice: unit tests in `common::rstest::tests`
+  exercise the frame-selection algorithm directly, and `rstest-bdd` 0.5.x
+  scenarios in `common/tests/rstest_span_recovery_behaviour.rs` describe the
+  direct, recovered, first-match, and macro-only outcomes in user terms.

--- a/docs/ownership-shape-lints-design.md
+++ b/docs/ownership-shape-lints-design.md
@@ -1,15 +1,15 @@
 # Ownership shape lints design for value clones and local shared ownership
 
 Status: Proposed Scope: ownership-shape lints for Phase 9. Primary audience:
-Whitaker contributors and lint implementers. Review tags:
+Whitaker contributors and lint implementers.
 
-- "[type:docstyle]"
+Triage: `type:syntax/md` `type:docstyle`
 
 Precedent documents:
 
-- "[Whitaker Dylint suite design](whitaker-dylint-suite-design.md)"
-- "[Brain trust lints design](brain-trust-lints-design.md)"
-- "[Roadmap](roadmap.md)"
+- [Whitaker Dylint suite design](whitaker-dylint-suite-design.md)
+- [Brain trust lints design](brain-trust-lints-design.md)
+- [Roadmap](roadmap.md)
 
 ## 1. Purpose and scope
 

--- a/docs/ownership-shape-lints-design.md
+++ b/docs/ownership-shape-lints-design.md
@@ -1,16 +1,15 @@
----
-Status: Proposed
-Scope: ownership-shape lints for Phase 9.
-Primary audience: Whitaker contributors and lint implementers.
-Review tags:
-  - "[type:docstyle]"
-Precedent documents:
-  - "[Whitaker Dylint suite design](whitaker-dylint-suite-design.md)"
-  - "[Brain trust lints design](brain-trust-lints-design.md)"
-  - "[Roadmap](roadmap.md)"
----
-
 # Ownership shape lints design for value clones and local shared ownership
+
+Status: Proposed Scope: ownership-shape lints for Phase 9. Primary audience:
+Whitaker contributors and lint implementers. Review tags:
+
+- "[type:docstyle]"
+
+Precedent documents:
+
+- "[Whitaker Dylint suite design](whitaker-dylint-suite-design.md)"
+- "[Brain trust lints design](brain-trust-lints-design.md)"
+- "[Roadmap](roadmap.md)"
 
 ## 1. Purpose and scope
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -456,7 +456,7 @@
   [rstest fixture and test hygiene lints](lints-for-rstest-fixtures-and-test-hygiene.md)
    §Lint A: call-site fixture extraction and §Integration constraints. Requires
   1.1.1.
-- [ ] 8.1.2. Add shared user-editable span recovery helpers for macro-heavy
+- [x] 8.1.2. Add shared user-editable span recovery helpers for macro-heavy
   test code paths, and use them to avoid diagnostics on macro-only glue. See
   [rstest fixture and test hygiene lints](lints-for-rstest-fixtures-and-test-hygiene.md)
    §Integration constraints and §Lint A: call-site fixture extraction. Requires

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -298,10 +298,12 @@ ______________________________________________________________________
 
 ### `function_attrs_follow_docs`
 
-Ensures doc comments appear before all other outer attributes on functions,
+#### Purpose for `function_attrs_follow_docs`
+
+Ensures doc comments appear before other outer attributes on functions,
 methods, and trait methods.
 
-#### Macro-aware span recovery
+#### Scope and behaviour for `function_attrs_follow_docs`
 
 When attributes are generated or reordered by a procedural macro (for example
 `rstest` or `derive`), the lint recovers the original source span from the
@@ -310,19 +312,38 @@ user-written source location (macro-only glue) are silently excluded from the
 ordering check, so the lint never fires on compiler- or macro-generated code
 that the developer cannot edit.
 
-#### What is checked
+The lint checks:
 
 - Free functions annotated with `#[rstest]`, `#[test]`, or any other attribute
   that does not prevent source-span recovery.
 - Inherent methods and trait methods.
 
-#### What is ignored
+The lint ignores:
 
-- Attributes whose recovered span is macro-only (e.g., inline hints injected
-  by `#[derive(...)]`).
+- Attributes whose recovered span is macro-only (for example, inline hints
+  injected by `#[derive(...)]`).
 - Inner attributes (`#![...]`).
 
-#### How to fix&#8203;
+#### Configuration for `function_attrs_follow_docs`
+
+`function_attrs_follow_docs` has no configuration knobs.
+
+#### What is allowed for `function_attrs_follow_docs`
+
+- Doc comments that appear before every other outer attribute on the same
+  function, method, or trait method.
+- Macro-generated attributes whose spans are excluded because they are
+  macro-only.
+- Inner attributes, which are outside the lint's scope.
+
+#### What is denied for `function_attrs_follow_docs`
+
+- Outer attributes that appear before a doc comment on the same function,
+  method, or trait method.
+- Macro-expanded attributes that recover to a user-editable source span and
+  sort before the doc comment.
+
+#### How to fix for `function_attrs_follow_docs`
 
 Move doc comments so they appear before other outer attributes:
 
@@ -338,7 +359,7 @@ fn example() {}
 fn example() {}
 ```
 
-With `rstest`, place the doc comment before all attributes including the test
+With `rstest`, place the doc comment before all attributes, including the test
 annotation:
 
 ```rust

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -298,12 +298,14 @@ ______________________________________________________________________
 
 ### `function_attrs_follow_docs`
 
-#### Purpose for `function_attrs_follow_docs`
+<!-- markdownlint-disable-next-line MD024 -->
+#### Purpose
 
 Ensures doc comments appear before other outer attributes on functions,
 methods, and trait methods.
 
-#### Scope and behaviour for `function_attrs_follow_docs`
+<!-- markdownlint-disable-next-line MD024 -->
+#### Scope and behaviour
 
 When attributes are generated or reordered by a procedural macro (for example
 `rstest` or `derive`), the lint recovers the original source span from the
@@ -323,11 +325,13 @@ The lint ignores:
   injected by `#[derive(...)]`).
 - Inner attributes (`#![...]`).
 
-#### Configuration for `function_attrs_follow_docs`
+<!-- markdownlint-disable-next-line MD024 -->
+#### Configuration
 
 `function_attrs_follow_docs` has no configuration knobs.
 
-#### What is allowed for `function_attrs_follow_docs`
+<!-- markdownlint-disable-next-line MD024 -->
+#### What is allowed
 
 - Doc comments that appear before every other outer attribute on the same
   function, method, or trait method.
@@ -335,14 +339,16 @@ The lint ignores:
   macro-only.
 - Inner attributes, which are outside the lint's scope.
 
-#### What is denied for `function_attrs_follow_docs`
+<!-- markdownlint-disable-next-line MD024 -->
+#### What is denied
 
 - Outer attributes that appear before a doc comment on the same function,
   method, or trait method.
 - Macro-expanded attributes that recover to a user-editable source span and
   sort before the doc comment.
 
-#### How to fix for `function_attrs_follow_docs`
+<!-- markdownlint-disable-next-line MD024 -->
+#### How to fix
 
 Move doc comments so they appear before other outer attributes:
 
@@ -413,11 +419,13 @@ ______________________________________________________________________
 
 ### `no_expect_outside_tests`
 
+<!-- markdownlint-disable-next-line MD024 -->
 #### Purpose
 
 Detect test attributes correctly so `no_expect_outside_tests` can allow
 `.expect()` in recognized test-only code while still flagging production use.
 
+<!-- markdownlint-disable-next-line MD024 -->
 #### Scope and behaviour
 
 Whitaker recognizes `#[test]`, prelude-qualified `#[test]` forms,
@@ -427,6 +435,7 @@ Whitaker recognizes `#[test]`, prelude-qualified `#[test]` forms,
 setting extends that matching list with project-specific markers, so the lint
 treats those annotated functions as tests too.
 
+<!-- markdownlint-disable-next-line MD024 -->
 #### Configuration
 
 ```toml
@@ -462,6 +471,7 @@ fn helper() {
 }
 ```
 
+<!-- markdownlint-disable-next-line MD024 -->
 #### What is allowed
 
 - Default markers such as `#[test]`, `#[::test]`,
@@ -471,12 +481,14 @@ fn helper() {
 - Project-specific markers listed in `additional_test_attributes`, such as
   `#[wasm_bindgen_test]`
 
+<!-- markdownlint-disable-next-line MD024 -->
 #### What is denied
 
 Functions using `.expect()` will still be flagged when their test attribute is
 not in Whitaker's default list and is not listed in
 `additional_test_attributes`.
 
+<!-- markdownlint-disable-next-line MD024 -->
 #### How to fix
 
 - Add the missing test marker to `additional_test_attributes` if the function is

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -307,7 +307,7 @@ methods, and trait methods.
 <!-- markdownlint-disable-next-line MD024 -->
 #### Scope and behaviour
 
-When attributes are generated or reordered by a procedural macro (for example
+When attributes are generated or reordered by a procedural macro (for example,
 `rstest` or `derive`), the lint recovers the original source span from the
 macro expansion chain. Attributes whose spans cannot be traced back to any
 user-written source location (macro-only glue) are silently excluded from the

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -298,9 +298,33 @@ ______________________________________________________________________
 
 ### `function_attrs_follow_docs`
 
-Ensures doc comments appear before all other outer attributes on functions.
+Ensures doc comments appear before all other outer attributes on functions,
+methods, and trait methods.
 
-**How to fix:** Move doc comments to appear before other attributes:
+#### Macro-aware span recovery
+
+When attributes are generated or reordered by a procedural macro (for example
+`rstest` or `derive`), the lint recovers the original source span from the
+macro expansion chain. Attributes whose spans cannot be traced back to any
+user-written source location (macro-only glue) are silently excluded from the
+ordering check, so the lint never fires on compiler- or macro-generated code
+that the developer cannot edit.
+
+#### What is checked
+
+- Free functions annotated with `#[rstest]`, `#[test]`, or any other attribute
+  that does not prevent source-span recovery.
+- Inherent methods and trait methods.
+
+#### What is ignored
+
+- Attributes whose recovered span is macro-only (e.g., inline hints injected
+  by `#[derive(...)]`).
+- Inner attributes (`#![...]`).
+
+#### How to fix&#8203;
+
+Move doc comments so they appear before other outer attributes:
 
 ```rust
 // Wrong
@@ -312,6 +336,27 @@ fn example() {}
 /// This function does something.
 #[inline]
 fn example() {}
+```
+
+With `rstest`, place the doc comment before all attributes including the test
+annotation:
+
+```rust
+// Wrong
+#[rstest]
+#[case(1, 2, 3)]
+/// Verifies addition.
+fn adds(#[case] a: i32, #[case] b: i32, #[case] expected: i32) {
+    assert_eq!(a + b, expected);
+}
+
+// Correct
+/// Verifies addition.
+#[rstest]
+#[case(1, 2, 3)]
+fn adds(#[case] a: i32, #[case] b: i32, #[case] expected: i32) {
+    assert_eq!(a + b, expected);
+}
 ```
 
 ______________________________________________________________________

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -314,10 +314,8 @@ that the developer cannot edit.
 
 The lint checks:
 
-- Every free function, inherent method, and trait method.
-- Macro-aware span recovery still applies when those items carry attributes
-  such as `#[rstest]` or `#[test]`; these are examples, not the condition that
-  enables the lint.
+- All functions, methods, and trait methods that carry at least one outer
+  attribute — including macro-heavy cases such as `#[rstest]` and `#[test]`.
 
 The lint ignores:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -314,9 +314,10 @@ that the developer cannot edit.
 
 The lint checks:
 
-- Free functions annotated with `#[rstest]`, `#[test]`, or any other attribute
-  that does not prevent source-span recovery.
-- Inherent methods and trait methods.
+- Every free function, inherent method, and trait method.
+- Macro-aware span recovery still applies when those items carry attributes
+  such as `#[rstest]` or `#[test]`; these are examples, not the condition that
+  enables the lint.
 
 The lint ignores:
 

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -7,7 +7,9 @@ use rustc_hir as hir;
 use rustc_hir::attrs::AttributeKind as HirAttributeKind;
 use rustc_lint::LateContext;
 use rustc_span::Span;
-use whitaker_common::{Attribute, AttributeKind, AttributePath};
+use whitaker_common::{
+    Attribute, AttributeKind, AttributePath, SpanRecoveryFrame, recover_user_editable_span,
+};
 
 /// Returns the body span for an inline or file-backed module.
 ///
@@ -51,6 +53,45 @@ pub fn has_test_like_hir_attributes(
         .iter()
         .filter_map(attribute_from_hir)
         .any(|attribute| attribute.is_test_like_with(additional))
+}
+
+/// Collects ordered span-recovery frames for a `rustc_span::Span`.
+///
+/// The first frame is always the original span when it is not dummy. Later
+/// frames follow the `source_callsite()` chain until the walk stops making
+/// progress or reaches a user-editable span.
+#[must_use]
+pub fn span_recovery_frames(span: Span) -> Vec<SpanRecoveryFrame<Span>> {
+    let mut frames = Vec::new();
+    let mut current = span;
+
+    loop {
+        if current.is_dummy() {
+            break;
+        }
+
+        let from_expansion = current.from_expansion();
+        frames.push(SpanRecoveryFrame::new(current, from_expansion));
+
+        if !from_expansion {
+            break;
+        }
+
+        let next = current.source_callsite();
+        if next.is_dummy() || next == current {
+            break;
+        }
+
+        current = next;
+    }
+
+    frames
+}
+
+/// Recovers the first user-editable HIR span from a macro expansion chain.
+#[must_use]
+pub fn recover_user_editable_hir_span(span: Span) -> Option<Span> {
+    recover_user_editable_span(span_recovery_frames(span).as_slice()).into_option()
 }
 
 fn attribute_from_hir(attr: &hir::Attribute) -> Option<Attribute> {

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -318,7 +318,10 @@ mod tests {
     use rustc_span::def_id::{DefId, DefPathHash, LocalDefId};
     use rustc_span::edition::Edition;
     use rustc_span::hygiene::{ExpnData, ExpnKind, LocalExpnId, MacroKind, Transparency};
-    use rustc_span::{BytePos, DUMMY_SP, Span, SpanData, StableSourceFileId, SyntaxContext, sym};
+    use rustc_span::{
+        BytePos, DUMMY_SP, Span, SpanData, StableSourceFileId, SyntaxContext,
+        create_default_session_globals_then, sym,
+    };
     use whitaker_common::SpanRecoveryFrame;
 
     fn test_span(lo: u32, hi: u32) -> Span {
@@ -358,21 +361,23 @@ mod tests {
     }
 
     fn expanded_span(span: Span, call_site: Span) -> Span {
-        let expn_id = LocalExpnId::fresh_empty();
-        expn_id.set_expn_data(
-            ExpnData::default(
-                ExpnKind::Macro(MacroKind::Bang, sym::include),
-                call_site,
-                Edition::Edition2024,
-                None,
-                None,
-            ),
-            TestHashStableContext,
-        );
+        create_default_session_globals_then(|| {
+            let expn_id = LocalExpnId::fresh_empty();
+            expn_id.set_expn_data(
+                ExpnData::default(
+                    ExpnKind::Macro(MacroKind::Bang, sym::include),
+                    call_site,
+                    Edition::Edition2024,
+                    None,
+                    None,
+                ),
+                TestHashStableContext,
+            );
 
-        span.with_ctxt(
-            SyntaxContext::root().apply_mark(expn_id.to_expn_id(), Transparency::Transparent),
-        )
+            span.with_ctxt(
+                SyntaxContext::root().apply_mark(expn_id.to_expn_id(), Transparency::Transparent),
+            )
+        })
     }
 
     #[test]

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -313,4 +313,35 @@ mod tests {
     //! - `crates/no_expect_outside_tests/examples/pass_expect_in_rstest_harness.rs`
     //! - `crates/no_expect_outside_tests/src/lib_ui_tests.rs`
     //!   (`rstest_example_compiles_under_test_harness`)
+    use super::{recover_user_editable_hir_span, span_recovery_frames};
+    use rustc_span::{BytePos, DUMMY_SP, Span};
+    use whitaker_common::SpanRecoveryFrame;
+
+    fn test_span(lo: u32, hi: u32) -> Span {
+        Span::with_root_ctxt(BytePos(lo), BytePos(hi))
+    }
+
+    #[test]
+    fn dummy_span_yields_no_frames() {
+        assert!(span_recovery_frames(DUMMY_SP).is_empty());
+    }
+
+    #[test]
+    fn non_expanded_span_yields_single_direct_frame() {
+        let span = test_span(10, 20);
+        let frames = span_recovery_frames(span);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames.first(), Some(&SpanRecoveryFrame::new(span, false)));
+    }
+
+    #[test]
+    fn recover_user_editable_hir_span_returns_none_for_dummy() {
+        assert_eq!(recover_user_editable_hir_span(DUMMY_SP), None);
+    }
+
+    #[test]
+    fn recover_user_editable_hir_span_returns_direct_span() {
+        let span = test_span(10, 20);
+        assert_eq!(recover_user_editable_hir_span(span), Some(span));
+    }
 }

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -318,10 +318,7 @@ mod tests {
     use rustc_span::def_id::{DefId, DefPathHash, LocalDefId};
     use rustc_span::edition::Edition;
     use rustc_span::hygiene::{ExpnData, ExpnKind, LocalExpnId, MacroKind, Transparency};
-    use rustc_span::{
-        BytePos, DUMMY_SP, Span, SpanData, StableSourceFileId, SyntaxContext,
-        create_default_session_globals_then, sym,
-    };
+    use rustc_span::{BytePos, DUMMY_SP, Span, SpanData, StableSourceFileId, SyntaxContext, sym};
     use whitaker_common::SpanRecoveryFrame;
 
     fn test_span(lo: u32, hi: u32) -> Span {
@@ -361,23 +358,21 @@ mod tests {
     }
 
     fn expanded_span(span: Span, call_site: Span) -> Span {
-        create_default_session_globals_then(|| {
-            let expn_id = LocalExpnId::fresh_empty();
-            expn_id.set_expn_data(
-                ExpnData::default(
-                    ExpnKind::Macro(MacroKind::Bang, sym::include),
-                    call_site,
-                    Edition::Edition2024,
-                    None,
-                    None,
-                ),
-                TestHashStableContext,
-            );
+        let expn_id = LocalExpnId::fresh_empty();
+        expn_id.set_expn_data(
+            ExpnData::default(
+                ExpnKind::Macro(MacroKind::Bang, sym::include),
+                call_site,
+                Edition::Edition2024,
+                None,
+                None,
+            ),
+            TestHashStableContext,
+        );
 
-            span.with_ctxt(
-                SyntaxContext::root().apply_mark(expn_id.to_expn_id(), Transparency::Transparent),
-            )
-        })
+        span.with_ctxt(
+            SyntaxContext::root().apply_mark(expn_id.to_expn_id(), Transparency::Transparent),
+        )
     }
 
     #[test]
@@ -397,16 +392,18 @@ mod tests {
 
     #[test]
     fn recoverable_span_yields_expansion_frame_then_callsite() {
-        let recovered = test_span(10, 20);
-        let expanded = expanded_span(test_span(30, 40), recovered);
+        rustc_span::create_default_session_globals_then(|| {
+            let recovered = test_span(10, 20);
+            let expanded = expanded_span(test_span(30, 40), recovered);
 
-        assert_eq!(
-            span_recovery_frames(expanded),
-            vec![
-                SpanRecoveryFrame::new(expanded, true),
-                SpanRecoveryFrame::new(recovered, false),
-            ]
-        );
-        assert_eq!(recover_user_editable_hir_span(expanded), Some(recovered));
+            assert_eq!(
+                span_recovery_frames(expanded),
+                vec![
+                    SpanRecoveryFrame::new(expanded, true),
+                    SpanRecoveryFrame::new(recovered, false),
+                ]
+            );
+            assert_eq!(recover_user_editable_hir_span(expanded), Some(recovered));
+        });
     }
 }

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -58,55 +58,42 @@ pub fn has_test_like_hir_attributes(
 /// The first frame is always the original span when it is not dummy. Later
 /// frames follow the `source_callsite()` chain until the walk stops making
 /// progress or reaches a user-editable span.
+fn walk_span_chain(start: Span) -> impl Iterator<Item = Span> {
+    let mut current = Some(start);
+
+    std::iter::from_fn(move || {
+        let span = current?;
+        if span.is_dummy() {
+            current = None;
+            return None;
+        }
+
+        current = if span.from_expansion() {
+            let next = span.source_callsite();
+            if next.is_dummy() || next == span {
+                None
+            } else {
+                Some(next)
+            }
+        } else {
+            None
+        };
+
+        Some(span)
+    })
+}
+
 #[must_use]
 pub fn span_recovery_frames(span: Span) -> Vec<SpanRecoveryFrame<Span>> {
-    let mut frames = Vec::new();
-    let mut current = span;
-
-    loop {
-        if current.is_dummy() {
-            break;
-        }
-
-        let from_expansion = current.from_expansion();
-        frames.push(SpanRecoveryFrame::new(current, from_expansion));
-
-        if !from_expansion {
-            break;
-        }
-
-        let next = current.source_callsite();
-        if next.is_dummy() || next == current {
-            break;
-        }
-
-        current = next;
-    }
-
-    frames
+    walk_span_chain(span)
+        .map(|current| SpanRecoveryFrame::new(current, current.from_expansion()))
+        .collect()
 }
 
 /// Recovers the first user-editable HIR span from a macro expansion chain.
 #[must_use]
 pub fn recover_user_editable_hir_span(span: Span) -> Option<Span> {
-    let mut current = span;
-
-    loop {
-        if current.is_dummy() {
-            return None;
-        }
-
-        if !current.from_expansion() {
-            return Some(current);
-        }
-
-        let next = current.source_callsite();
-        if next.is_dummy() || next == current {
-            return None;
-        }
-
-        current = next;
-    }
+    walk_span_chain(span).find(|current| !current.from_expansion())
 }
 
 fn attribute_from_hir(attr: &hir::Attribute) -> Option<Attribute> {
@@ -314,6 +301,7 @@ mod tests {
     //! - `crates/no_expect_outside_tests/src/lib_ui_tests.rs`
     //!   (`rstest_example_compiles_under_test_harness`)
     use super::{recover_user_editable_hir_span, span_recovery_frames};
+    use rstest::{fixture, rstest};
     use rustc_data_structures::stable_hasher::HashingControls;
     use rustc_span::def_id::{DefId, DefPathHash, LocalDefId};
     use rustc_span::edition::Edition;
@@ -375,35 +363,54 @@ mod tests {
         )
     }
 
-    #[test]
-    fn dummy_span_yields_no_frames_or_recovered_span() {
-        assert!(span_recovery_frames(DUMMY_SP).is_empty());
-        assert_eq!(recover_user_editable_hir_span(DUMMY_SP), None);
+    #[derive(Clone, Copy)]
+    enum SpanRecoveryCase {
+        Dummy,
+        Direct,
+        Recovered,
     }
 
-    #[test]
-    fn non_expanded_span_yields_single_direct_frame_and_span() {
-        let span = test_span(10, 20);
-        let frames = span_recovery_frames(span);
-        assert_eq!(frames.len(), 1);
-        assert_eq!(frames.first(), Some(&SpanRecoveryFrame::new(span, false)));
-        assert_eq!(recover_user_editable_hir_span(span), Some(span));
+    #[fixture]
+    fn build_span_case()
+    -> impl Fn(SpanRecoveryCase) -> (Span, Vec<SpanRecoveryFrame<Span>>, Option<Span>) {
+        move |case| match case {
+            SpanRecoveryCase::Dummy => (DUMMY_SP, vec![], None),
+            SpanRecoveryCase::Direct => {
+                let span = test_span(10, 20);
+                (span, vec![SpanRecoveryFrame::new(span, false)], Some(span))
+            }
+            SpanRecoveryCase::Recovered => {
+                let recovered = test_span(10, 20);
+                let expanded = expanded_span(test_span(30, 40), recovered);
+
+                (
+                    expanded,
+                    vec![
+                        SpanRecoveryFrame::new(expanded, true),
+                        SpanRecoveryFrame::new(recovered, false),
+                    ],
+                    Some(recovered),
+                )
+            }
+        }
     }
 
-    #[test]
-    fn recoverable_span_yields_expansion_frame_then_callsite() {
+    #[rstest]
+    #[case::dummy(SpanRecoveryCase::Dummy)]
+    #[case::direct(SpanRecoveryCase::Direct)]
+    #[case::recovered(SpanRecoveryCase::Recovered)]
+    fn span_recovery_walks_expected_frames(
+        #[case] case: SpanRecoveryCase,
+        build_span_case: impl Fn(SpanRecoveryCase) -> (Span, Vec<SpanRecoveryFrame<Span>>, Option<Span>),
+    ) {
         rustc_span::create_default_session_globals_then(|| {
-            let recovered = test_span(10, 20);
-            let expanded = expanded_span(test_span(30, 40), recovered);
+            let (span, expected_frames, expected_recovered_span) = build_span_case(case);
 
+            assert_eq!(span_recovery_frames(span), expected_frames);
             assert_eq!(
-                span_recovery_frames(expanded),
-                vec![
-                    SpanRecoveryFrame::new(expanded, true),
-                    SpanRecoveryFrame::new(recovered, false),
-                ]
+                recover_user_editable_hir_span(span),
+                expected_recovered_span
             );
-            assert_eq!(recover_user_editable_hir_span(expanded), Some(recovered));
         });
     }
 }

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -7,9 +7,7 @@ use rustc_hir as hir;
 use rustc_hir::attrs::AttributeKind as HirAttributeKind;
 use rustc_lint::LateContext;
 use rustc_span::Span;
-use whitaker_common::{
-    Attribute, AttributeKind, AttributePath, SpanRecoveryFrame, recover_user_editable_span,
-};
+use whitaker_common::{Attribute, AttributeKind, AttributePath, SpanRecoveryFrame};
 
 /// Returns the body span for an inline or file-backed module.
 ///
@@ -91,7 +89,24 @@ pub fn span_recovery_frames(span: Span) -> Vec<SpanRecoveryFrame<Span>> {
 /// Recovers the first user-editable HIR span from a macro expansion chain.
 #[must_use]
 pub fn recover_user_editable_hir_span(span: Span) -> Option<Span> {
-    recover_user_editable_span(span_recovery_frames(span).as_slice()).into_option()
+    let mut current = span;
+
+    loop {
+        if current.is_dummy() {
+            return None;
+        }
+
+        if !current.from_expansion() {
+            return Some(current);
+        }
+
+        let next = current.source_callsite();
+        if next.is_dummy() || next == current {
+            return None;
+        }
+
+        current = next;
+    }
 }
 
 fn attribute_from_hir(attr: &hir::Attribute) -> Option<Attribute> {

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -314,34 +314,94 @@ mod tests {
     //! - `crates/no_expect_outside_tests/src/lib_ui_tests.rs`
     //!   (`rstest_example_compiles_under_test_harness`)
     use super::{recover_user_editable_hir_span, span_recovery_frames};
-    use rustc_span::{BytePos, DUMMY_SP, Span};
+    use rustc_data_structures::stable_hasher::HashingControls;
+    use rustc_span::def_id::{DefId, DefPathHash, LocalDefId};
+    use rustc_span::edition::Edition;
+    use rustc_span::hygiene::{ExpnData, ExpnKind, LocalExpnId, MacroKind, Transparency};
+    use rustc_span::{BytePos, DUMMY_SP, Span, SpanData, StableSourceFileId, SyntaxContext, sym};
     use whitaker_common::SpanRecoveryFrame;
 
     fn test_span(lo: u32, hi: u32) -> Span {
         Span::with_root_ctxt(BytePos(lo), BytePos(hi))
     }
 
+    #[derive(Clone, Copy)]
+    struct TestHashStableContext;
+
+    impl rustc_span::HashStableContext for TestHashStableContext {
+        fn def_path_hash(&self, _def_id: DefId) -> DefPathHash {
+            DefPathHash::default()
+        }
+
+        fn hash_spans(&self) -> bool {
+            false
+        }
+
+        fn unstable_opts_incremental_ignore_spans(&self) -> bool {
+            true
+        }
+
+        fn def_span(&self, _def_id: LocalDefId) -> Span {
+            DUMMY_SP
+        }
+
+        fn span_data_to_lines_and_cols(
+            &mut self,
+            _span: &SpanData,
+        ) -> Option<(StableSourceFileId, usize, BytePos, usize, BytePos)> {
+            None
+        }
+
+        fn hashing_controls(&self) -> HashingControls {
+            HashingControls { hash_spans: false }
+        }
+    }
+
+    fn expanded_span(span: Span, call_site: Span) -> Span {
+        let expn_id = LocalExpnId::fresh_empty();
+        expn_id.set_expn_data(
+            ExpnData::default(
+                ExpnKind::Macro(MacroKind::Bang, sym::include),
+                call_site,
+                Edition::Edition2024,
+                None,
+                None,
+            ),
+            TestHashStableContext,
+        );
+
+        span.with_ctxt(
+            SyntaxContext::root().apply_mark(expn_id.to_expn_id(), Transparency::Transparent),
+        )
+    }
+
     #[test]
-    fn dummy_span_yields_no_frames() {
+    fn dummy_span_yields_no_frames_or_recovered_span() {
         assert!(span_recovery_frames(DUMMY_SP).is_empty());
-    }
-
-    #[test]
-    fn non_expanded_span_yields_single_direct_frame() {
-        let span = test_span(10, 20);
-        let frames = span_recovery_frames(span);
-        assert_eq!(frames.len(), 1);
-        assert_eq!(frames.first(), Some(&SpanRecoveryFrame::new(span, false)));
-    }
-
-    #[test]
-    fn recover_user_editable_hir_span_returns_none_for_dummy() {
         assert_eq!(recover_user_editable_hir_span(DUMMY_SP), None);
     }
 
     #[test]
-    fn recover_user_editable_hir_span_returns_direct_span() {
+    fn non_expanded_span_yields_single_direct_frame_and_span() {
         let span = test_span(10, 20);
+        let frames = span_recovery_frames(span);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames.first(), Some(&SpanRecoveryFrame::new(span, false)));
         assert_eq!(recover_user_editable_hir_span(span), Some(span));
+    }
+
+    #[test]
+    fn recoverable_span_yields_expansion_frame_then_callsite() {
+        let recovered = test_span(10, 20);
+        let expanded = expanded_span(test_span(30, 40), recovered);
+
+        assert_eq!(
+            span_recovery_frames(expanded),
+            vec![
+                SpanRecoveryFrame::new(expanded, true),
+                SpanRecoveryFrame::new(recovered, false),
+            ]
+        );
+        assert_eq!(recover_user_editable_hir_span(expanded), Some(recovered));
     }
 }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -53,11 +53,12 @@ pub fn has_test_like_hir_attributes(
         .any(|attribute| attribute.is_test_like_with(additional))
 }
 
-/// Collects ordered span-recovery frames for a `rustc_span::Span`.
+/// Internal iterator over a `Span` callsite chain.
 ///
-/// The first frame is always the original span when it is not dummy. Later
-/// frames follow the `source_callsite()` chain until the walk stops making
-/// progress or reaches a user-editable span.
+/// The walk yields the original span first, then follows `source_callsite()`
+/// while the current span still comes from expansion. It stops when it reaches
+/// a dummy span, a non-expansion span, or a callsite that is dummy or makes no
+/// progress.
 fn walk_span_chain(start: Span) -> impl Iterator<Item = Span> {
     let mut current = Some(start);
 
@@ -83,6 +84,15 @@ fn walk_span_chain(start: Span) -> impl Iterator<Item = Span> {
     })
 }
 
+/// Collects ordered [`SpanRecoveryFrame`] values for a `rustc_span::Span`.
+///
+/// The first frame is always the original span when it is not dummy. Later
+/// frames follow the `source_callsite()` chain produced by
+/// [`walk_span_chain`], preserving each yielded span together with its
+/// `from_expansion()` state in a [`SpanRecoveryFrame`].
+///
+/// The walk stops when it reaches a dummy span, a user-editable span, or a
+/// `source_callsite()` value that is dummy or makes no further progress.
 #[must_use]
 pub fn span_recovery_frames(span: Span) -> Vec<SpanRecoveryFrame<Span>> {
     walk_span_chain(span)
@@ -284,133 +294,4 @@ fn module_has_harness_descriptor<'tcx>(
         })
 }
 
-#[cfg(test)]
-mod tests {
-    //! `collect_rstest_companion_test_functions` depends on a real
-    //! `rustc_lint::LateContext`, which is only available while rustc is
-    //! walking fully lowered HIR for an actual compilation session. The
-    //! helper inspects sibling HIR items, parent-module relationships, and
-    //! harness-generated companion modules, so there is no stable, lightweight
-    //! unit-test seam that can construct the required `LateContext` and HIR in
-    //! isolation inside this crate.
-    //!
-    //! Coverage therefore lives in the no-expect lint's UI/example harness
-    //! regressions, which exercise this detection path end-to-end with real
-    //! rstest expansion output:
-    //! - `crates/no_expect_outside_tests/examples/pass_expect_in_rstest_harness.rs`
-    //! - `crates/no_expect_outside_tests/src/lib_ui_tests.rs`
-    //!   (`rstest_example_compiles_under_test_harness`)
-    use super::{recover_user_editable_hir_span, span_recovery_frames};
-    use rstest::{fixture, rstest};
-    use rustc_data_structures::stable_hasher::HashingControls;
-    use rustc_span::def_id::{DefId, DefPathHash, LocalDefId};
-    use rustc_span::edition::Edition;
-    use rustc_span::hygiene::{ExpnData, ExpnKind, LocalExpnId, MacroKind, Transparency};
-    use rustc_span::{BytePos, DUMMY_SP, Span, SpanData, StableSourceFileId, SyntaxContext, sym};
-    use whitaker_common::SpanRecoveryFrame;
-
-    fn test_span(lo: u32, hi: u32) -> Span {
-        Span::with_root_ctxt(BytePos(lo), BytePos(hi))
-    }
-
-    #[derive(Clone, Copy)]
-    struct TestHashStableContext;
-
-    impl rustc_span::HashStableContext for TestHashStableContext {
-        fn def_path_hash(&self, _def_id: DefId) -> DefPathHash {
-            DefPathHash::default()
-        }
-
-        fn hash_spans(&self) -> bool {
-            false
-        }
-
-        fn unstable_opts_incremental_ignore_spans(&self) -> bool {
-            true
-        }
-
-        fn def_span(&self, _def_id: LocalDefId) -> Span {
-            DUMMY_SP
-        }
-
-        fn span_data_to_lines_and_cols(
-            &mut self,
-            _span: &SpanData,
-        ) -> Option<(StableSourceFileId, usize, BytePos, usize, BytePos)> {
-            None
-        }
-
-        fn hashing_controls(&self) -> HashingControls {
-            HashingControls { hash_spans: false }
-        }
-    }
-
-    fn expanded_span(span: Span, call_site: Span) -> Span {
-        let expn_id = LocalExpnId::fresh_empty();
-        expn_id.set_expn_data(
-            ExpnData::default(
-                ExpnKind::Macro(MacroKind::Bang, sym::include),
-                call_site,
-                Edition::Edition2024,
-                None,
-                None,
-            ),
-            TestHashStableContext,
-        );
-
-        span.with_ctxt(
-            SyntaxContext::root().apply_mark(expn_id.to_expn_id(), Transparency::Transparent),
-        )
-    }
-
-    #[derive(Clone, Copy)]
-    enum SpanRecoveryCase {
-        Dummy,
-        Direct,
-        Recovered,
-    }
-
-    #[fixture]
-    fn build_span_case()
-    -> impl Fn(SpanRecoveryCase) -> (Span, Vec<SpanRecoveryFrame<Span>>, Option<Span>) {
-        move |case| match case {
-            SpanRecoveryCase::Dummy => (DUMMY_SP, vec![], None),
-            SpanRecoveryCase::Direct => {
-                let span = test_span(10, 20);
-                (span, vec![SpanRecoveryFrame::new(span, false)], Some(span))
-            }
-            SpanRecoveryCase::Recovered => {
-                let recovered = test_span(10, 20);
-                let expanded = expanded_span(test_span(30, 40), recovered);
-
-                (
-                    expanded,
-                    vec![
-                        SpanRecoveryFrame::new(expanded, true),
-                        SpanRecoveryFrame::new(recovered, false),
-                    ],
-                    Some(recovered),
-                )
-            }
-        }
-    }
-
-    #[rstest]
-    #[case::dummy(SpanRecoveryCase::Dummy)]
-    #[case::direct(SpanRecoveryCase::Direct)]
-    #[case::recovered(SpanRecoveryCase::Recovered)]
-    fn span_recovery_walks_expected_frames(
-        #[case] case: SpanRecoveryCase,
-        build_span_case: impl Fn(SpanRecoveryCase) -> (Span, Vec<SpanRecoveryFrame<Span>>, Option<Span>),
-    ) {
-        rustc_span::create_default_session_globals_then(|| {
-            let (span, expected_frames, expected_recovered_span) = build_span_case(case);
-
-            assert_eq!(span_recovery_frames(span), expected_frames);
-            assert_eq!(
-                recover_user_editable_hir_span(span),
-                expected_recovered_span
-            );
-        });
-    }
-}
+mod tests;

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -294,4 +294,5 @@ fn module_has_harness_descriptor<'tcx>(
         })
 }
 
+#[cfg(test)]
 mod tests;

--- a/src/hir/tests.rs
+++ b/src/hir/tests.rs
@@ -1,4 +1,4 @@
-//! Tests for HIR span recovery helpers and their macro-expansion behavior.
+//! Tests for HIR span recovery helpers and their macro-expansion behaviour.
 //!
 //! `collect_rstest_companion_test_functions` depends on a real
 //! `rustc_lint::LateContext`, which is only available while rustc is walking

--- a/src/hir/tests.rs
+++ b/src/hir/tests.rs
@@ -1,0 +1,130 @@
+//! Tests for HIR span recovery helpers and their macro-expansion behavior.
+//!
+//! `collect_rstest_companion_test_functions` depends on a real
+//! `rustc_lint::LateContext`, which is only available while rustc is walking
+//! fully lowered HIR for an actual compilation session. The helper inspects
+//! sibling HIR items, parent-module relationships, and harness-generated
+//! companion modules, so there is no stable, lightweight unit-test seam that
+//! can construct the required `LateContext` and HIR in isolation inside this
+//! crate.
+//!
+//! Coverage therefore lives in the no-expect lint's UI/example harness
+//! regressions, which exercise this detection path end-to-end with real rstest
+//! expansion output:
+//! - `crates/no_expect_outside_tests/examples/pass_expect_in_rstest_harness.rs`
+//! - `crates/no_expect_outside_tests/src/lib_ui_tests.rs`
+//!   (`rstest_example_compiles_under_test_harness`)
+
+use super::{recover_user_editable_hir_span, span_recovery_frames};
+use rstest::{fixture, rstest};
+use rustc_data_structures::stable_hasher::HashingControls;
+use rustc_span::def_id::{DefId, DefPathHash, LocalDefId};
+use rustc_span::edition::Edition;
+use rustc_span::hygiene::{ExpnData, ExpnKind, LocalExpnId, MacroKind, Transparency};
+use rustc_span::{BytePos, DUMMY_SP, Span, SpanData, StableSourceFileId, SyntaxContext, sym};
+use whitaker_common::SpanRecoveryFrame;
+
+fn test_span(lo: u32, hi: u32) -> Span {
+    Span::with_root_ctxt(BytePos(lo), BytePos(hi))
+}
+
+#[derive(Clone, Copy)]
+struct TestHashStableContext;
+
+impl rustc_span::HashStableContext for TestHashStableContext {
+    fn def_path_hash(&self, _def_id: DefId) -> DefPathHash {
+        DefPathHash::default()
+    }
+
+    fn hash_spans(&self) -> bool {
+        false
+    }
+
+    fn unstable_opts_incremental_ignore_spans(&self) -> bool {
+        true
+    }
+
+    fn def_span(&self, _def_id: LocalDefId) -> Span {
+        DUMMY_SP
+    }
+
+    fn span_data_to_lines_and_cols(
+        &mut self,
+        _span: &SpanData,
+    ) -> Option<(StableSourceFileId, usize, BytePos, usize, BytePos)> {
+        None
+    }
+
+    fn hashing_controls(&self) -> HashingControls {
+        HashingControls { hash_spans: false }
+    }
+}
+
+fn expanded_span(span: Span, call_site: Span) -> Span {
+    let expn_id = LocalExpnId::fresh_empty();
+    expn_id.set_expn_data(
+        ExpnData::default(
+            ExpnKind::Macro(MacroKind::Bang, sym::include),
+            call_site,
+            Edition::Edition2024,
+            None,
+            None,
+        ),
+        TestHashStableContext,
+    );
+
+    span.with_ctxt(
+        SyntaxContext::root().apply_mark(expn_id.to_expn_id(), Transparency::Transparent),
+    )
+}
+
+#[derive(Clone, Copy)]
+enum SpanRecoveryCase {
+    Dummy,
+    Direct,
+    Recovered,
+}
+
+#[fixture]
+fn build_span_case()
+-> impl Fn(SpanRecoveryCase) -> (Span, Vec<SpanRecoveryFrame<Span>>, Option<Span>) {
+    move |case| match case {
+        SpanRecoveryCase::Dummy => (DUMMY_SP, vec![], None),
+        SpanRecoveryCase::Direct => {
+            let span = test_span(10, 20);
+            (span, vec![SpanRecoveryFrame::new(span, false)], Some(span))
+        }
+        SpanRecoveryCase::Recovered => {
+            let recovered = test_span(10, 20);
+            let expanded = expanded_span(test_span(30, 40), recovered);
+
+            (
+                expanded,
+                vec![
+                    SpanRecoveryFrame::new(expanded, true),
+                    SpanRecoveryFrame::new(recovered, false),
+                ],
+                Some(recovered),
+            )
+        }
+    }
+}
+
+#[rstest]
+#[case::dummy(SpanRecoveryCase::Dummy)]
+#[case::direct(SpanRecoveryCase::Direct)]
+#[case::recovered(SpanRecoveryCase::Recovered)]
+fn span_recovery_walks_expected_frames(
+    #[case] case: SpanRecoveryCase,
+    build_span_case: impl Fn(SpanRecoveryCase) -> (Span, Vec<SpanRecoveryFrame<Span>>, Option<Span>),
+) {
+    rustc_span::create_default_session_globals_then(|| {
+        let (span, expected_frames, expected_recovered_span) = build_span_case(case);
+
+        assert_eq!(span_recovery_frames(span), expected_frames);
+        assert_eq!(
+            recover_user_editable_hir_span(span),
+            expected_recovered_span
+        );
+    });
+}

--- a/src/hir/tests.rs
+++ b/src/hir/tests.rs
@@ -82,6 +82,7 @@ fn expanded_span(span: Span, call_site: Span) -> Span {
 enum SpanRecoveryCase {
     Dummy,
     Direct,
+    MacroOnly,
     Recovered,
 }
 
@@ -93,6 +94,10 @@ fn build_span_case()
         SpanRecoveryCase::Direct => {
             let span = test_span(10, 20);
             (span, vec![SpanRecoveryFrame::new(span, false)], Some(span))
+        }
+        SpanRecoveryCase::MacroOnly => {
+            let expanded = expanded_span(test_span(30, 40), DUMMY_SP);
+            (expanded, vec![SpanRecoveryFrame::new(expanded, true)], None)
         }
         SpanRecoveryCase::Recovered => {
             let recovered = test_span(10, 20);
@@ -113,6 +118,7 @@ fn build_span_case()
 #[rstest]
 #[case::dummy(SpanRecoveryCase::Dummy)]
 #[case::direct(SpanRecoveryCase::Direct)]
+#[case::macro_only(SpanRecoveryCase::MacroOnly)]
 #[case::recovered(SpanRecoveryCase::Recovered)]
 fn span_recovery_walks_expected_frames(
     #[case] case: SpanRecoveryCase,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 // Link against `rustc_driver` only when consumers need the dylint driver runtime.
 // Unit tests of this crate should not pull the compiler driver to avoid the
 // duplicated `std`/`core` link errors seen during all-features test runs.
+#[cfg(feature = "dylint-driver")]
+extern crate rustc_data_structures;
 #[cfg(all(feature = "dylint-driver", not(test)))]
 extern crate rustc_driver;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,9 @@ pub mod testing;
 
 pub use config::{ModuleMaxLinesConfig, SharedConfig};
 #[cfg(feature = "dylint-driver")]
-pub use hir::{module_body_span, module_header_span};
+pub use hir::{
+    module_body_span, module_header_span, recover_user_editable_hir_span, span_recovery_frames,
+};
 pub use lints::{LintCrateTemplate, TemplateError, TemplateFiles};
 
 /// Returns a greeting for the library.


### PR DESCRIPTION
## Summary
- Status: COMPLETE
- Implements the plan for 8.1.2: shared user-editable span recovery helpers for macro-heavy `rstest` code paths. This turns the prior planning material into an implemented foundation with a pure policy in `whitaker-common`, a thin `rustc_span::Span` adapter in `whitaker`, and an adopter in `function_attrs_follow_docs` demonstrating the approach. Includes tests, docs, and execution-plan updates.

## Rationale
- Move from planning material toward a concrete implementation that can be exercised by a real adopter and validated with unit and behavioural tests.
- Enforce a clean policy boundary: pure policy in `whitaker-common`, adapter in `whitaker`, and a single adopter to demonstrate correctness and reduce crate-local logic in macro-heavy paths.
- Provide gating, tests, and documentation to prevent scope creep and ensure future updates stay aligned with 8.1.2 goals.

## Changes
- Add new span-recovery module and tests:
  - common/src/rstest/span.rs (new)
  - common/src/rstest/mod.rs (exports updated)
  - common/src/lib.rs (exported SpanRecoveryFrame, UserEditableSpan, recover_user_editable_span)
  - common/src/rstest/tests.rs (unit tests for recovery policy)
  - common/tests/features/rstest_span_recovery.feature (Behaviour-driven tests)
  - common/tests/rstest_span_recovery_behaviour.rs (BDD-based tests)
- Implemented rustc-span adapter and helpers:
  - src/hir.rs (span_recovery_frames and recover_user_editable_hir_span added)
  - src/lib.rs (re-exports for adapter behind dylint-driver feature)
- Adopter integration:
  - crates/function_attrs_follow_docs/src/driver.rs updated to use the shared recovery adapter.
  - crates/function_attrs_follow_docs/src/tests/order_detection.rs updated for new surface usage.
- Documentation and exec plan:
  - docs/execplans/8-1-2-shared-user-editable-span-recovery-helpers.md added (ExecPlan with status COMPLETE)
  - docs/lints-for-rstest-fixtures-and-test-hygiene.md updated with 8.1.2 implementation decisions
  - docs/roadmap.md updated to mark 8.1.2 as done
- Misc:
  - Updated internal exports and surface in src/lib.rs to expose recovery helpers via the existing `whitaker` facade when the dylint-driver feature is enabled.

## Goals and implementation outline (updated)
- Pure policy surface in `whitaker-common` for determining if a frame in a span chain is user-editable and whether recovery is possible.
- Thin `rustc_span::Span` adapter in `whitaker` (via `src/hir.rs`) to walk the source-callsite chain and produce an ordered frame list consumable by the policy.
- At least one real consumer (demonstrated by `function_attrs_follow_docs`) adopting the shared helper to reduce crate-local logic and properly handle macro-generated glue.
- Documentation updates reflecting decisions and final design when implemented.

## Implementation stages (summary)
- Stage B: Define the contract with tests first (failing tests define the contract).
- Stage C: Implement the pure shared policy (unit tests and docs).
- Stage D: Implement the `rustc_span::Span` adapter (surface and re-exports behind `dylint-driver`).
- Stage E: Adopt the helper in one consumer (e.g., update `function_attrs_follow_docs` and regression tests).
- Stage F: Update design/docs and roadmap with implementation decisions.
- Stage G: Mark roadmap item 8.1.2 as done after gates pass.
- Stage H/I: Run full gates (`make fmt`, `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`, `make test`).

## Validation and evidence (planning gates)
- The plan outlines unit tests and BDD-style tests demonstrating the contract (direct, recovered, macro-only, and first-match behavior).
- End-of-turn gates include format, lint, and test runs consistent with 8.1.2 gates. ExecPlan notes reflect that gates pass at turn end.

## Documentation impact
- ExecPlan added at `docs/execplans/8-1-2-shared-user-editable-span-recovery-helpers.md` and marked COMPLETE.
- Design decisions captured in `docs/lints-for-rstest-fixtures-and-test-hygiene.md`.
- Roadmap updated to reflect item 8.1.2 as DONE once implementation and gates are satisfied.

## Notes for reviewers
- This PR transitions from planning to implementation for 8.1.2 and introduces new public surface on `whitaker-common` and `whitaker` behind a feature gate. One adopter demonstrates viability and helps validate policy correctness and integration points.
- No user-facing runtime API changes beyond the new shared surface and its adoption in a consumer example.

## Task link
- Task: https://www.devboxer.com/task/ffb7bb88-d24d-410e-958f-8ca741eea97f

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

## Summary by Sourcery

Introduce shared rstest span recovery helpers and adopt them in an existing rstest-related lint path to avoid diagnostics on macro-only glue.

New Features:
- Add a pure rstest span recovery policy in whitaker-common that classifies ordered span frames as direct, recovered, or macro-only user-editable spans.
- Expose rustc_span::Span-based span recovery and frame-construction helpers in whitaker for use by compiler-integrated lints.
- Adopt the shared user-editable span recovery helper in the function_attrs_follow_docs lint to drive attribute ordering and item-bound checks from recovered user spans.

Enhancements:
- Export the new span recovery types and helpers through existing whitaker-common and whitaker facades behind the dylint-driver feature.

Documentation:
- Document the 8.1.2 implementation decisions and span recovery behavior, add an execplan for the shared helpers, and update the roadmap to mark 8.1.2 complete.

Tests:
- Add unit tests and rstest-bdd behavioral scenarios for the shared span recovery policy, and extend function_attrs_follow_docs tests to cover recovered span ordering and macro-only attribute filtering.