### PR TITLE
Add tests and docs for installer internal release helpers

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -61,6 +61,73 @@ make check-fmt  # Verify formatting
 make fmt        # Apply formatting
 ```
 
+## Installer release helper binaries
+
+The `whitaker-installer` crate exposes several internal release-helper binaries
+used by GitHub workflows and packaging scripts. These are part of the build
+contract even though they are not user-facing CLI entry points.
+
+### Why `autobins = false` is required
+
+`installer/Cargo.toml` sets `autobins = false` and declares every binary target
+explicitly. This is required because the release workflows invoke specific bin
+names that do not always match Cargo's filename-derived defaults.
+
+Current explicit targets:
+
+- `whitaker-installer` from `src/main.rs`
+- `whitaker-package-lints` from `src/bin/package_lints.rs`
+- `whitaker-package-installer` from `src/bin/package_installer_bin.rs`
+- `whitaker-package-dependency-binary` from
+  `src/bin/package_dependency_binary.rs`
+
+Without explicit declarations, Cargo would infer fallback names such as
+`package_lints` and `package_installer_bin`. Those names do not match the
+workflow invocations, so release and rolling-release builds would fail even
+though the source files exist.
+
+### Validation coverage and purpose
+
+Workflow validation in `tests/workflows/` protects this contract from drift:
+
+- `test_installer_packaging_bins_match_release_workflow_contract` asserts that
+  the workflow-facing binary names exist in workspace metadata.
+- The same test also asserts that filename-derived fallback target names are
+  absent, proving the crate still relies on explicit target declarations rather
+  than accidental Cargo defaults.
+- `workflow_test_helpers.py` centralizes the `cargo metadata --no-deps` lookup
+  used by these contract tests so packaging changes fail with one clear error
+  path.
+
+When modifying release helpers, keep the workflow YAML, `installer/Cargo.toml`,
+and the metadata-based tests in lock-step.
+
+### Worked example: adding another packaging binary
+
+When adding a new internal helper binary, make all of the following changes in
+one patch:
+
+1. Add the Rust entry point under `installer/src/bin/`.
+2. Add a matching `[[bin]]` stanza in `installer/Cargo.toml`.
+3. Keep `autobins = false` so Cargo does not expose unexpected fallback names.
+4. Update any workflow or script that invokes the helper to use the explicit
+   bin name.
+5. Extend the workflow contract test so the new target is asserted alongside
+   the existing helpers.
+
+Example `Cargo.toml` entry:
+
+```toml
+[[bin]]
+name = "whitaker-package-example"
+path = "src/bin/package_example.rs"
+```
+
+If the workflow should invoke that helper, add an assertion to
+`test_installer_packaging_bins_match_release_workflow_contract` before relying
+on it in release automation. That keeps the breakage in unit-style Python tests
+instead of the rolling-release pipeline.
+
 ## Dependency binary packaging
 
 Whitaker publishes repository-hosted copies of `cargo-dylint` and `dylint-link`

--- a/installer/tests/behaviour_docs.rs
+++ b/installer/tests/behaviour_docs.rs
@@ -74,7 +74,7 @@ fn given_revision_pinning_metadata(toml_world: &TomlWorld) {
 
 #[given("a workspace metadata example with pre-built path")]
 fn given_prebuilt_path_metadata(toml_world: &TomlWorld) {
-    let block = find_block_containing("path = ");
+    let block = find_block_containing(r#"path = "/home/user/.local/share/whitaker/lints/"#);
     set_toml_content(toml_world, &block);
 }
 

--- a/installer/tests/behaviour_docs.rs
+++ b/installer/tests/behaviour_docs.rs
@@ -74,7 +74,7 @@ fn given_revision_pinning_metadata(toml_world: &TomlWorld) {
 
 #[given("a workspace metadata example with pre-built path")]
 fn given_prebuilt_path_metadata(toml_world: &TomlWorld) {
-    let block = find_block_containing(r#"path = "/home/user/.local/share/whitaker/lints/"#);
+    let block = find_block_containing("/whitaker/lints/");
     set_toml_content(toml_world, &block);
 }
 

--- a/tests/workflows/test_workflow_test_helpers.py
+++ b/tests/workflows/test_workflow_test_helpers.py
@@ -20,12 +20,17 @@ class TestCargoMetadata:
 
     def test_requires_cargo_on_path(self) -> None:
         """The helper fails fast when `cargo` cannot be resolved."""
-        with patch("tests.workflows.workflow_test_helpers.shutil.which", return_value=None):
-            with pytest.raises(
+        with (
+            patch(
+                "tests.workflows.workflow_test_helpers.shutil.which",
+                return_value=None,
+            ),
+            pytest.raises(
                 AssertionError,
                 match="cargo executable must be available in PATH",
-            ):
-                workflow_test_helpers._cargo_metadata()
+            ),
+        ):
+            workflow_test_helpers._cargo_metadata()
 
     def test_reports_subprocess_failure(self) -> None:
         """The helper surfaces `cargo metadata` stderr on failure."""
@@ -126,28 +131,29 @@ class TestCargoMetadata:
 class TestWorkspacePackageMetadata:
     """Tests for `_workspace_package_metadata()` lookups."""
 
-    def test_requires_packages_list(self) -> None:
-        """The helper rejects metadata without a list-valued packages key."""
+    @pytest.mark.parametrize(
+        ("return_value", "expected_match"),
+        [
+            (
+                {"packages": "not-a-list"},
+                "cargo metadata must include a packages list",
+            ),
+            (
+                {"packages": [{"name": "whitaker-common"}]},
+                "workspace package 'whitaker-installer' is missing",
+            ),
+        ],
+        ids=["non-list-packages", "missing-package"],
+    )
+    def test_rejects_invalid_metadata(
+        self, return_value: dict, expected_match: str
+    ) -> None:
+        """The helper rejects non-list packages and absent package names."""
         with patch(
             "tests.workflows.workflow_test_helpers._cargo_metadata",
-            return_value={"packages": "not-a-list"},
+            return_value=return_value,
         ):
-            with pytest.raises(
-                AssertionError,
-                match="cargo metadata must include a packages list",
-            ):
-                workflow_test_helpers._workspace_package_metadata("whitaker-installer")
-
-    def test_reports_missing_workspace_package(self) -> None:
-        """The helper reports missing packages clearly."""
-        with patch(
-            "tests.workflows.workflow_test_helpers._cargo_metadata",
-            return_value={"packages": [{"name": "whitaker-common"}]},
-        ):
-            with pytest.raises(
-                AssertionError,
-                match="workspace package 'whitaker-installer' is missing",
-            ):
+            with pytest.raises(AssertionError, match=expected_match):
                 workflow_test_helpers._workspace_package_metadata("whitaker-installer")
 
     def test_returns_matching_package_and_ignores_non_dict_entries(self) -> None:

--- a/tests/workflows/test_workflow_test_helpers.py
+++ b/tests/workflows/test_workflow_test_helpers.py
@@ -1,0 +1,167 @@
+"""Unit tests for workflow test helper metadata lookups.
+
+This module exercises the private Cargo metadata helpers directly so workflow
+contract tests fail with clear messages when metadata resolution changes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from tests.workflows import workflow_test_helpers
+
+
+class TestCargoMetadata:
+    """Tests for `_cargo_metadata()` error handling and edge cases."""
+
+    def test_requires_cargo_on_path(self) -> None:
+        """The helper fails fast when `cargo` cannot be resolved."""
+        with patch("tests.workflows.workflow_test_helpers.shutil.which", return_value=None):
+            with pytest.raises(
+                AssertionError,
+                match="cargo executable must be available in PATH",
+            ):
+                workflow_test_helpers._cargo_metadata()
+
+    def test_reports_subprocess_failure(self) -> None:
+        """The helper surfaces `cargo metadata` stderr on failure."""
+        completed = subprocess.CompletedProcess(
+            args=["/usr/bin/cargo", "metadata"],
+            returncode=1,
+            stdout="",
+            stderr="metadata broke",
+        )
+
+        with (
+            patch(
+                "tests.workflows.workflow_test_helpers.shutil.which",
+                return_value="/usr/bin/cargo",
+            ),
+            patch(
+                "tests.workflows.workflow_test_helpers.subprocess.run",
+                return_value=completed,
+            ),
+            pytest.raises(
+                AssertionError,
+                match="cargo metadata failed while resolving workspace metadata",
+            ),
+        ):
+            workflow_test_helpers._cargo_metadata()
+
+    @pytest.mark.parametrize(
+        ("stdout", "expected_type_name"),
+        [
+            (json.dumps([]), "list"),
+            (json.dumps("workspace"), "str"),
+        ],
+        ids=["json-list", "json-string"],
+    )
+    def test_rejects_non_mapping_json(
+        self, stdout: str, expected_type_name: str
+    ) -> None:
+        """The helper accepts only object-shaped `cargo metadata` output."""
+        completed = subprocess.CompletedProcess(
+            args=["/usr/bin/cargo", "metadata"],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+
+        with (
+            patch(
+                "tests.workflows.workflow_test_helpers.shutil.which",
+                return_value="/usr/bin/cargo",
+            ),
+            patch(
+                "tests.workflows.workflow_test_helpers.subprocess.run",
+                return_value=completed,
+            ),
+            pytest.raises(
+                AssertionError,
+                match="cargo metadata must return a JSON object",
+            ),
+        ):
+            workflow_test_helpers._cargo_metadata()
+
+        parsed = json.loads(stdout)
+        assert type(parsed).__name__ == expected_type_name
+
+    def test_returns_parsed_workspace_metadata(self) -> None:
+        """The helper returns parsed JSON for successful metadata calls."""
+        payload = {"packages": [{"name": "whitaker-installer"}]}
+        completed = subprocess.CompletedProcess(
+            args=["/usr/bin/cargo", "metadata"],
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+        with (
+            patch(
+                "tests.workflows.workflow_test_helpers.shutil.which",
+                return_value="/usr/bin/cargo",
+            ),
+            patch(
+                "tests.workflows.workflow_test_helpers.subprocess.run",
+                return_value=completed,
+            ) as run_mock,
+        ):
+            metadata = workflow_test_helpers._cargo_metadata()
+
+        assert metadata == payload
+        run_mock.assert_called_once_with(
+            ["/usr/bin/cargo", "metadata", "--format-version", "1", "--no-deps"],
+            cwd=workflow_test_helpers.REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=workflow_test_helpers.CARGO_METADATA_TIMEOUT_SECONDS,
+        )
+
+
+class TestWorkspacePackageMetadata:
+    """Tests for `_workspace_package_metadata()` lookups."""
+
+    def test_requires_packages_list(self) -> None:
+        """The helper rejects metadata without a list-valued packages key."""
+        with patch(
+            "tests.workflows.workflow_test_helpers._cargo_metadata",
+            return_value={"packages": "not-a-list"},
+        ):
+            with pytest.raises(
+                AssertionError,
+                match="cargo metadata must include a packages list",
+            ):
+                workflow_test_helpers._workspace_package_metadata("whitaker-installer")
+
+    def test_reports_missing_workspace_package(self) -> None:
+        """The helper reports missing packages clearly."""
+        with patch(
+            "tests.workflows.workflow_test_helpers._cargo_metadata",
+            return_value={"packages": [{"name": "whitaker-common"}]},
+        ):
+            with pytest.raises(
+                AssertionError,
+                match="workspace package 'whitaker-installer' is missing",
+            ):
+                workflow_test_helpers._workspace_package_metadata("whitaker-installer")
+
+    def test_returns_matching_package_and_ignores_non_dict_entries(self) -> None:
+        """The helper skips malformed entries and returns the matching package."""
+        package = {
+            "name": "whitaker-installer",
+            "targets": [{"name": "whitaker-installer", "kind": ["bin"]}],
+        }
+        with patch(
+            "tests.workflows.workflow_test_helpers._cargo_metadata",
+            return_value={"packages": ["invalid", {"name": 42}, package]},
+        ):
+            metadata = workflow_test_helpers._workspace_package_metadata(
+                "whitaker-installer"
+            )
+
+        assert metadata == package

--- a/tests/workflows/test_workflow_test_helpers.py
+++ b/tests/workflows/test_workflow_test_helpers.py
@@ -21,10 +21,7 @@ class TestCargoMetadata:
     def test_requires_cargo_on_path(self) -> None:
         """The helper fails fast when `cargo` cannot be resolved."""
         with (
-            patch(
-                "tests.workflows.workflow_test_helpers.shutil.which",
-                return_value=None,
-            ),
+            patch.object(workflow_test_helpers.shutil, "which", return_value=None),
             pytest.raises(
                 AssertionError,
                 match="cargo executable must be available in PATH",
@@ -42,13 +39,11 @@ class TestCargoMetadata:
         )
 
         with (
-            patch(
-                "tests.workflows.workflow_test_helpers.shutil.which",
-                return_value="/usr/bin/cargo",
+            patch.object(
+                workflow_test_helpers.shutil, "which", return_value="/usr/bin/cargo"
             ),
-            patch(
-                "tests.workflows.workflow_test_helpers.subprocess.run",
-                return_value=completed,
+            patch.object(
+                workflow_test_helpers.subprocess, "run", return_value=completed
             ),
             pytest.raises(
                 AssertionError,
@@ -77,13 +72,11 @@ class TestCargoMetadata:
         )
 
         with (
-            patch(
-                "tests.workflows.workflow_test_helpers.shutil.which",
-                return_value="/usr/bin/cargo",
+            patch.object(
+                workflow_test_helpers.shutil, "which", return_value="/usr/bin/cargo"
             ),
-            patch(
-                "tests.workflows.workflow_test_helpers.subprocess.run",
-                return_value=completed,
+            patch.object(
+                workflow_test_helpers.subprocess, "run", return_value=completed
             ),
             pytest.raises(
                 AssertionError,
@@ -106,13 +99,11 @@ class TestCargoMetadata:
         )
 
         with (
-            patch(
-                "tests.workflows.workflow_test_helpers.shutil.which",
-                return_value="/usr/bin/cargo",
+            patch.object(
+                workflow_test_helpers.shutil, "which", return_value="/usr/bin/cargo"
             ),
-            patch(
-                "tests.workflows.workflow_test_helpers.subprocess.run",
-                return_value=completed,
+            patch.object(
+                workflow_test_helpers.subprocess, "run", return_value=completed
             ) as run_mock,
         ):
             metadata = workflow_test_helpers._cargo_metadata()
@@ -149,12 +140,13 @@ class TestWorkspacePackageMetadata:
         self, return_value: dict, expected_match: str
     ) -> None:
         """The helper rejects non-list packages and absent package names."""
-        with patch(
-            "tests.workflows.workflow_test_helpers._cargo_metadata",
-            return_value=return_value,
+        with (
+            patch.object(
+                workflow_test_helpers, "_cargo_metadata", return_value=return_value
+            ),
+            pytest.raises(AssertionError, match=expected_match),
         ):
-            with pytest.raises(AssertionError, match=expected_match):
-                workflow_test_helpers._workspace_package_metadata("whitaker-installer")
+            workflow_test_helpers._workspace_package_metadata("whitaker-installer")
 
     def test_returns_matching_package_and_ignores_non_dict_entries(self) -> None:
         """The helper skips malformed entries and returns the matching package."""
@@ -162,8 +154,9 @@ class TestWorkspacePackageMetadata:
             "name": "whitaker-installer",
             "targets": [{"name": "whitaker-installer", "kind": ["bin"]}],
         }
-        with patch(
-            "tests.workflows.workflow_test_helpers._cargo_metadata",
+        with patch.object(
+            workflow_test_helpers,
+            "_cargo_metadata",
             return_value={"packages": ["invalid", {"name": 42}, package]},
         ):
             metadata = workflow_test_helpers._workspace_package_metadata(

--- a/tests/workflows/workflow_test_helpers.py
+++ b/tests/workflows/workflow_test_helpers.py
@@ -48,7 +48,7 @@ def _cargo_metadata() -> dict[str, object]:
     cargo_executable = shutil.which("cargo")
     assert cargo_executable is not None, "cargo executable must be available in PATH"
 
-    completed = subprocess.run(  # noqa: S603  # FIXME: uses trusted test-only tool
+    completed = subprocess.run(  # noqa: S603  # FIXME: https://github.com/leynos/whitaker/issues/101 uses trusted test-only tool
         [cargo_executable, "metadata", "--format-version", "1", "--no-deps"],
         cwd=REPO_ROOT,
         check=False,
@@ -335,7 +335,7 @@ def run_act_build_lints(*, artefact_dir: Path) -> tuple[int, str]:
         "--env",
         f"LINT_CRATES={lint_crates}",
     ]
-    completed = subprocess.run(  # noqa: S603,S607  # FIXME: uses trusted test-only PATH-resolved tool
+    completed = subprocess.run(  # noqa: S603,S607  # FIXME: https://github.com/leynos/whitaker/issues/101 uses trusted test-only PATH-resolved tool
         command,
         cwd=REPO_ROOT,
         check=False,
@@ -359,7 +359,7 @@ def workflow_runtime_is_ready() -> bool:
     if shutil.which("act") is None:
         return False
 
-    completed = subprocess.run(  # noqa: S603,S607  # FIXME: uses trusted test-only PATH-resolved tool
+    completed = subprocess.run(  # noqa: S603,S607  # FIXME: https://github.com/leynos/whitaker/issues/101 uses trusted test-only PATH-resolved tool
         [
             "act",
             "workflow_dispatch",


### PR DESCRIPTION
## Summary
- Adds tests and documentation for internal installer release-helper binaries and their workflow contract
- Introduces Python-based tests to validate internal Cargo metadata helpers used by workflows
- Updates an example in behaviour docs to reflect a real prebuilt path for consistency

## Changes

### Documentation
- docs/developers-guide.md
  - Adds a new section: "Installer release helper binaries" explaining why autobins = false is required, lists current explicit binary targets, and outlines the purpose and validation coverage of workflow contract tests.
  - Provides guidance on how to extend the contract when adding new packaging binaries, including a worked example and alignment steps for related workflows.
  - Emphasizes keeping workflow YAML, installer/Cargo.toml, and metadata-based tests in lock-step when modifying release helpers.

### Tests
- installer/tests/behaviour_docs.rs
  - Updates the pre-built path example from a generic placeholder to a concrete path (path = "/whitaker/lints/") to improve determinism in tests.

- tests/workflows/test_workflow_test_helpers.py (new)
  - Introduces unit tests for internal cargo metadata helpers:
    - TestCargoMetadata: checks that cargo must be on PATH, surfaces cargo metadata failures, rejects non-mapping JSON, and returns parsed workspace metadata.
    - TestWorkspacePackageMetadata: validates presence of a packages list, reports missing workspace packages, and returns the matching package while ignoring malformed entries.
  - These tests exercise internal APIs used by workflow contract tests to guard against drift in metadata resolution.

- tests/workflows/workflow_test_helpers.py
  - Minor documentation change to test comments: references issue #101 for the PATH-resolved tooling note to reflect current tracking.

## Why this matters
- The installer exposes internal release-helper binaries that are used by GitHub workflows and packaging scripts. Ensuring explicit target declarations and contract-driven tests helps prevent breakages when Cargo or tooling defaults change.
- The new Python tests provide clearer, deterministic validation of how workflow tests resolve workspace metadata, reducing flakiness and surfacing errors with actionable messages.

## Test plan
- Run Rust tests: cargo test (in the installer crate) to ensure the new behaviour_docs change remains valid.
- Run Python tests: pytest to exercise tests/workflows/test_workflow_test_helpers.py and related workflow test helpers.
- Verify that the contract tests for installer packaging bins still pass and that the explicit bin targets are correctly reflected in workspace metadata.
- If modifying release helpers in the future, update the docs and tests in lock-step as described in the new documentation.

## Notes
- No user-facing API changes; this work strengthens internal APIs and the associated contract tests and docs to reduce drift and surprises in workflows and packaging.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---
ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/432a36f0-45d3-4fd8-a2b7-27de0389b0ef

## Summary by Sourcery

Document and test the installer’s internal release-helper binaries and the workflow metadata helpers they depend on.

Enhancements:
- Clarify workflow helper comments to reference the tracking issue for PATH-resolved tooling.

Documentation:
- Describe the installer release-helper binaries, why explicit bin targets with `autobins = false` are required, and how to extend the workflow contract when adding new packaging binaries.

Tests:
- Add Python unit tests for the workflow cargo metadata helpers to validate error handling and workspace package resolution, and adjust an installer behaviour doc test to use a concrete pre-built path example.