### PR TITLE
Refactor refresh_source_build_companions using should_refresh_companions

### DIFF
--- a/installer/src/deps/install.rs
+++ b/installer/src/deps/install.rs
@@ -294,16 +294,21 @@ fn mark_tool_installed(status: &mut DylintToolStatus, tool: &DependencyTool) {
     }
 }
 
+fn should_refresh_companions(
+    outcome: InstallOutcome,
+    tool: &DependencyTool,
+    status: &DylintToolStatus,
+) -> bool {
+    outcome == InstallOutcome::SourceBuild && tool.package == "cargo-dylint" && !status.dylint_link
+}
+
 fn refresh_source_build_companions(
     status: &mut DylintToolStatus,
     executor: &dyn CommandExecutor,
     tool: &DependencyTool,
     outcome: InstallOutcome,
 ) {
-    if outcome != InstallOutcome::SourceBuild
-        || tool.package != "cargo-dylint"
-        || status.dylint_link
-    {
+    if !should_refresh_companions(outcome, tool, status) {
         return;
     }
 
@@ -333,5 +338,45 @@ fn cargo_source_install_request<'a>(
             tool.package,
         ],
         success_message: format!("Installed {} from source with cargo install.", tool.package),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_refresh_companions_requires_source_built_cargo_dylint_without_link() {
+        let cargo_dylint = &DEPENDENCY_TOOLS[0];
+        let dylint_link = &DEPENDENCY_TOOLS[1];
+        let missing_link = DylintToolStatus {
+            cargo_dylint: true,
+            dylint_link: false,
+        };
+        let installed_link = DylintToolStatus {
+            cargo_dylint: true,
+            dylint_link: true,
+        };
+
+        assert!(should_refresh_companions(
+            InstallOutcome::SourceBuild,
+            cargo_dylint,
+            &missing_link,
+        ));
+        assert!(!should_refresh_companions(
+            InstallOutcome::Installed,
+            cargo_dylint,
+            &missing_link,
+        ));
+        assert!(!should_refresh_companions(
+            InstallOutcome::SourceBuild,
+            dylint_link,
+            &missing_link,
+        ));
+        assert!(!should_refresh_companions(
+            InstallOutcome::SourceBuild,
+            cargo_dylint,
+            &installed_link,
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Extracted the refresh decision into a new helper: should_refresh_companions
- Refactored refresh_source_build_companions to rely on the helper
- Added unit tests for the new helper to validate refresh behavior

## Changes
### Core Functionality
- Added should_refresh_companions(outcome: InstallOutcome, tool: &DependencyTool, status: &DylintToolStatus) -> bool
- Refactored refresh_source_build_companions to use should_refresh_companions and return early when it is false

### Tests
- Introduced unit tests in installer/src/deps/install.rs:
  - should_refresh_companions_requires_source_built_cargo_dylint_without_link
  - Covers four scenarios:
    - SourceBuild + cargo-dylint + no dylint_link -> true
    - Installed + cargo-dylint + missing_link -> false
    - SourceBuild + dylint_link + missing_link -> false
    - SourceBuild + cargo-dylint + installed dylint_link -> false

### Notes
- No public API changes; this is a targeted internal refactor to improve readability and testability

## Test plan
- Run cargo test for the workspace
- Specifically verify the installer crate tests pass and the new should_refresh_companions tests cover the intended scenarios

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/a0c61280-d4ff-467c-8593-938941d2175a

## Summary by Sourcery

Refactor companion refresh logic into a dedicated helper and add targeted tests for its behavior.

Enhancements:
- Extract companion refresh decision into a reusable should_refresh_companions helper used by refresh_source_build_companions.

Tests:
- Add unit test coverage for should_refresh_companions across key install and link state combinations.