### PR TITLE
Structured JSON diagnostics, rstest parametrisation, installer refactor

### DIFF
--- a/crates/no_std_fs_operations/tests/fixtures/excluded_project/Cargo.toml
+++ b/crates/no_std_fs_operations/tests/fixtures/excluded_project/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+
+[workspace]

--- a/crates/no_std_fs_operations/tests/fixtures/non_excluded_project/Cargo.toml
+++ b/crates/no_std_fs_operations/tests/fixtures/non_excluded_project/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+
+[workspace]

--- a/crates/no_std_fs_operations/tests/integration_exclusion.rs
+++ b/crates/no_std_fs_operations/tests/integration_exclusion.rs
@@ -7,18 +7,19 @@
 //! # Prerequisites
 //!
 //! - `cargo-dylint` and `dylint-link` must be installed
-//! - The lint library must be built before running these tests
+//! - The workspace must be buildable so the harness can build the lint library
 //!
 //! These tests are marked `#[ignore]` by default because they require external
-//! dependencies and a built lint library. Run with `--ignored` to execute.
+//! dependencies. Run with `--ignored` to execute.
 
 use std::env;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
 
 use cargo_metadata::{Message, Metadata, MetadataCommand};
-use rstest::rstest;
+use rstest::{fixture, rstest};
 use serial_test::serial;
 
 const LINT_CRATE_NAME: &str = "no_std_fs_operations";
@@ -133,8 +134,15 @@ fn find_cdylib_in_artifacts(stdout: &[u8], package_id: &cargo_metadata::PackageI
     panic!("cdylib artifact not found in build output");
 }
 
+/// Result of invoking `cargo dylint` against a fixture crate.
+struct CargoDylintResult {
+    is_success: bool,
+    stdout: Vec<u8>,
+    stderr: String,
+}
+
 /// Runs `cargo dylint` on the given fixture project directory.
-fn run_cargo_dylint(fixture_dir: &Path, library_path: &Path) -> (bool, Vec<u8>, String) {
+fn run_cargo_dylint(fixture_dir: &Path, library_path: &Path) -> CargoDylintResult {
     let output = Command::new("cargo")
         .arg("dylint")
         .arg("--all")
@@ -149,7 +157,11 @@ fn run_cargo_dylint(fixture_dir: &Path, library_path: &Path) -> (bool, Vec<u8>, 
 
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
 
-    (output.status.success(), output.stdout, stderr)
+    CargoDylintResult {
+        is_success: output.status.success(),
+        stdout: output.stdout,
+        stderr,
+    }
 }
 
 /// Counts diagnostics emitted by the `no_std_fs_operations` lint from cargo JSON output.
@@ -177,39 +189,46 @@ fn fixture_path(name: &str) -> PathBuf {
         .join(name)
 }
 
+#[fixture]
+fn lint_library_path() -> PathBuf {
+    static LINT_LIBRARY_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+    LINT_LIBRARY_PATH.get_or_init(build_lint_library).clone()
+}
+
 #[rstest]
 #[case("excluded_project", false, true)]
 #[case("non_excluded_project", true, false)]
 #[ignore = "requires cargo-dylint and built lint library"]
 #[serial]
 fn exclusion_behaviour_matches_fixture_configuration(
+    lint_library_path: PathBuf,
     #[case] fixture: &str,
     #[case] expect_diagnostics: bool,
     #[case] expected_success: bool,
 ) {
-    let library_path = build_lint_library();
     let fixture_dir = fixture_path(fixture);
 
-    let (success, stdout, stderr) = run_cargo_dylint(&fixture_dir, &library_path);
-    let count = diagnostic_count(&stdout);
+    let result = run_cargo_dylint(&fixture_dir, &lint_library_path);
+    let count = diagnostic_count(&result.stdout);
 
     assert!(
-        success == expected_success,
+        result.is_success == expected_success,
         "fixture `{fixture}` should return success={expected_success}, but stderr was:\n{}",
-        stderr
+        result.stderr
     );
 
     if expect_diagnostics {
         assert!(
             count > 0,
             "fixture `{fixture}` should emit `no_std_fs_operations` diagnostics, but stderr was:\n{}",
-            stderr
+            result.stderr
         );
     } else {
         assert!(
             count == 0,
             "fixture `{fixture}` should emit zero `no_std_fs_operations` diagnostics, but stderr was:\n{}",
-            stderr
+            result.stderr
         );
     }
 }

--- a/crates/no_std_fs_operations/tests/integration_exclusion.rs
+++ b/crates/no_std_fs_operations/tests/integration_exclusion.rs
@@ -196,29 +196,47 @@ fn lint_library_path() -> PathBuf {
     LINT_LIBRARY_PATH.get_or_init(build_lint_library).clone()
 }
 
+struct Expectation {
+    should_emit_diagnostics: bool,
+    should_succeed: bool,
+}
+
 #[rstest]
-#[case("excluded_project", false, true)]
-#[case("non_excluded_project", true, false)]
+#[case(
+    "excluded_project",
+    Expectation {
+        should_emit_diagnostics: false,
+        should_succeed: true,
+    }
+)]
+#[case(
+    "non_excluded_project",
+    Expectation {
+        should_emit_diagnostics: true,
+        should_succeed: false,
+    }
+)]
 #[ignore = "requires cargo-dylint and built lint library"]
 #[serial]
 fn exclusion_behaviour_matches_fixture_configuration(
     lint_library_path: PathBuf,
     #[case] fixture: &str,
-    #[case] expect_diagnostics: bool,
-    #[case] expected_success: bool,
+    #[case] expectation: Expectation,
 ) {
+    let should_emit_diagnostics = expectation.should_emit_diagnostics;
+    let should_succeed = expectation.should_succeed;
     let fixture_dir = fixture_path(fixture);
 
     let result = run_cargo_dylint(&fixture_dir, &lint_library_path);
     let count = diagnostic_count(&result.stdout);
 
     assert!(
-        result.is_success == expected_success,
-        "fixture `{fixture}` should return success={expected_success}, but stderr was:\n{}",
+        result.is_success == should_succeed,
+        "fixture `{fixture}` should return success={should_succeed}, but stderr was:\n{}",
         result.stderr
     );
 
-    if expect_diagnostics {
+    if should_emit_diagnostics {
         assert!(
             count > 0,
             "fixture `{fixture}` should emit `no_std_fs_operations` diagnostics, but stderr was:\n{}",

--- a/crates/no_std_fs_operations/tests/integration_exclusion.rs
+++ b/crates/no_std_fs_operations/tests/integration_exclusion.rs
@@ -18,10 +18,10 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use cargo_metadata::{Message, Metadata, MetadataCommand};
+use rstest::rstest;
 use serial_test::serial;
 
 const LINT_CRATE_NAME: &str = "no_std_fs_operations";
-const DIAGNOSTIC_MARKER: &str = "bypasses the capability-based filesystem policy.";
 
 /// Builds the lint library and returns the path to the release directory.
 fn build_lint_library() -> PathBuf {
@@ -134,25 +134,39 @@ fn find_cdylib_in_artifacts(stdout: &[u8], package_id: &cargo_metadata::PackageI
 }
 
 /// Runs `cargo dylint` on the given fixture project directory.
-fn run_cargo_dylint(fixture_dir: &Path, library_path: &Path) -> (bool, String, String) {
+fn run_cargo_dylint(fixture_dir: &Path, library_path: &Path) -> (bool, Vec<u8>, String) {
     let output = Command::new("cargo")
         .arg("dylint")
         .arg("--all")
+        .arg("--")
+        .arg("--message-format")
+        .arg("json")
         .current_dir(fixture_dir)
         .env("DYLINT_LIBRARY_PATH", library_path)
         .env("DYLINT_RUSTFLAGS", "-D warnings")
         .output()
         .expect("failed to execute cargo dylint");
 
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
 
-    (output.status.success(), stdout, stderr)
+    (output.status.success(), output.stdout, stderr)
 }
 
-/// Counts emitted lint diagnostics using a stable message fragment.
-fn diagnostic_count(output: &str) -> usize {
-    output.matches(DIAGNOSTIC_MARKER).count()
+/// Counts diagnostics emitted by the `no_std_fs_operations` lint from cargo JSON output.
+fn diagnostic_count(output: &[u8]) -> usize {
+    Message::parse_stream(Cursor::new(output))
+        .map(|message| message.expect("cargo dylint should emit valid JSON messages"))
+        .filter_map(|message| match message {
+            Message::CompilerMessage(message) => Some(message.message),
+            _ => None,
+        })
+        .filter(|diagnostic| {
+            diagnostic
+                .code
+                .as_ref()
+                .is_some_and(|code| code.code == LINT_CRATE_NAME)
+        })
+        .count()
 }
 
 /// Returns the path to a named fixture project under `tests/fixtures/`.
@@ -163,45 +177,39 @@ fn fixture_path(name: &str) -> PathBuf {
         .join(name)
 }
 
-#[test]
+#[rstest]
+#[case("excluded_project", false, true)]
+#[case("non_excluded_project", true, false)]
 #[ignore = "requires cargo-dylint and built lint library"]
 #[serial]
-fn excluded_crate_suppresses_diagnostics() {
+fn exclusion_behaviour_matches_fixture_configuration(
+    #[case] fixture: &str,
+    #[case] expect_diagnostics: bool,
+    #[case] expected_success: bool,
+) {
     let library_path = build_lint_library();
-    let fixture_dir = fixture_path("excluded_project");
+    let fixture_dir = fixture_path(fixture);
 
-    let (success, _stdout, stderr) = run_cargo_dylint(&fixture_dir, &library_path);
-    let count = diagnostic_count(&stderr);
+    let (success, stdout, stderr) = run_cargo_dylint(&fixture_dir, &library_path);
+    let count = diagnostic_count(&stdout);
 
     assert!(
-        count == 0,
-        "excluded crate should emit zero diagnostics matching '{}', but stderr was:\n{}",
-        DIAGNOSTIC_MARKER,
+        success == expected_success,
+        "fixture `{fixture}` should return success={expected_success}, but stderr was:\n{}",
         stderr
     );
 
-    // The build should succeed because the lint is suppressed
-    assert!(
-        success,
-        "cargo dylint should succeed for excluded crate, stderr:\n{}",
-        stderr
-    );
-}
-
-#[test]
-#[ignore = "requires cargo-dylint and built lint library"]
-#[serial]
-fn non_excluded_crate_emits_diagnostics() {
-    let library_path = build_lint_library();
-    let fixture_dir = fixture_path("non_excluded_project");
-
-    let (_success, _stdout, stderr) = run_cargo_dylint(&fixture_dir, &library_path);
-    let count = diagnostic_count(&stderr);
-
-    assert!(
-        count > 0,
-        "non-excluded crate should emit diagnostics matching '{}', but stderr was:\n{}",
-        DIAGNOSTIC_MARKER,
-        stderr
-    );
+    if expect_diagnostics {
+        assert!(
+            count > 0,
+            "fixture `{fixture}` should emit `no_std_fs_operations` diagnostics, but stderr was:\n{}",
+            stderr
+        );
+    } else {
+        assert!(
+            count == 0,
+            "fixture `{fixture}` should emit zero `no_std_fs_operations` diagnostics, but stderr was:\n{}",
+            stderr
+        );
+    }
 }

--- a/crates/no_std_fs_operations/tests/integration_exclusion.rs
+++ b/crates/no_std_fs_operations/tests/integration_exclusion.rs
@@ -18,9 +18,10 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use cargo_metadata::{Message, Metadata, MetadataCommand};
+use serial_test::serial;
 
 const LINT_CRATE_NAME: &str = "no_std_fs_operations";
-const DIAGNOSTIC_MARKER: &str = "std::fs operations bypass";
+const DIAGNOSTIC_MARKER: &str = "bypasses the capability-based filesystem policy.";
 
 /// Builds the lint library and returns the path to the release directory.
 fn build_lint_library() -> PathBuf {
@@ -137,11 +138,9 @@ fn run_cargo_dylint(fixture_dir: &Path, library_path: &Path) -> (bool, String, S
     let output = Command::new("cargo")
         .arg("dylint")
         .arg("--all")
-        .arg("--")
-        .arg("-D")
-        .arg("warnings")
         .current_dir(fixture_dir)
         .env("DYLINT_LIBRARY_PATH", library_path)
+        .env("DYLINT_RUSTFLAGS", "-D warnings")
         .output()
         .expect("failed to execute cargo dylint");
 
@@ -149,6 +148,11 @@ fn run_cargo_dylint(fixture_dir: &Path, library_path: &Path) -> (bool, String, S
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
 
     (output.status.success(), stdout, stderr)
+}
+
+/// Counts emitted lint diagnostics using a stable message fragment.
+fn diagnostic_count(output: &str) -> usize {
+    output.matches(DIAGNOSTIC_MARKER).count()
 }
 
 /// Returns the path to a named fixture project under `tests/fixtures/`.
@@ -161,15 +165,17 @@ fn fixture_path(name: &str) -> PathBuf {
 
 #[test]
 #[ignore = "requires cargo-dylint and built lint library"]
+#[serial]
 fn excluded_crate_suppresses_diagnostics() {
     let library_path = build_lint_library();
     let fixture_dir = fixture_path("excluded_project");
 
     let (success, _stdout, stderr) = run_cargo_dylint(&fixture_dir, &library_path);
+    let count = diagnostic_count(&stderr);
 
     assert!(
-        !stderr.contains(DIAGNOSTIC_MARKER),
-        "excluded crate should NOT emit '{}' diagnostic, but stderr was:\n{}",
+        count == 0,
+        "excluded crate should emit zero diagnostics matching '{}', but stderr was:\n{}",
         DIAGNOSTIC_MARKER,
         stderr
     );
@@ -184,15 +190,17 @@ fn excluded_crate_suppresses_diagnostics() {
 
 #[test]
 #[ignore = "requires cargo-dylint and built lint library"]
+#[serial]
 fn non_excluded_crate_emits_diagnostics() {
     let library_path = build_lint_library();
     let fixture_dir = fixture_path("non_excluded_project");
 
     let (_success, _stdout, stderr) = run_cargo_dylint(&fixture_dir, &library_path);
+    let count = diagnostic_count(&stderr);
 
     assert!(
-        stderr.contains(DIAGNOSTIC_MARKER),
-        "non-excluded crate should emit '{}' diagnostic, but stderr was:\n{}",
+        count > 0,
+        "non-excluded crate should emit diagnostics matching '{}', but stderr was:\n{}",
         DIAGNOSTIC_MARKER,
         stderr
     );

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -46,14 +46,22 @@ during the run. `diagnostic_count` then parses the JSON message stream with
 `code.code` is `no_std_fs_operations`, which keeps the assertions tied to the
 lint's structured diagnostics instead of brittle text matching.
 
-The tests are annotated with `#[serial]` from `serial_test` so concurrent
-subprocess runs do not interfere with one another. They are also marked
-`#[ignore]` by default because they depend on external tooling and a buildable
-workspace. Before running them, install `cargo-dylint` and `dylint-link`. The
-harness calls `build_lint_library()` before running `cargo dylint`, so the
-workspace build step is handled automatically. Run them with
-`cargo test -- --ignored`, or the equivalent nextest invocation with
-`--ignored`.
+The tests are annotated with `#[serial]` from `serial_test`, and the
+repository-level nextest contract also requires them to match the
+`serial-dylint-ui` test group in `.config/nextest.toml` when they are exercised
+through `make test`. Both the attribute and the repo-level group are required
+for correct serialized execution because nextest runs each test in a separate
+process, so the in-process `#[serial]` mutex alone is not sufficient. They are
+also marked `#[ignore]` by default because they depend on external tooling and
+a buildable workspace. Before running them, install `cargo-dylint` and
+`dylint-link`. The harness calls `build_lint_library()` before running
+`cargo dylint`, so the workspace build is handled automatically. Run them with
+one of the following commands:
+
+```sh
+cargo test -p no_std_fs_operations --test integration_exclusion -- --ignored
+cargo nextest run -p no_std_fs_operations --test integration_exclusion --run-ignored ignored-only
+```
 
 The parameterized `#[rstest]` case
 `exclusion_behaviour_matches_fixture_configuration` covers both fixtures. For

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -499,7 +499,7 @@ The `dylint-link` verification in `installer/src/deps.rs` is implemented by
 seven small private helpers:
 
 - `find_binary_on_path(binary_name)` returns the first executable candidate so
-  the install check can validate the exact path it found.
+  the installation check can validate the exact path it found.
 - `find_binary_in_directory(directory, binary_name)` performs the per-directory
   search that `find_binary_on_path()` uses while walking `PATH`.
 - `binary_candidates(directory, binary_name)` builds the ordered set of

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -48,12 +48,14 @@ lint's structured diagnostics instead of brittle text matching.
 
 The tests are annotated with `#[serial]` from `serial_test` so concurrent
 subprocess runs do not interfere with one another. They are also marked
-`#[ignore]` by default because they depend on external tooling and a prebuilt
-lint artefact. Before running them, install `cargo-dylint` and `dylint-link`,
-and build the lint library. Run them with `cargo test -- --ignored`, or the
-equivalent nextest invocation with `--ignored`.
+`#[ignore]` by default because they depend on external tooling and a buildable
+workspace. Before running them, install `cargo-dylint` and `dylint-link`. The
+harness calls `build_lint_library()` before running `cargo dylint`, so the
+workspace build step is handled automatically. Run them with
+`cargo test -- --ignored`, or the equivalent nextest invocation with
+`--ignored`.
 
-The parametrised `#[rstest]` case
+The parameterized `#[rstest]` case
 `exclusion_behaviour_matches_fixture_configuration` covers both fixtures. For
 each case, it asserts the subprocess exit status and the `no_std_fs_operations`
 diagnostic count, so the test verifies both the success path for excluded

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -24,6 +24,41 @@ make test
 This executes unit, behaviour, and UI harness tests. The shared target enables
 `rstest` fixtures and `rstest-bdd` scenarios.
 
+### Integration tests for lint exclusion behaviour
+
+The `no_std_fs_operations` crate includes end-to-end behavioural coverage for
+the `excluded_crates` configuration. These integration tests invoke
+`cargo dylint` in a subprocess so they exercise the full lint-loading and
+configuration path, rather than only unit-level helpers.
+
+The fixtures live under `crates/no_std_fs_operations/tests/fixtures/` as two
+small crates: `excluded_project`, which configures the exclusion, and
+`non_excluded_project`, which leaves the lint unexcluded. Each fixture
+`Cargo.toml` includes an empty `[workspace]` table so Cargo treats the fixture
+as its own workspace root. This prevents Cargo from resolving upwards to the
+enclosing Whitaker workspace and inheriting unrelated configuration.
+
+The harness centres on `run_cargo_dylint`, which executes
+`cargo dylint --all -- --message-format json` with `DYLINT_LIBRARY_PATH` set to
+the built lint library and `DYLINT_RUSTFLAGS=-D warnings` set to deny warnings
+during the run. `diagnostic_count` then parses the JSON message stream with
+`cargo_metadata::Message` and counts only `CompilerMessage` entries whose
+`code.code` is `no_std_fs_operations`, which keeps the assertions tied to the
+lint's structured diagnostics instead of brittle text matching.
+
+The tests are annotated with `#[serial]` from `serial_test` so concurrent
+subprocess runs do not interfere with one another. They are also marked
+`#[ignore]` by default because they depend on external tooling and a prebuilt
+lint artefact. Before running them, install `cargo-dylint` and `dylint-link`,
+and build the lint library. Run them with `cargo test -- --ignored`, or the
+equivalent nextest invocation with `--ignored`.
+
+The parametrised `#[rstest]` case
+`exclusion_behaviour_matches_fixture_configuration` covers both fixtures. For
+each case, it asserts the subprocess exit status and the `no_std_fs_operations`
+diagnostic count, so the test verifies both the success path for excluded
+crates and the failure path for non-excluded crates.
+
 ### Test profiles
 
 By default, `make test` excludes slow installer integration tests

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -28,7 +28,7 @@ This executes unit, behaviour, and UI harness tests. The shared target enables
 
 The `no_std_fs_operations` crate includes end-to-end behavioural coverage for
 the `excluded_crates` configuration. These integration tests invoke
-`cargo dylint` in a subprocess so they exercise the full lint-loading and
+`cargo dylint` in a subprocess, so they exercise the full lint-loading and
 configuration path, rather than only unit-level helpers.
 
 The fixtures live under `crates/no_std_fs_operations/tests/fixtures/` as two

--- a/installer/src/install_flow.rs
+++ b/installer/src/install_flow.rs
@@ -13,6 +13,11 @@ use std::time::Duration;
 use whitaker_installer::builder::{library_extension, library_prefix};
 use whitaker_installer::cli::InstallArgs;
 use whitaker_installer::crate_name::CrateName;
+use whitaker_installer::deps::{
+    CommandExecutor, check_dylint_tools, install_dylint_tools_with_output,
+};
+#[cfg(test)]
+use whitaker_installer::deps::{DependencyInstallOptions, install_dylint_tools_with_options};
 use whitaker_installer::dirs::BaseDirs;
 use whitaker_installer::error::{InstallerError, Result};
 use whitaker_installer::install_metrics::{InstallMode, RecordOutcome, record_install};
@@ -20,6 +25,54 @@ use whitaker_installer::output::write_stderr_line;
 use whitaker_installer::prebuilt::{PrebuiltConfig, PrebuiltResult, attempt_prebuilt};
 use whitaker_installer::prebuilt_path::prebuilt_library_dir;
 use whitaker_installer::resolution::{EXPERIMENTAL_LINT_CRATES, LINT_CRATES, SUITE_CRATE};
+
+pub(crate) fn ensure_dylint_tools_core(
+    quiet: bool,
+    stderr: &mut dyn Write,
+    all_installed: bool,
+    do_install: impl FnOnce(&mut dyn Write) -> Result<()>,
+) -> Result<()> {
+    if all_installed {
+        return Ok(());
+    }
+
+    if !quiet {
+        write_stderr_line(stderr, "Installing required Dylint tools...");
+    }
+
+    do_install(stderr)?;
+
+    if !quiet {
+        write_stderr_line(stderr, "Dylint tools installed successfully.");
+        write_stderr_line(stderr, "");
+    }
+
+    Ok(())
+}
+
+pub(crate) fn ensure_dylint_tools_with_executor(
+    executor: &dyn CommandExecutor,
+    quiet: bool,
+    stderr: &mut dyn Write,
+) -> Result<()> {
+    let status = check_dylint_tools(executor);
+    ensure_dylint_tools_core(quiet, stderr, status.all_installed(), |stderr| {
+        install_dylint_tools_with_output(executor, &status, quiet, stderr)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn ensure_dylint_tools_with_options(
+    executor: &dyn CommandExecutor,
+    quiet: bool,
+    stderr: &mut dyn Write,
+    options: DependencyInstallOptions<'_>,
+) -> Result<()> {
+    let status = check_dylint_tools(executor);
+    ensure_dylint_tools_core(quiet, stderr, status.all_installed(), |stderr| {
+        install_dylint_tools_with_options(executor, &status, stderr, options)
+    })
+}
 
 /// Context needed to attempt prebuilt installation.
 pub(crate) struct PrebuiltInstallationContext<'a> {

--- a/installer/src/install_flow.rs
+++ b/installer/src/install_flow.rs
@@ -29,10 +29,10 @@ use whitaker_installer::resolution::{EXPERIMENTAL_LINT_CRATES, LINT_CRATES, SUIT
 pub(crate) fn ensure_dylint_tools_core(
     quiet: bool,
     stderr: &mut dyn Write,
-    all_installed: bool,
+    is_all_installed: bool,
     do_install: impl FnOnce(&mut dyn Write) -> Result<()>,
 ) -> Result<()> {
-    if all_installed {
+    if is_all_installed {
         return Ok(());
     }
 
@@ -64,12 +64,11 @@ pub(crate) fn ensure_dylint_tools_with_executor(
 #[cfg(test)]
 pub(crate) fn ensure_dylint_tools_with_options(
     executor: &dyn CommandExecutor,
-    quiet: bool,
     stderr: &mut dyn Write,
     options: DependencyInstallOptions<'_>,
 ) -> Result<()> {
     let status = check_dylint_tools(executor);
-    ensure_dylint_tools_core(quiet, stderr, status.all_installed(), |stderr| {
+    ensure_dylint_tools_core(options.quiet, stderr, status.all_installed(), |stderr| {
         install_dylint_tools_with_options(executor, &status, stderr, options)
     })
 }

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -7,9 +7,11 @@
 mod install_flow;
 mod staged_suite;
 
+#[cfg(test)]
+use crate::install_flow::ensure_dylint_tools_with_options;
 use crate::install_flow::{
     MetricsWriteContext, PrebuiltInstallationContext, detect_host_target,
-    try_prebuilt_installation, write_install_metrics,
+    ensure_dylint_tools_with_executor, try_prebuilt_installation, write_install_metrics,
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
@@ -17,12 +19,7 @@ use std::io::Write;
 use std::time::Instant;
 use whitaker_installer::cli::{Cli, Command, InstallArgs};
 use whitaker_installer::crate_name::CrateName;
-use whitaker_installer::deps::{
-    CommandExecutor, DylintToolStatus, SystemCommandExecutor, check_dylint_tools,
-    install_dylint_tools_with_output,
-};
-#[cfg(test)]
-use whitaker_installer::deps::{DependencyInstallOptions, install_dylint_tools_with_options};
+use whitaker_installer::deps::SystemCommandExecutor;
 use whitaker_installer::dirs::{BaseDirs, SystemBaseDirs};
 use whitaker_installer::error::{InstallerError, Result};
 use whitaker_installer::install_metrics::InstallMode;
@@ -183,51 +180,6 @@ fn determine_dry_run_target_dir(
 fn ensure_dylint_tools(quiet: bool, stderr: &mut dyn Write) -> Result<()> {
     let executor = SystemCommandExecutor;
     ensure_dylint_tools_with_executor(&executor, quiet, stderr)
-}
-
-fn ensure_dylint_tools_core(
-    quiet: bool,
-    stderr: &mut dyn Write,
-    all_installed: bool,
-    do_install: impl FnOnce(&mut dyn Write) -> Result<()>,
-) -> Result<()> {
-    if all_installed {
-        return Ok(());
-    }
-    if !quiet {
-        write_stderr_line(stderr, "Installing required Dylint tools...");
-    }
-    do_install(stderr)?;
-    if !quiet {
-        write_stderr_line(stderr, "Dylint tools installed successfully.");
-        write_stderr_line(stderr, "");
-    }
-
-    Ok(())
-}
-
-fn ensure_dylint_tools_with_executor(
-    executor: &dyn CommandExecutor,
-    quiet: bool,
-    stderr: &mut dyn Write,
-) -> Result<()> {
-    let status = check_dylint_tools(executor);
-    ensure_dylint_tools_core(quiet, stderr, status.all_installed(), |stderr| {
-        install_dylint_tools_with_output(executor, &status, quiet, stderr)
-    })
-}
-
-#[cfg(test)]
-fn ensure_dylint_tools_with_options(
-    executor: &dyn CommandExecutor,
-    quiet: bool,
-    stderr: &mut dyn Write,
-    options: DependencyInstallOptions<'_>,
-) -> Result<()> {
-    let status = check_dylint_tools(executor);
-    ensure_dylint_tools_core(quiet, stderr, status.all_installed(), |stderr| {
-        install_dylint_tools_with_options(executor, &status, stderr, options)
-    })
 }
 
 /// Ensures a Whitaker workspace is available.

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -182,31 +182,39 @@ fn determine_dry_run_target_dir(
 /// Checks for and installs Dylint tools if missing.
 fn ensure_dylint_tools(quiet: bool, stderr: &mut dyn Write) -> Result<()> {
     let executor = SystemCommandExecutor;
-    ensure_dylint_tools_with_install(&executor, quiet, stderr, |status, stderr| {
-        install_dylint_tools_with_output(&executor, status, quiet, stderr)
-    })
+    ensure_dylint_tools_with_executor(&executor, quiet, stderr)
 }
 
-fn ensure_dylint_tools_with_install(
-    executor: &dyn CommandExecutor,
+fn ensure_dylint_tools_core(
     quiet: bool,
     stderr: &mut dyn Write,
-    install: impl FnOnce(&DylintToolStatus, &mut dyn Write) -> Result<()>,
+    all_installed: bool,
+    do_install: impl FnOnce(&mut dyn Write) -> Result<()>,
 ) -> Result<()> {
-    let status = check_dylint_tools(executor);
-    if status.all_installed() {
+    if all_installed {
         return Ok(());
     }
     if !quiet {
         write_stderr_line(stderr, "Installing required Dylint tools...");
     }
-    install(&status, stderr)?;
+    do_install(stderr)?;
     if !quiet {
         write_stderr_line(stderr, "Dylint tools installed successfully.");
         write_stderr_line(stderr, "");
     }
 
     Ok(())
+}
+
+fn ensure_dylint_tools_with_executor(
+    executor: &dyn CommandExecutor,
+    quiet: bool,
+    stderr: &mut dyn Write,
+) -> Result<()> {
+    let status = check_dylint_tools(executor);
+    ensure_dylint_tools_core(quiet, stderr, status.all_installed(), |stderr| {
+        install_dylint_tools_with_output(executor, &status, quiet, stderr)
+    })
 }
 
 #[cfg(test)]
@@ -217,22 +225,9 @@ fn ensure_dylint_tools_with_options(
     options: DependencyInstallOptions<'_>,
 ) -> Result<()> {
     let status = check_dylint_tools(executor);
-
-    if status.all_installed() {
-        return Ok(());
-    }
-
-    if !quiet {
-        write_stderr_line(stderr, "Installing required Dylint tools...");
-    }
-
-    install_dylint_tools_with_options(executor, &status, stderr, options)?;
-
-    if !quiet {
-        write_stderr_line(stderr, "Dylint tools installed successfully.");
-        write_stderr_line(stderr, "");
-    }
-    Ok(())
+    ensure_dylint_tools_core(quiet, stderr, status.all_installed(), |stderr| {
+        install_dylint_tools_with_options(executor, &status, stderr, options)
+    })
 }
 
 /// Ensures a Whitaker workspace is available.

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -21,6 +21,8 @@ use whitaker_installer::deps::{
     CommandExecutor, DylintToolStatus, SystemCommandExecutor, check_dylint_tools,
     install_dylint_tools_with_output,
 };
+#[cfg(test)]
+use whitaker_installer::deps::{DependencyInstallOptions, install_dylint_tools_with_options};
 use whitaker_installer::dirs::{BaseDirs, SystemBaseDirs};
 use whitaker_installer::error::{InstallerError, Result};
 use whitaker_installer::install_metrics::InstallMode;
@@ -199,6 +201,33 @@ fn ensure_dylint_tools_with_install(
         write_stderr_line(stderr, "Installing required Dylint tools...");
     }
     install(&status, stderr)?;
+    if !quiet {
+        write_stderr_line(stderr, "Dylint tools installed successfully.");
+        write_stderr_line(stderr, "");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn ensure_dylint_tools_with_options(
+    executor: &dyn CommandExecutor,
+    quiet: bool,
+    stderr: &mut dyn Write,
+    options: DependencyInstallOptions<'_>,
+) -> Result<()> {
+    let status = check_dylint_tools(executor);
+
+    if status.all_installed() {
+        return Ok(());
+    }
+
+    if !quiet {
+        write_stderr_line(stderr, "Installing required Dylint tools...");
+    }
+
+    install_dylint_tools_with_options(executor, &status, stderr, options)?;
+
     if !quiet {
         write_stderr_line(stderr, "Dylint tools installed successfully.");
         write_stderr_line(stderr, "");

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the installer CLI entrypoint.
 
 use super::*;
-use rstest::rstest;
+use rstest::{fixture, rstest};
 use std::path::PathBuf;
 use std::time::Duration;
 use whitaker_installer::cli::InstallArgs;
@@ -24,6 +24,15 @@ fn dependency_install_options<'a>(
         repository_installer,
         target: Some(TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid target")),
         quiet,
+    }
+}
+
+#[fixture]
+fn test_base_dirs() -> TestBaseDirs {
+    TestBaseDirs {
+        home_dir: Some(PathBuf::from("/tmp")),
+        bin_dir: Some(PathBuf::from("/tmp/bin")),
+        data_dir: Some(PathBuf::from("/tmp")),
     }
 }
 
@@ -97,8 +106,8 @@ fn resolve_requested_crates_rejects_unknown_lints() {
     ));
 }
 
-#[test]
-fn ensure_dylint_tools_skips_install_when_installed() {
+#[rstest]
+fn ensure_dylint_tools_skips_install_when_installed(test_base_dirs: TestBaseDirs) {
     with_fake_binary_on_path("dylint-link", || {
         let executor = StubExecutor::new(vec![ExpectedCall {
             cmd: "cargo",
@@ -106,14 +115,9 @@ fn ensure_dylint_tools_skips_install_when_installed() {
             result: Ok(success_output()),
         }]);
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
-        let dirs = TestBaseDirs {
-            home_dir: Some(PathBuf::from("/tmp")),
-            bin_dir: Some(PathBuf::from("/tmp/bin")),
-            data_dir: Some(PathBuf::from("/tmp")),
-        };
 
         let mut stderr = Vec::new();
-        let options = dependency_install_options(&dirs, &repository_installer, false);
+        let options = dependency_install_options(&test_base_dirs, &repository_installer, false);
         let result = ensure_dylint_tools_with_options(&executor, &mut stderr, options);
 
         assert!(result.is_ok());
@@ -130,6 +134,7 @@ fn ensure_dylint_tools_skips_install_when_installed() {
 )]
 #[case::quiet_suppresses_output(true, "", "")]
 fn ensure_dylint_tools_installs_missing_tools(
+    test_base_dirs: TestBaseDirs,
     #[case] quiet: bool,
     #[case] expected_start: &str,
     #[case] expected_end: &str,
@@ -158,14 +163,9 @@ fn ensure_dylint_tools_installs_missing_tools(
             },
         ]);
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
-        let dirs = TestBaseDirs {
-            home_dir: Some(PathBuf::from("/tmp")),
-            bin_dir: Some(PathBuf::from("/tmp/bin")),
-            data_dir: Some(PathBuf::from("/tmp")),
-        };
 
         let mut stderr = Vec::new();
-        let options = dependency_install_options(&dirs, &repository_installer, quiet);
+        let options = dependency_install_options(&test_base_dirs, &repository_installer, quiet);
         let result = ensure_dylint_tools_with_options(&executor, &mut stderr, options);
 
         assert!(result.is_ok());
@@ -189,8 +189,8 @@ fn ensure_dylint_tools_installs_missing_tools(
     });
 }
 
-#[test]
-fn ensure_dylint_tools_propagates_install_failures() {
+#[rstest]
+fn ensure_dylint_tools_propagates_install_failures(test_base_dirs: TestBaseDirs) {
     with_fake_binary_on_path("dylint-link", || {
         let executor = StubExecutor::new(vec![
             ExpectedCall {
@@ -210,14 +210,9 @@ fn ensure_dylint_tools_propagates_install_failures() {
             },
         ]);
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
-        let dirs = TestBaseDirs {
-            home_dir: Some(PathBuf::from("/tmp")),
-            bin_dir: Some(PathBuf::from("/tmp/bin")),
-            data_dir: Some(PathBuf::from("/tmp")),
-        };
 
         let mut stderr = Vec::new();
-        let options = dependency_install_options(&dirs, &repository_installer, false);
+        let options = dependency_install_options(&test_base_dirs, &repository_installer, false);
         let err = ensure_dylint_tools_with_options(&executor, &mut stderr, options)
             .expect_err("expected install failure");
 

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -113,7 +113,7 @@ fn ensure_dylint_tools_skips_install_when_installed() {
 
         let mut stderr = Vec::new();
         let options = dependency_install_options(&repository_installer, false);
-        let result = ensure_dylint_tools_with_options(&executor, false, &mut stderr, options);
+        let result = ensure_dylint_tools_with_options(&executor, &mut stderr, options);
 
         assert!(result.is_ok());
         assert!(stderr.is_empty());
@@ -160,7 +160,7 @@ fn ensure_dylint_tools_installs_missing_tools(
 
         let mut stderr = Vec::new();
         let options = dependency_install_options(&repository_installer, quiet);
-        let result = ensure_dylint_tools_with_options(&executor, quiet, &mut stderr, options);
+        let result = ensure_dylint_tools_with_options(&executor, &mut stderr, options);
 
         assert!(result.is_ok());
         let stderr_text = String::from_utf8(stderr).expect("stderr was not UTF-8");
@@ -207,7 +207,7 @@ fn ensure_dylint_tools_propagates_install_failures() {
 
         let mut stderr = Vec::new();
         let options = dependency_install_options(&repository_installer, false);
-        let err = ensure_dylint_tools_with_options(&executor, false, &mut stderr, options)
+        let err = ensure_dylint_tools_with_options(&executor, &mut stderr, options)
             .expect_err("expected install failure");
 
         assert!(matches!(

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -15,16 +15,12 @@ use whitaker_installer::test_utils::dependency_binary_helpers::{
 use whitaker_installer::test_utils::*;
 
 fn dependency_install_options<'a>(
+    dirs: &'a TestBaseDirs,
     repository_installer: &'a dyn DependencyBinaryInstaller,
     quiet: bool,
 ) -> DependencyInstallOptions<'a> {
-    let dirs = TestBaseDirs {
-        home_dir: Some(PathBuf::from("/tmp")),
-        bin_dir: Some(PathBuf::from("/tmp/bin")),
-        data_dir: Some(PathBuf::from("/tmp")),
-    };
     DependencyInstallOptions {
-        dirs: Box::leak(Box::new(dirs)),
+        dirs,
         repository_installer,
         target: Some(TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid target")),
         quiet,
@@ -110,9 +106,14 @@ fn ensure_dylint_tools_skips_install_when_installed() {
             result: Ok(success_output()),
         }]);
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
+        let dirs = TestBaseDirs {
+            home_dir: Some(PathBuf::from("/tmp")),
+            bin_dir: Some(PathBuf::from("/tmp/bin")),
+            data_dir: Some(PathBuf::from("/tmp")),
+        };
 
         let mut stderr = Vec::new();
-        let options = dependency_install_options(&repository_installer, false);
+        let options = dependency_install_options(&dirs, &repository_installer, false);
         let result = ensure_dylint_tools_with_options(&executor, &mut stderr, options);
 
         assert!(result.is_ok());
@@ -157,9 +158,14 @@ fn ensure_dylint_tools_installs_missing_tools(
             },
         ]);
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
+        let dirs = TestBaseDirs {
+            home_dir: Some(PathBuf::from("/tmp")),
+            bin_dir: Some(PathBuf::from("/tmp/bin")),
+            data_dir: Some(PathBuf::from("/tmp")),
+        };
 
         let mut stderr = Vec::new();
-        let options = dependency_install_options(&repository_installer, quiet);
+        let options = dependency_install_options(&dirs, &repository_installer, quiet);
         let result = ensure_dylint_tools_with_options(&executor, &mut stderr, options);
 
         assert!(result.is_ok());
@@ -204,9 +210,14 @@ fn ensure_dylint_tools_propagates_install_failures() {
             },
         ]);
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
+        let dirs = TestBaseDirs {
+            home_dir: Some(PathBuf::from("/tmp")),
+            bin_dir: Some(PathBuf::from("/tmp/bin")),
+            data_dir: Some(PathBuf::from("/tmp")),
+        };
 
         let mut stderr = Vec::new();
-        let options = dependency_install_options(&repository_installer, false);
+        let options = dependency_install_options(&dirs, &repository_installer, false);
         let err = ensure_dylint_tools_with_options(&executor, &mut stderr, options)
             .expect_err("expected install failure");
 

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use whitaker_installer::cli::InstallArgs;
 use whitaker_installer::dependency_binaries::DependencyBinaryInstaller;
-use whitaker_installer::deps::{DependencyInstallOptions, install_dylint_tools_with_options};
+use whitaker_installer::deps::DependencyInstallOptions;
 use whitaker_installer::dirs::BaseDirs;
 use whitaker_installer::installer_packaging::TargetTriple;
 use whitaker_installer::test_utils::dependency_binary_helpers::{
@@ -113,10 +113,7 @@ fn ensure_dylint_tools_skips_install_when_installed() {
 
         let mut stderr = Vec::new();
         let options = dependency_install_options(&repository_installer, false);
-        let result =
-            ensure_dylint_tools_with_install(&executor, false, &mut stderr, |status, stderr| {
-                install_dylint_tools_with_options(&executor, status, stderr, options)
-            });
+        let result = ensure_dylint_tools_with_options(&executor, false, &mut stderr, options);
 
         assert!(result.is_ok());
         assert!(stderr.is_empty());
@@ -163,10 +160,7 @@ fn ensure_dylint_tools_installs_missing_tools(
 
         let mut stderr = Vec::new();
         let options = dependency_install_options(&repository_installer, quiet);
-        let result =
-            ensure_dylint_tools_with_install(&executor, quiet, &mut stderr, |status, stderr| {
-                install_dylint_tools_with_options(&executor, status, stderr, options)
-            });
+        let result = ensure_dylint_tools_with_options(&executor, quiet, &mut stderr, options);
 
         assert!(result.is_ok());
         let stderr_text = String::from_utf8(stderr).expect("stderr was not UTF-8");
@@ -213,10 +207,7 @@ fn ensure_dylint_tools_propagates_install_failures() {
 
         let mut stderr = Vec::new();
         let options = dependency_install_options(&repository_installer, false);
-        let err =
-            ensure_dylint_tools_with_install(&executor, false, &mut stderr, |status, stderr| {
-                install_dylint_tools_with_options(&executor, status, stderr, options)
-            })
+        let err = ensure_dylint_tools_with_options(&executor, false, &mut stderr, options)
             .expect_err("expected install failure");
 
         assert!(matches!(


### PR DESCRIPTION
## Summary
- Rebased branch onto origin/main with conflict resolution to ensure a clean merge base.
- Adds workspace context to integration test fixtures by declaring [workspace] in their Cargo.toml files, enabling proper isolation semantics during tests.
- Reworks integration tests to count diagnostics via the lint's code and run tests serially to avoid interference.
- Configures cargo-dylint invocation to suppress warnings through the DYLINT_RUSTFLAGS environment variable rather than CLI arguments.
- Extends test harness to support installer tooling scenarios and dependency-install options in tests.

## Changes
### Fixtures
- Add [workspace] to Cargo.toml for:
  - crates/no_std_fs_operations/tests/fixtures/excluded_project/Cargo.toml
  - crates/no_std_fs_operations/tests/fixtures/non_excluded_project/Cargo.toml

### Integration tests
- Update crates/no_std_fs_operations/tests/integration_exclusion.rs:
  - Change diagnostic text to reflect new wording: "bypasses the capability-based filesystem policy."
  - Import serial_test::serial and annotate tests with #[serial] to ensure serial execution.
  - Introduce diagnostic_count(output: &[u8]) -> usize to count diagnostics emitted by the lint by parsing cargo's JSON messages and filtering by the lint's code.
  - Replace previous dylint invocation cleaner flags with environment-based flag suppression:
    - Use .env("DYLINT_RUSTFLAGS", "-D warnings") instead of passing -D warnings through arguments.
  - Update run_cargo_dylint() to rely on DYLINT_RUSTFLAGS and to count diagnostics from stdout.
  - Tests now assert:
    - excluded_crate_suppresses_diagnostics: diagnostic count == 0
    - non_excluded_crate_emits_diagnostics: diagnostic count > 0

### Docs
- Updated docs/developers-guide.md to document the new integration-test harness, the diagnostic counting approach, and workspace-aware fixtures.

### Installer
- Introduced test-time support for installing dylint tools with configurable options via DependencyInstallOptions.
- Added wrapper to call installer with options in tests, enabling deterministic testing of missing-yet-needed tooling scenarios.
- Extended installer tests to cover cases where the repository asset is missing, ensuring proper error propagation and behavior when dependencies are unavailable.

### Tests
- Expanded test helpers to support option-based installation paths and to simulate missing repository installers in tests.

## Test plan
- Prerequisites: cargo-dylint and a built lint library.
- Steps:
  1. Build the lint library as before (required by the tests).
  2. Run integration tests for no_std_fs_operations fixtures:
     - Excluded project should emit zero diagnostics.
     - Non-excluded project should emit one or more diagnostics.
- The tests use serial execution to avoid cross-test interference and are guarded with #[ignore] if cargo-dylint or dylint library is unavailable.
- Installer tests require similar prerequisites for dylint tooling in the test environment.

## Rationale
- Wiring the fixtures into a workspace makes isolation behavior during integration tests match real workspace semantics.
- Counting diagnostics rather than string-contains checks makes tests robust to formatting and ordering changes in dylint output.
- Serial tests ensure deterministic results when using shared global tooling (dylint) in CI/local runs.
- Extending tests with installer-option wiring allows validating scenarios where specific tooling is installed or missing.

📎 Task: https://www.devboxer.com/task/57b00cf8-db09-439f-82ce-9f10c9700fa8