### PR TITLE
Publish rolling release from partial assets; gate on assets only

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -393,13 +393,13 @@ jobs:
           printf '%s\n' "dist/dependency-binaries-licences.md" >> dist/release-assets.txt
 
       - name: Delete existing rolling release
-        if: steps.assets.outputs.has_assets == 'true' && needs.build-dependency-binaries.result != 'failure'
+        if: steps.assets.outputs.has_assets == 'true'
         run: gh release delete rolling --cleanup-tag --yes || true
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create rolling release
-        if: steps.assets.outputs.has_assets == 'true' && needs.build-dependency-binaries.result != 'failure'
+        if: steps.assets.outputs.has_assets == 'true'
         run: |
           set -euxo pipefail
           SHA=$(git rev-parse --short HEAD)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -113,6 +113,22 @@ returns only the matched branch body and excludes the closing `fi`, so
 follow-on assertions can stay focused on the branch contents rather than shell
 framing.
 
+#### GitHub-expression helpers
+
+Four helpers in `rolling_release_workflow_test_support.py` analyse `if` guard
+expressions on workflow steps:
+
+| Helper                                         | Signature                                    | Purpose                                                                                                                                                               |
+| ---------------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_github_operand_pattern`                      | `(operand: str) -> re.Pattern[str]`          | Builds a regex that matches the operand as a standalone token, preventing partial-name false positives (e.g. a prefix or suffix sharing characters with the operand). |
+| `_github_expression_mentions_operand`          | `(expression: object, operand: str) -> bool` | Returns `True` when the normalised expression contains the operand as a whole token.                                                                                  |
+| `_github_expression_negates_operand`           | `(expression: object, operand: str) -> bool` | Returns `True` when the expression contains `!operand` or `!(operand)`. Double negation (`!!operand`) is not flagged.                                                 |
+| `_github_expression_compares_operand_to_false` | `(expression: object, operand: str) -> bool` | Returns `True` when the expression contains `operand == false` (or `false == operand`) in any quoting style. Strict-equality only; `!=` comparisons are not matched.  |
+
+Use these helpers together in step-guard assertions to verify gating semantics
+rather than exact expression strings, making tests resilient to harmless
+formatting changes in the workflow YAML.
+
 Local workflow tests use the Makefile variables `UV` and `WORKFLOW_TEST_VENV`:
 
 - `UV` selects the `uv` executable used to create and populate the workflow-test

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -87,6 +87,27 @@ libraries = [
 ]
 ```
 
+### Rolling release downloads
+
+Whitaker publishes a `rolling` pre-release tag that is continuously updated and
+overwritten on every push to `main`. It is intended for early adopters who want
+the latest available build outputs before the next stable release is cut.
+
+Rolling releases are best-effort builds. If some matrix legs fail, Whitaker
+still publishes the artefacts that were built successfully. For example, a
+target-specific `cargo-dylint` archive may be missing from one rolling release
+even though other target archives were updated successfully. Do not assume that
+every supported target is present in every rolling release.
+
+Stable releases differ from `rolling`: a stable tag is expected to contain the
+complete artefact set for the release. For production installs, pin to a stable
+release tag rather than consuming `rolling`.
+
+If you consume rolling-release archives from scripts or CI, verify that the
+required target archive exists before proceeding. Treat missing archives as an
+expected condition for rolling releases rather than assuming the artefact set
+is complete.
+
 ### Selecting individual lints
 
 To load specific lints instead of the full suite, specify each lint explicitly:

--- a/tests/workflows/rolling_release_workflow_test_support.py
+++ b/tests/workflows/rolling_release_workflow_test_support.py
@@ -108,7 +108,7 @@ def _github_expression_negates_operand(expression: object, operand: str) -> bool
     """Return whether a GitHub expression contains `!<operand>`."""
     operand_pattern = _github_operand_pattern(operand).pattern
     return re.search(
-        rf"!\s*(?:\(\s*{operand_pattern}\s*\)|{operand_pattern})",
+        rf"(?<!!)!\s*(?:\(\s*{operand_pattern}\s*\)|{operand_pattern})",
         _github_expression_value(expression),
     ) is not None
 
@@ -122,8 +122,8 @@ def _github_expression_compares_operand_to_false(
     operand_pattern = _github_operand_pattern(operand).pattern
     false_literal_pattern = r"(?:'false'|\"false\"|false)"
     return re.search(
-        rf"(?:{operand_pattern}\s*(?:==|!=)\s*{false_literal_pattern}"
-        rf"|{false_literal_pattern}\s*(?:==|!=)\s*{operand_pattern})",
+        rf"(?:{operand_pattern}\s*==\s*{false_literal_pattern}"
+        rf"|{false_literal_pattern}\s*==\s*{operand_pattern})",
         normalized_expression,
     ) is not None
 

--- a/tests/workflows/rolling_release_workflow_test_support.py
+++ b/tests/workflows/rolling_release_workflow_test_support.py
@@ -106,8 +106,9 @@ def _github_expression_mentions_operand(expression: object, operand: str) -> boo
 
 def _github_expression_negates_operand(expression: object, operand: str) -> bool:
     """Return whether a GitHub expression contains `!<operand>`."""
+    operand_pattern = _github_operand_pattern(operand).pattern
     return re.search(
-        rf"!\s*{_github_operand_pattern(operand).pattern}",
+        rf"!\s*(?:\(\s*{operand_pattern}\s*\)|{operand_pattern})",
         _github_expression_value(expression),
     ) is not None
 
@@ -121,7 +122,8 @@ def _github_expression_compares_operand_to_false(
     operand_pattern = _github_operand_pattern(operand).pattern
     false_literal_pattern = r"(?:'false'|\"false\"|false)"
     return re.search(
-        rf"{operand_pattern}\s*(?:==|!=)\s*{false_literal_pattern}",
+        rf"(?:{operand_pattern}\s*(?:==|!=)\s*{false_literal_pattern}"
+        rf"|{false_literal_pattern}\s*(?:==|!=)\s*{operand_pattern})",
         normalized_expression,
     ) is not None
 

--- a/tests/workflows/rolling_release_workflow_test_support.py
+++ b/tests/workflows/rolling_release_workflow_test_support.py
@@ -8,6 +8,9 @@ It provides:
 - `_get_job_dict()` to fetch job mappings such as `jobs["publish"]`.
 - `_workflow_dispatch_inputs()` to return `workflow_dispatch.inputs`.
 - `_github_expression_value()` to normalize `${{ ... }}` expressions.
+- `_github_expression_mentions_operand()` to find a standalone operand token.
+- `_github_expression_negates_operand()` to detect `!operand`.
+- `_github_expression_compares_operand_to_false()` to detect `operand == false`.
 - `_get_needs_list()` to normalize a job `needs` field to `list[str]`.
 - `_find_step_by_name()` to locate named workflow steps in a step list.
 - `_nesting_delta()`, `_collect_branch_lines()`, and
@@ -87,6 +90,40 @@ def _github_expression_value(value: object) -> str:
     if stripped.startswith("${{") and stripped.endswith("}}"):
         return stripped[3:-2].strip()
     return stripped
+
+
+def _github_operand_pattern(operand: str) -> re.Pattern[str]:
+    """Return a regex that matches an operand as a standalone token."""
+    return re.compile(rf"(?<![\w.-]){re.escape(operand)}(?![\w.-])")
+
+
+def _github_expression_mentions_operand(expression: object, operand: str) -> bool:
+    """Return whether a GitHub expression mentions the operand token."""
+    return _github_operand_pattern(operand).search(
+        _github_expression_value(expression)
+    ) is not None
+
+
+def _github_expression_negates_operand(expression: object, operand: str) -> bool:
+    """Return whether a GitHub expression contains `!<operand>`."""
+    return re.search(
+        rf"!\s*{_github_operand_pattern(operand).pattern}",
+        _github_expression_value(expression),
+    ) is not None
+
+
+def _github_expression_compares_operand_to_false(
+    expression: object,
+    operand: str,
+) -> bool:
+    """Return whether a GitHub expression compares the operand to false."""
+    normalized_expression = _github_expression_value(expression)
+    operand_pattern = _github_operand_pattern(operand).pattern
+    false_literal_pattern = r"(?:'false'|\"false\"|false)"
+    return re.search(
+        rf"{operand_pattern}\s*(?:==|!=)\s*{false_literal_pattern}",
+        normalized_expression,
+    ) is not None
 
 
 def _get_needs_list(publish_job: dict[str, Any]) -> list[str]:

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -192,6 +192,48 @@ def test_publish_job_runs_even_if_build_lints_fails(workflow_text: str) -> None:
     )
 
 
+def _assert_step_guard_gated_on_assets_only(
+    steps: list,
+    step_name: str,
+    action: str,
+) -> None:
+    """Assert a publish-step guard depends only on collected assets."""
+    step = _find_step_by_name(steps, step_name)
+    assert step is not None, (
+        f"publish job must include {step_name!r} before rolling release "
+        f"{action}"
+    )
+
+    guard = _github_expression_value(step.get("if"))
+    assert _github_expression_mentions_operand(
+        guard,
+        "steps.assets.outputs.has_assets",
+    ), (
+        f"rolling release {action} must be gated on collected assets, so "
+        "successful dependency archives still publish when other matrix legs "
+        "fail"
+    )
+    assert not _github_expression_negates_operand(
+        guard,
+        "steps.assets.outputs.has_assets",
+    ), (
+        f"rolling release {action} must treat has_assets as a positive guard, "
+        "not a negated condition"
+    )
+    assert not _github_expression_compares_operand_to_false(
+        guard,
+        "steps.assets.outputs.has_assets",
+    ), f"rolling release {action} must not compare has_assets to false"
+    assert not _github_expression_mentions_operand(
+        guard,
+        "needs.build-dependency-binaries.result",
+    ), (
+        f"rolling release {action} must not be gated on dependency build "
+        "results, so successful dependency archives still publish when other "
+        "matrix legs fail"
+    )
+
+
 def test_publish_release_does_not_require_full_dependency_matrix_success(
     workflow_text: str,
 ) -> None:
@@ -206,81 +248,12 @@ def test_publish_release_does_not_require_full_dependency_matrix_success(
         "publication waits for all successful dependency artefacts to be "
         "collected"
     )
-
-    delete_step = _find_step_by_name(
-        publish_job.get("steps"),
-        "Delete existing rolling release",
+    steps = publish_job.get("steps")
+    _assert_step_guard_gated_on_assets_only(
+        steps, "Delete existing rolling release", "deletion"
     )
-    assert delete_step is not None, (
-        "publish job must delete any existing rolling release before "
-        "recreating it"
-    )
-    delete_guard = _github_expression_value(delete_step.get("if"))
-    assert _github_expression_mentions_operand(
-        delete_guard,
-        "steps.assets.outputs.has_assets",
-    ), (
-        "rolling release deletion must be gated on collected assets, so "
-        "successful dependency archives still publish when other matrix legs "
-        "fail"
-    )
-    assert not _github_expression_negates_operand(
-        delete_guard,
-        "steps.assets.outputs.has_assets",
-    ), (
-        "rolling release deletion must treat has_assets as a positive guard, "
-        "not a negated condition"
-    )
-    assert not _github_expression_compares_operand_to_false(
-        delete_guard,
-        "steps.assets.outputs.has_assets",
-    ), (
-        "rolling release deletion must not compare has_assets to false"
-    )
-    assert not _github_expression_mentions_operand(
-        delete_guard,
-        "needs.build-dependency-binaries.result",
-    ), (
-        "rolling release deletion must not be gated on dependency build "
-        "results, so successful dependency archives still publish when other "
-        "matrix legs fail"
-    )
-
-    create_step = _find_step_by_name(
-        publish_job.get("steps"),
-        "Create rolling release",
-    )
-    assert create_step is not None, (
-        "publish job must recreate the rolling release when assets are "
-        "available"
-    )
-    create_guard = _github_expression_value(create_step.get("if"))
-    assert _github_expression_mentions_operand(
-        create_guard,
-        "steps.assets.outputs.has_assets",
-    ), (
-        "rolling release creation must be gated on collected assets and must "
-        "publish whatever artefacts were built"
-    )
-    assert not _github_expression_negates_operand(
-        create_guard,
-        "steps.assets.outputs.has_assets",
-    ), (
-        "rolling release creation must treat has_assets as a positive guard, "
-        "not a negated condition"
-    )
-    assert not _github_expression_compares_operand_to_false(
-        create_guard,
-        "steps.assets.outputs.has_assets",
-    ), (
-        "rolling release creation must not compare has_assets to false"
-    )
-    assert not _github_expression_mentions_operand(
-        create_guard,
-        "needs.build-dependency-binaries.result",
-    ), (
-        "rolling release creation must not be blocked by aggregate dependency "
-        "matrix failures"
+    _assert_step_guard_gated_on_assets_only(
+        steps, "Create rolling release", "creation"
     )
 
 

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -188,6 +188,50 @@ def test_publish_job_runs_even_if_build_lints_fails(workflow_text: str) -> None:
         "through to has_assets=false"
     )
 
+
+def test_publish_release_does_not_require_full_dependency_matrix_success(
+    workflow_text: str,
+) -> None:
+    """Ensure publish step releases partial dependency artefacts."""
+    workflow_mapping = _load_workflow_mapping(workflow_text)
+    jobs = _get_job_dict(workflow_mapping, "jobs")
+    publish_job = _get_job_dict(jobs, "publish")
+
+    delete_step = _find_step_by_name(
+        publish_job.get("steps"),
+        "Delete existing rolling release",
+    )
+    assert delete_step is not None, (
+        "publish job must delete any existing rolling release before "
+        "recreating it"
+    )
+    delete_guard = _github_expression_value(delete_step.get("if"))
+    assert delete_guard == "steps.assets.outputs.has_assets == 'true'", (
+        "rolling release deletion must depend only on collected assets, so "
+        "successful dependency archives still publish when other matrix legs "
+        "fail"
+    )
+
+    create_step = _find_step_by_name(
+        publish_job.get("steps"),
+        "Create rolling release",
+    )
+    assert create_step is not None, (
+        "publish job must recreate the rolling release when assets are "
+        "available"
+    )
+    create_guard = _github_expression_value(create_step.get("if"))
+    assert create_guard == "steps.assets.outputs.has_assets == 'true'", (
+        "rolling release creation must not require the full dependency "
+        "matrix to succeed; publish whatever artefacts were built"
+    )
+
+    assert "needs.build-dependency-binaries.result" not in create_guard, (
+        "rolling release creation must not be blocked by aggregate dependency "
+        "matrix failures"
+    )
+
+
 def test_restore_step_guards_against_missing_dependency_assets(
     workflow_text: str,
 ) -> None:

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -32,6 +32,9 @@ from tests.workflows.rolling_release_workflow_test_support import (
     _find_step_by_name,
     _get_job_dict,
     _get_needs_list,
+    _github_expression_compares_operand_to_false,
+    _github_expression_mentions_operand,
+    _github_expression_negates_operand,
     _github_expression_value,
     _load_workflow_mapping,
 )
@@ -213,12 +216,31 @@ def test_publish_release_does_not_require_full_dependency_matrix_success(
         "recreating it"
     )
     delete_guard = _github_expression_value(delete_step.get("if"))
-    assert "steps.assets.outputs.has_assets" in delete_guard, (
+    assert _github_expression_mentions_operand(
+        delete_guard,
+        "steps.assets.outputs.has_assets",
+    ), (
         "rolling release deletion must be gated on collected assets, so "
         "successful dependency archives still publish when other matrix legs "
         "fail"
     )
-    assert "needs.build-dependency-binaries.result" not in delete_guard, (
+    assert not _github_expression_negates_operand(
+        delete_guard,
+        "steps.assets.outputs.has_assets",
+    ), (
+        "rolling release deletion must treat has_assets as a positive guard, "
+        "not a negated condition"
+    )
+    assert not _github_expression_compares_operand_to_false(
+        delete_guard,
+        "steps.assets.outputs.has_assets",
+    ), (
+        "rolling release deletion must not compare has_assets to false"
+    )
+    assert not _github_expression_mentions_operand(
+        delete_guard,
+        "needs.build-dependency-binaries.result",
+    ), (
         "rolling release deletion must not be gated on dependency build "
         "results, so successful dependency archives still publish when other "
         "matrix legs fail"
@@ -233,12 +255,30 @@ def test_publish_release_does_not_require_full_dependency_matrix_success(
         "available"
     )
     create_guard = _github_expression_value(create_step.get("if"))
-    assert "steps.assets.outputs.has_assets" in create_guard, (
+    assert _github_expression_mentions_operand(
+        create_guard,
+        "steps.assets.outputs.has_assets",
+    ), (
         "rolling release creation must be gated on collected assets and must "
         "publish whatever artefacts were built"
     )
-
-    assert "needs.build-dependency-binaries.result" not in create_guard, (
+    assert not _github_expression_negates_operand(
+        create_guard,
+        "steps.assets.outputs.has_assets",
+    ), (
+        "rolling release creation must treat has_assets as a positive guard, "
+        "not a negated condition"
+    )
+    assert not _github_expression_compares_operand_to_false(
+        create_guard,
+        "steps.assets.outputs.has_assets",
+    ), (
+        "rolling release creation must not compare has_assets to false"
+    )
+    assert not _github_expression_mentions_operand(
+        create_guard,
+        "needs.build-dependency-binaries.result",
+    ), (
         "rolling release creation must not be blocked by aggregate dependency "
         "matrix failures"
     )

--- a/tests/workflows/test_rolling_release_workflow.py
+++ b/tests/workflows/test_rolling_release_workflow.py
@@ -196,6 +196,13 @@ def test_publish_release_does_not_require_full_dependency_matrix_success(
     workflow_mapping = _load_workflow_mapping(workflow_text)
     jobs = _get_job_dict(workflow_mapping, "jobs")
     publish_job = _get_job_dict(jobs, "publish")
+    needs_list = _get_needs_list(publish_job)
+
+    assert "build-dependency-binaries" in needs_list, (
+        "publish job must still depend on build-dependency-binaries so release "
+        "publication waits for all successful dependency artefacts to be "
+        "collected"
+    )
 
     delete_step = _find_step_by_name(
         publish_job.get("steps"),
@@ -206,10 +213,15 @@ def test_publish_release_does_not_require_full_dependency_matrix_success(
         "recreating it"
     )
     delete_guard = _github_expression_value(delete_step.get("if"))
-    assert delete_guard == "steps.assets.outputs.has_assets == 'true'", (
-        "rolling release deletion must depend only on collected assets, so "
+    assert "steps.assets.outputs.has_assets" in delete_guard, (
+        "rolling release deletion must be gated on collected assets, so "
         "successful dependency archives still publish when other matrix legs "
         "fail"
+    )
+    assert "needs.build-dependency-binaries.result" not in delete_guard, (
+        "rolling release deletion must not be gated on dependency build "
+        "results, so successful dependency archives still publish when other "
+        "matrix legs fail"
     )
 
     create_step = _find_step_by_name(
@@ -221,9 +233,9 @@ def test_publish_release_does_not_require_full_dependency_matrix_success(
         "available"
     )
     create_guard = _github_expression_value(create_step.get("if"))
-    assert create_guard == "steps.assets.outputs.has_assets == 'true'", (
-        "rolling release creation must not require the full dependency "
-        "matrix to succeed; publish whatever artefacts were built"
+    assert "steps.assets.outputs.has_assets" in create_guard, (
+        "rolling release creation must be gated on collected assets and must "
+        "publish whatever artefacts were built"
     )
 
     assert "needs.build-dependency-binaries.result" not in create_guard, (

--- a/tests/workflows/test_rolling_release_workflow_test_support.py
+++ b/tests/workflows/test_rolling_release_workflow_test_support.py
@@ -1,0 +1,73 @@
+"""Unit tests for rolling-release workflow expression helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.workflows.rolling_release_workflow_test_support import (
+    _github_expression_compares_operand_to_false,
+    _github_expression_mentions_operand,
+    _github_expression_negates_operand,
+)
+
+
+OPERAND = "steps.assets.outputs.has_assets"
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        ("steps.assets.outputs.has_assets == 'true'", True),
+        ("${{ steps.assets.outputs.has_assets == 'true' }}", True),
+        ("other.steps.assets.outputs.has_assets", False),
+        ("steps.assets.outputs.has_assets_extra", False),
+        ("needs.build-dependency-binaries.result != 'failure'", False),
+    ],
+)
+def test_github_expression_mentions_operand(
+    expression: str,
+    expected: bool,
+) -> None:
+    """Report whether the expression mentions the operand as a whole token."""
+    assert _github_expression_mentions_operand(expression, OPERAND) is expected
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        ("!steps.assets.outputs.has_assets", True),
+        ("! steps.assets.outputs.has_assets", True),
+        ("!(steps.assets.outputs.has_assets)", True),
+        ("!!steps.assets.outputs.has_assets", False),
+        ("steps.assets.outputs.has_assets == 'true'", False),
+    ],
+)
+def test_github_expression_negates_operand(
+    expression: str,
+    expected: bool,
+) -> None:
+    """Report whether the expression contains a real negation."""
+    assert _github_expression_negates_operand(expression, OPERAND) is expected
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        ("steps.assets.outputs.has_assets == false", True),
+        ("steps.assets.outputs.has_assets == 'false'", True),
+        ('steps.assets.outputs.has_assets == "false"', True),
+        ("false == steps.assets.outputs.has_assets", True),
+        ("steps.assets.outputs.has_assets  ==  false", True),
+        ("steps.assets.outputs.has_assets != 'false'", False),
+        ("steps.assets.outputs.has_assets == 'true'", False),
+    ],
+)
+def test_github_expression_compares_operand_to_false(
+    expression: str,
+    expected: bool,
+) -> None:
+    """Report whether the expression uses equality against false."""
+    assert _github_expression_compares_operand_to_false(
+        expression,
+        OPERAND,
+    ) is expected


### PR DESCRIPTION
## Summary
- Relax publish gating to allow releasing rolling assets even if the full dependency matrix did not succeed.
- Add tests and helpers for gating semantics; update documentation to reflect rolling-release behavior and constraints.

## Changes
### .github/workflows/rolling-release.yml
- Delete existing rolling release: remove the condition needs.build-dependency-binaries.result != 'failure' so it only gates on assets presence.
- Create rolling release: remove the condition needs.build-dependency-binaries.result != 'failure' so release is created when assets exist, regardless of full dependency success.

### tests/workflows/rolling_release_workflow.py
- Added test_publish_release_does_not_require_full_dependency_matrix_success to verify new behavior:
  - Delete step guard remains: steps.assets.outputs.has_assets == 'true'
  - Create step guard is also solely based on has_assets and does not reference needs.build-dependency-binaries.result
  - Ensures publish can proceed when the dependency matrix did not fully succeed

### tests/workflows/rolling_release_workflow_test_support.py
- Added helper functions to support GitHub expression analysis in tests:
  - `_github_operand_pattern(operand: str) -> re.Pattern[str]`
  - `_github_expression_mentions_operand(expression: object, operand: str) -> bool`
  - `_github_expression_negates_operand(expression: object, operand: str) -> bool`
  - `_github_expression_compares_operand_to_false(expression: object, operand: str) -> bool`

### tests/workflows/test_rolling_release_workflow_test_support.py
- Added unit tests for the new expression helper functions to validate gating analysis logic.

### docs/developers-guide.md
- Document GitHub-expression helpers and how tests analyze workflow step guards for gating semantics.

### docs/users-guide.md
- Update rolling release guidance:
  - Rolling releases are best-effort; if some matrix legs fail, artefacts that were built may still be published.
  - Some targets/artefacts may be missing in rolling releases; production/stable releases remain the complete artefact set.
  - Verify required artefacts exist before relying on rolling-release assets.

## Why
- Previously a failing dependency matrix could block publishing even when partial assets were available. This change allows releasing partial artifact sets, improving resilience when some build steps fail (e.g., cargo-dylint install issues), and aligns tests/docs with the new gating behavior.

## Test plan
- Run pytest on the workflow tests, especially:
  - test_publish_release_does_not_require_full_dependency_matrix_success
- Verify that the publish steps gate only on assets presence and do not require full dependency matrix success.

## Potential impact
- Enables partial releases when some artefacts are built.
- May publish incomplete artefacts if only a subset is produced; ensure release policy handles partial releases appropriately.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/26158c38-57b0-45ce-ac4c-edfea5c379af