### PR TITLE
Dylint-link verification: add PATH-based probe and tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -465,6 +465,8 @@ five small private helpers:
   the install check can validate the exact path it found.
 - `find_binary_in_directory(directory, binary_name)` performs the per-directory
   search that `find_binary_on_path()` uses while walking `PATH`.
+- `binary_candidates(directory, binary_name)` builds the ordered set of
+  candidate paths that each directory contributes to the lookup.
 - `dylint_link_probe_toolchain()` preserves an existing `RUSTUP_TOOLCHAIN`
   value or synthesizes `stable-<host-target>` so `dylint-link --help` can run
   in the same environments where `dylint-link --version` exits early.
@@ -474,12 +476,15 @@ five small private helpers:
 - `is_executable_file(path)` applies the platform-specific file test:
   executable-bit plus regular-file checks on Unix, and `path.is_file()` on
   non-Unix targets where the executable suffix carries the meaning.
+- `windows_path_extensions()` normalizes `PATHEXT` on Windows so
+  `binary_candidates()` can expand extensionless names the same way the shell
+  does.
 
-These helpers are covered by direct unit tests in `installer/src/deps/tests.rs`
-for missing PATH values, empty PATH values, multiple PATH directories,
-non-executable Unix files, executable Unix files, broken PATH shims, and
-Windows `PATHEXT` resolution via both direct helper tests and
-`check_dylint_tools()`.
+These key helpers are covered by direct unit tests in
+`installer/src/deps/path_tests.rs` for missing PATH values, empty PATH values,
+multiple PATH directories, non-executable Unix files, executable Unix files,
+broken PATH shims, and Windows `PATHEXT` resolution via both direct helper
+tests and `check_dylint_tools()`.
 
 Installer PATH-fixture helpers now live in
 `installer/src/test_utils/dependency_binary_helpers.rs` instead of being

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -459,7 +459,7 @@ code checks for a resolvable `dylint-link` binary only after local
 artefact was used or when `dylint-link` was already present.
 
 The `dylint-link` verification in `installer/src/deps.rs` is implemented by
-five small private helpers:
+seven small private helpers:
 
 - `find_binary_on_path(binary_name)` returns the first executable candidate so
   the install check can validate the exact path it found.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -411,8 +411,10 @@ The dependency-install path is split into focused modules under
 1. Attempt the repository-hosted dependency archive for the current target.
 2. Verify the installed tool is now usable. `cargo-dylint` is checked by
    running `cargo dylint --version`, while `dylint-link` is checked by
-   resolving the executable on `PATH` because upstream requires
-   `RUSTUP_TOOLCHAIN` even for `--version`.
+   resolving the executable on `PATH` and invoking it with `--help`. The probe
+   synthesizes `RUSTUP_TOOLCHAIN` from the host target when the environment
+   variable is unset, because upstream reads that variable before processing
+   CLI flags.
 3. If the repository download reports `NotFound`, skip `cargo binstall` and
    fall back directly to `cargo install`.
 4. For other repository failures, fall back to `cargo binstall` when available
@@ -456,21 +458,30 @@ code checks for a resolvable `dylint-link` binary only after local
 `cargo-dylint` installs and does not re-check it when the pre-built repository
 artefact was used or when `dylint-link` was already present.
 
-The PATH-based `dylint-link` verification in `installer/src/deps.rs` is
-implemented by two small private helpers:
+The `dylint-link` verification in `installer/src/deps.rs` is implemented by
+four small private helpers:
 
 - `is_binary_on_path(binary_name)` walks `PATH` with `std::env::split_paths`,
   checks each directory for `<binary_name>`, and on Windows also checks the
   executable suffixes from `PATHEXT` while falling back to
   `.COM;.EXE;.BAT;.CMD` when `PATHEXT` is unset.
+- `find_binary_on_path(binary_name)` returns the first executable candidate so
+  the install check can validate the exact path it found.
+- `dylint_link_probe_toolchain()` preserves an existing `RUSTUP_TOOLCHAIN`
+  value or synthesizes `stable-<host-target>` so `dylint-link --help` can run
+  in the same environments where `dylint-link --version` exits early.
+- `dylint_link_probe_succeeds(path)` runs the resolved binary with `--help` and
+  requires a successful exit status before Whitaker treats the tool as
+  installed.
 - `is_executable_file(path)` applies the platform-specific file test:
   executable-bit plus regular-file checks on Unix, and `path.is_file()` on
   non-Unix targets where the executable suffix carries the meaning.
 
 These helpers are covered by direct unit tests in `installer/src/deps/tests.rs`
 for missing PATH values, empty PATH values, multiple PATH directories,
-non-executable Unix files, executable Unix files, and Windows `PATHEXT`
-resolution via both direct helper tests and `check_dylint_tools()`.
+non-executable Unix files, executable Unix files, broken PATH shims, and
+Windows `PATHEXT` resolution via both direct helper tests and
+`check_dylint_tools()`.
 
 Installer PATH-fixture helpers now live in
 `installer/src/test_utils/dependency_binary_helpers.rs` instead of being

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -409,7 +409,10 @@ The dependency-install path is split into focused modules under
 `installer/src/deps.rs` drives the high-level fallback order:
 
 1. Attempt the repository-hosted dependency archive for the current target.
-2. Verify the installed tool is now runnable.
+2. Verify the installed tool is now usable. `cargo-dylint` is checked by
+   running `cargo dylint --version`, while `dylint-link` is checked by
+   resolving the executable on `PATH` because upstream requires
+   `RUSTUP_TOOLCHAIN` even for `--version`.
 3. If the repository download reports `NotFound`, skip `cargo binstall` and
    fall back directly to `cargo install`.
 4. For other repository failures, fall back to `cargo binstall` when available
@@ -449,9 +452,9 @@ latest upstream release.
 `update_status_after_install()` delegates the local-install probe decision to
 `should_refresh_companions()`. That helper returns `true` only when the install
 outcome was not `RepositoryRelease` and `dylint-link` is still missing, so the
-code probes for `dylint-link` only after local `cargo-dylint` installs and does
-not re-check it when the pre-built repository artefact was used or when
-`dylint-link` was already present.
+code checks for a resolvable `dylint-link` binary only after local
+`cargo-dylint` installs and does not re-check it when the pre-built repository
+artefact was used or when `dylint-link` was already present.
 
 ### CLI tool usage
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -456,6 +456,37 @@ code checks for a resolvable `dylint-link` binary only after local
 `cargo-dylint` installs and does not re-check it when the pre-built repository
 artefact was used or when `dylint-link` was already present.
 
+The PATH-based `dylint-link` verification in `installer/src/deps.rs` is
+implemented by two small private helpers:
+
+- `is_binary_on_path(binary_name)` walks `PATH` with `std::env::split_paths`,
+  checks each directory for `<binary_name>`, and on Windows also checks the
+  executable suffixes from `PATHEXT` while falling back to
+  `.COM;.EXE;.BAT;.CMD` when `PATHEXT` is unset.
+- `is_executable_file(path)` applies the platform-specific file test:
+  executable-bit plus regular-file checks on Unix, and `path.is_file()` on
+  non-Unix targets where the executable suffix carries the meaning.
+
+These helpers are covered by direct unit tests in `installer/src/deps/tests.rs`
+for missing PATH values, empty PATH values, multiple PATH directories,
+non-executable Unix files, executable Unix files, and Windows `PATHEXT`
+resolution via both direct helper tests and `check_dylint_tools()`.
+
+Installer PATH-fixture helpers now live in
+`installer/src/test_utils/dependency_binary_helpers.rs` instead of being
+duplicated across multiple test modules. The key helpers are:
+
+- `with_fake_binary_on_path(binary_name, run)`, which creates a temporary PATH
+  entry containing one executable and runs the closure under `env_test_guard()`.
+- `with_fake_path(setup, run)`, which provides two temporary PATH directories
+  for tests that need to control PATH ordering or place binaries in later
+  entries.
+- `write_fake_binary(path, is_executable)`, which writes a fake binary and, on
+  Unix, sets executable permissions explicitly for positive and negative tests.
+- `AlwaysNotFoundRepositoryInstaller`, a repository-installer test double used
+  by `installer/src/tests.rs` to force the direct Cargo fallback path without
+  network access.
+
 ### CLI tool usage
 
 Release automation uses the `whitaker-package-dependency-binary` helper in

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -459,14 +459,12 @@ code checks for a resolvable `dylint-link` binary only after local
 artefact was used or when `dylint-link` was already present.
 
 The `dylint-link` verification in `installer/src/deps.rs` is implemented by
-four small private helpers:
+five small private helpers:
 
-- `is_binary_on_path(binary_name)` walks `PATH` with `std::env::split_paths`,
-  checks each directory for `<binary_name>`, and on Windows also checks the
-  executable suffixes from `PATHEXT` while falling back to
-  `.COM;.EXE;.BAT;.CMD` when `PATHEXT` is unset.
 - `find_binary_on_path(binary_name)` returns the first executable candidate so
   the install check can validate the exact path it found.
+- `find_binary_in_directory(directory, binary_name)` performs the per-directory
+  search that `find_binary_on_path()` uses while walking `PATH`.
 - `dylint_link_probe_toolchain()` preserves an existing `RUSTUP_TOOLCHAIN`
   value or synthesizes `stable-<host-target>` so `dylint-link --help` can run
   in the same environments where `dylint-link --version` exits early.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -41,9 +41,10 @@ This:
    Cargo, and on success it prints
    `Installed <tool> from source with cargo install.`. After installation,
    `cargo-dylint` is verified by running `cargo dylint --version`, while
-   `dylint-link` is verified by resolving the executable on `PATH`. This avoids
-   false failures from upstream `dylint-link --version`, which requires
-   `RUSTUP_TOOLCHAIN` even when the binary is correctly installed.
+   `dylint-link` is verified by resolving the executable on `PATH` and then
+   invoking it with `--help`. The installer sets `RUSTUP_TOOLCHAIN` for that
+   probe when needed, which avoids false failures from upstream
+   `dylint-link --version` while still rejecting stale shims and broken scripts.
 2. Clones the Whitaker repository to a platform-specific data directory
 3. Builds the lint libraries
 4. Creates `whitaker` and `whitaker-ls` wrapper scripts. `whitaker` invokes
@@ -57,8 +58,9 @@ After installation, run `whitaker --all` in any Rust project to lint it. Use
 On Windows, the installer's `PATH` check honours `PATHEXT` and falls back to
 the usual executable suffixes when `PATHEXT` is unset, so a normal
 Cargo-installed executable such as `dylint-link.exe` in
-`%USERPROFILE%\\.cargo\\bin` is treated as installed without needing a separate
-wrapper or environment-variable workaround.
+`%USERPROFILE%\\.cargo\\bin` is located correctly and then verified with the
+same invocation-based probe without needing a separate wrapper or manual
+environment-variable workaround.
 
 **Options:**
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -58,8 +58,8 @@ After installation, run `whitaker --all` in any Rust project to lint it. Use
 On Windows, the installer's `PATH` check honours `PATHEXT` and falls back to
 the usual executable suffixes when `PATHEXT` is unset, so a normal
 Cargo-installed executable such as `dylint-link.exe` in
-`%USERPROFILE%\\.cargo\\bin` is located correctly and then verified with the
-same invocation-based probe without needing a separate wrapper or manual
+`%USERPROFILE%\.cargo\bin` is located correctly and then verified with the same
+invocation-based probe without needing a separate wrapper or manual
 environment-variable workaround.
 
 **Options:**

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -39,7 +39,11 @@ This:
    to `cargo binstall` when available and then to `cargo install`. When the
    source-build path is taken, the installer reports that it is falling back to
    Cargo, and on success it prints
-   `Installed <tool> from source with cargo install.`.
+   `Installed <tool> from source with cargo install.`. After installation,
+   `cargo-dylint` is verified by running `cargo dylint --version`, while
+   `dylint-link` is verified by resolving the executable on `PATH`. This avoids
+   false failures from upstream `dylint-link --version`, which requires
+   `RUSTUP_TOOLCHAIN` even when the binary is correctly installed.
 2. Clones the Whitaker repository to a platform-specific data directory
 3. Builds the lint libraries
 4. Creates `whitaker` and `whitaker-ls` wrapper scripts. `whitaker` invokes
@@ -49,6 +53,12 @@ This:
 
 After installation, run `whitaker --all` in any Rust project to lint it. Use
 `whitaker-ls` to list the installed Whitaker suite libraries.
+
+On Windows, the installer's `PATH` check honours `PATHEXT` and falls back to
+the usual executable suffixes when `PATHEXT` is unset, so a normal
+Cargo-installed executable such as `dylint-link.exe` in
+`%USERPROFILE%\\.cargo\\bin` is treated as installed without needing a separate
+wrapper or environment-variable workaround.
 
 **Options:**
 

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -52,7 +52,7 @@ path = "src/bin/package_dependency_binary.rs"
 ##   testing and are excluded from release builds.
 ## - **API stability**: The test-support surface is not covered by semver
 ##   guarantees and may change between minor releases.
-test-support = []
+test-support = ["dep:temp-env"]
 
 [dependencies]
 camino = { workspace = true }
@@ -66,7 +66,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tar = { workspace = true }
-temp-env = { workspace = true }
+temp-env = { workspace = true, optional = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
@@ -81,6 +81,7 @@ mockall = { workspace = true }
 rstest = { workspace = true }
 rstest-bdd = { workspace = true }
 rstest-bdd-macros = { workspace = true }
+temp-env = { workspace = true }
 tempfile = { workspace = true }
 whitaker-installer = { path = ".", features = ["test-support"] }
 

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -66,6 +66,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tar = { workspace = true }
+temp-env = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
@@ -80,7 +81,6 @@ mockall = { workspace = true }
 rstest = { workspace = true }
 rstest-bdd = { workspace = true }
 rstest-bdd-macros = { workspace = true }
-temp-env = { workspace = true }
 tempfile = { workspace = true }
 whitaker-installer = { path = ".", features = ["test-support"] }
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -111,12 +111,12 @@ Dependency-tool verification is asymmetric by design:
 - `cargo-dylint` is checked by running `cargo dylint --version`.
 - `dylint-link` is checked by resolving the executable on `PATH` and then
   invoking it with `--help`. The probe injects `RUSTUP_TOOLCHAIN` when the
-  caller has not already set it, which avoids the false negatives from
+  caller has not already set it which avoids the false negatives from
   `dylint-link --version` while still rejecting stale shims and broken scripts.
 
 On Windows, the installer honours `PATHEXT` while scanning `PATH`, so the
 normal Cargo-installed `dylint-link.exe` and other shell-resolved executable
-suffixes are recognised and then verified with the same invocation-based probe.
+suffixes are recognized and then verified with the same invocation-based probe.
 
 The wrappers are:
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -106,6 +106,17 @@ cargo dylint --all
 The installer generates wrapper scripts and provides shell configuration
 snippets to simplify this setup.
 
+Dependency-tool verification is asymmetric by design:
+
+- `cargo-dylint` is checked by running `cargo dylint --version`.
+- `dylint-link` is checked by resolving the executable on `PATH` instead of
+  running `dylint-link --version`, because upstream requires `RUSTUP_TOOLCHAIN`
+  even for `--version`.
+
+On Windows, the installer honours `PATHEXT` while scanning `PATH`, so the
+normal Cargo-installed `dylint-link.exe` and other shell-resolved executable
+suffixes are recognised.
+
 The wrappers are:
 
 - `whitaker` — runs `cargo dylint` with the staged library path.

--- a/installer/README.md
+++ b/installer/README.md
@@ -111,7 +111,7 @@ Dependency-tool verification is asymmetric by design:
 - `cargo-dylint` is checked by running `cargo dylint --version`.
 - `dylint-link` is checked by resolving the executable on `PATH` and then
   invoking it with `--help`. The probe injects `RUSTUP_TOOLCHAIN` when the
-  caller has not already set it which avoids the false negatives from
+  caller has not already set it, which avoids the false negatives from
   `dylint-link --version` while still rejecting stale shims and broken scripts.
 
 On Windows, the installer honours `PATHEXT` while scanning `PATH`, so the

--- a/installer/README.md
+++ b/installer/README.md
@@ -109,13 +109,14 @@ snippets to simplify this setup.
 Dependency-tool verification is asymmetric by design:
 
 - `cargo-dylint` is checked by running `cargo dylint --version`.
-- `dylint-link` is checked by resolving the executable on `PATH` instead of
-  running `dylint-link --version`, because upstream requires `RUSTUP_TOOLCHAIN`
-  even for `--version`.
+- `dylint-link` is checked by resolving the executable on `PATH` and then
+  invoking it with `--help`. The probe injects `RUSTUP_TOOLCHAIN` when the
+  caller has not already set it, which avoids the false negatives from
+  `dylint-link --version` while still rejecting stale shims and broken scripts.
 
 On Windows, the installer honours `PATHEXT` while scanning `PATH`, so the
 normal Cargo-installed `dylint-link.exe` and other shell-resolved executable
-suffixes are recognised.
+suffixes are recognised and then verified with the same invocation-based probe.
 
 The wrappers are:
 

--- a/installer/src/dependency_binaries/manifest.rs
+++ b/installer/src/dependency_binaries/manifest.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 /// # Example
 ///
 /// ```
-/// use whitaker_installer::dependency_binaries::manifest::{
+/// use whitaker_installer::dependency_binaries::{
 ///     parse_manifest, required_dependency_binaries, DependencyBinary
 /// };
 ///
@@ -117,7 +117,7 @@ impl From<toml::de::Error> for ManifestError {
 /// # Example
 ///
 /// ```
-/// use whitaker_installer::dependency_binaries::manifest::manifest_contents;
+/// use whitaker_installer::dependency_binaries::manifest_contents;
 ///
 /// let contents = manifest_contents();
 /// assert!(contents.contains("dependency_binaries"));
@@ -140,7 +140,7 @@ pub fn manifest_contents() -> &'static str {
 /// Parse the embedded manifest:
 ///
 /// ```
-/// use whitaker_installer::dependency_binaries::manifest::{
+/// use whitaker_installer::dependency_binaries::{
 ///     manifest_contents, parse_manifest
 /// };
 ///
@@ -153,7 +153,7 @@ pub fn manifest_contents() -> &'static str {
 /// Parse a custom manifest string:
 ///
 /// ```
-/// use whitaker_installer::dependency_binaries::manifest::parse_manifest;
+/// use whitaker_installer::dependency_binaries::parse_manifest;
 ///
 /// let manifest = r#"
 ///     [[dependency_binaries]]
@@ -172,7 +172,7 @@ pub fn manifest_contents() -> &'static str {
 /// Reject duplicate packages:
 ///
 /// ```
-/// use whitaker_installer::dependency_binaries::manifest::parse_manifest;
+/// use whitaker_installer::dependency_binaries::parse_manifest;
 ///
 /// let manifest_with_duplicates = r#"
 ///     [[dependency_binaries]]
@@ -219,7 +219,7 @@ pub fn parse_manifest(contents: &str) -> Result<Vec<DependencyBinary>, ManifestE
 /// # Example
 ///
 /// ```
-/// use whitaker_installer::dependency_binaries::manifest::required_dependency_binaries;
+/// use whitaker_installer::dependency_binaries::required_dependency_binaries;
 ///
 /// let dependencies = required_dependency_binaries()
 ///     .expect("embedded manifest should be valid");
@@ -249,7 +249,7 @@ pub fn required_dependency_binaries() -> Result<&'static [DependencyBinary], Man
 /// Find an existing package (returns `Some`):
 ///
 /// ```
-/// use whitaker_installer::dependency_binaries::manifest::find_dependency_binary;
+/// use whitaker_installer::dependency_binaries::find_dependency_binary;
 ///
 /// let tool = find_dependency_binary("cargo-dylint")
 ///     .expect("manifest should parse")
@@ -262,7 +262,7 @@ pub fn required_dependency_binaries() -> Result<&'static [DependencyBinary], Man
 /// Search for a non-existent package (returns `None`):
 ///
 /// ```
-/// use whitaker_installer::dependency_binaries::manifest::find_dependency_binary;
+/// use whitaker_installer::dependency_binaries::find_dependency_binary;
 ///
 /// let result = find_dependency_binary("non-existent-package")
 ///     .expect("manifest should parse");
@@ -273,7 +273,7 @@ pub fn required_dependency_binaries() -> Result<&'static [DependencyBinary], Man
 /// Handle manifest parse errors:
 ///
 /// ```
-/// use whitaker_installer::dependency_binaries::manifest::find_dependency_binary;
+/// use whitaker_installer::dependency_binaries::find_dependency_binary;
 ///
 /// // This will only fail if the embedded manifest is corrupted
 /// match find_dependency_binary("cargo-dylint") {

--- a/installer/src/deps.rs
+++ b/installer/src/deps.rs
@@ -229,14 +229,15 @@ fn binary_candidates(directory: &Path, binary_name: &str) -> Vec<std::path::Path
     {
         if Path::new(binary_name).extension().is_some() {
             candidates.push(directory.join(binary_name));
+        } else {
+            let lowercase_name = binary_name.to_ascii_lowercase();
+            candidates.extend(
+                windows_path_extensions()
+                    .into_iter()
+                    .filter(|extension| !lowercase_name.ends_with(&extension.to_ascii_lowercase()))
+                    .map(|extension| directory.join(format!("{binary_name}{extension}"))),
+            );
         }
-        let lowercase_name = binary_name.to_ascii_lowercase();
-        candidates.extend(
-            windows_path_extensions()
-                .into_iter()
-                .filter(|extension| !lowercase_name.ends_with(&extension.to_ascii_lowercase()))
-                .map(|extension| directory.join(format!("{binary_name}{extension}"))),
-        );
     }
     candidates
 }

--- a/installer/src/deps.rs
+++ b/installer/src/deps.rs
@@ -165,12 +165,10 @@ pub fn install_dylint_tools_with_options(
 
 fn is_tool_installed(executor: &dyn CommandExecutor, tool: &DependencyTool) -> bool {
     if tool == &DYLINT_LINK_TOOL {
-        if !is_binary_on_path(tool.command) {
-            return false;
-        }
-
-        return find_binary_on_path(tool.command)
-            .is_some_and(|binary_path| dylint_link_probe_succeeds(&binary_path));
+        return match find_binary_on_path(tool.command) {
+            Some(binary_path) => dylint_link_probe_succeeds(&binary_path),
+            None => false,
+        };
     }
     command_succeeds(executor, tool.command, tool.args)
 }
@@ -179,6 +177,7 @@ fn is_binstall_available(executor: &dyn CommandExecutor) -> bool {
     command_succeeds(executor, "cargo", &["binstall", "--version"])
 }
 
+#[cfg(test)]
 fn is_binary_on_path(binary_name: &str) -> bool {
     find_binary_on_path(binary_name).is_some()
 }

--- a/installer/src/deps.rs
+++ b/installer/src/deps.rs
@@ -9,7 +9,6 @@ use crate::dependency_binaries::{
 };
 use crate::dirs::{BaseDirs, SystemBaseDirs};
 use crate::error::{InstallerError, Result};
-use std::fs;
 use std::io;
 use std::io::Write;
 use std::path::Path;
@@ -202,7 +201,7 @@ fn is_binary_on_path(binary_name: &str) -> bool {
 fn is_executable_file(path: &Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
 
-    fs::metadata(path)
+    std::fs::metadata(path)
         .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
         .unwrap_or(false)
 }

--- a/installer/src/deps.rs
+++ b/installer/src/deps.rs
@@ -223,11 +223,14 @@ fn dylint_link_probe_toolchain() -> Option<String> {
 
 fn binary_candidates(directory: &Path, binary_name: &str) -> Vec<std::path::PathBuf> {
     #[cfg(windows)]
-    let mut candidates = vec![directory.join(binary_name)];
+    let mut candidates = Vec::new();
     #[cfg(not(windows))]
     let candidates = vec![directory.join(binary_name)];
     #[cfg(windows)]
     {
+        if Path::new(binary_name).extension().is_some() {
+            candidates.push(directory.join(binary_name));
+        }
         let lowercase_name = binary_name.to_ascii_lowercase();
         candidates.extend(
             windows_path_extensions()
@@ -275,5 +278,7 @@ fn is_executable_file(path: &Path) -> bool {
     path.is_file()
 }
 
+#[cfg(test)]
+mod path_tests;
 #[cfg(test)]
 mod tests;

--- a/installer/src/deps.rs
+++ b/installer/src/deps.rs
@@ -9,8 +9,10 @@ use crate::dependency_binaries::{
 };
 use crate::dirs::{BaseDirs, SystemBaseDirs};
 use crate::error::{InstallerError, Result};
+use std::fs;
 use std::io;
 use std::io::Write;
+use std::path::Path;
 use std::process::{Command, Output};
 
 mod install;
@@ -163,11 +165,51 @@ pub fn install_dylint_tools_with_options(
 }
 
 fn is_tool_installed(executor: &dyn CommandExecutor, tool: &DependencyTool) -> bool {
+    if tool == &DYLINT_LINK_TOOL {
+        return is_binary_on_path(tool.command);
+    }
     command_succeeds(executor, tool.command, tool.args)
 }
 
 fn is_binstall_available(executor: &dyn CommandExecutor) -> bool {
     command_succeeds(executor, "cargo", &["binstall", "--version"])
+}
+
+fn is_binary_on_path(binary_name: &str) -> bool {
+    let Some(path_var) = std::env::var_os("PATH") else {
+        return false;
+    };
+
+    std::env::split_paths(&path_var).any(|directory| {
+        let direct = directory.join(binary_name);
+        if is_executable_file(&direct) {
+            return true;
+        }
+
+        #[cfg(windows)]
+        {
+            let windows_executable = directory.join(format!("{binary_name}.exe"));
+            if is_executable_file(&windows_executable) {
+                return true;
+            }
+        }
+
+        false
+    })
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
 }
 
 #[cfg(test)]

--- a/installer/src/deps.rs
+++ b/installer/src/deps.rs
@@ -180,21 +180,50 @@ fn is_binary_on_path(binary_name: &str) -> bool {
     };
 
     std::env::split_paths(&path_var).any(|directory| {
-        let direct = directory.join(binary_name);
-        if is_executable_file(&direct) {
-            return true;
-        }
-
-        #[cfg(windows)]
-        {
-            let windows_executable = directory.join(format!("{binary_name}.exe"));
-            if is_executable_file(&windows_executable) {
-                return true;
-            }
-        }
-
-        false
+        binary_candidates(&directory, binary_name)
+            .into_iter()
+            .any(|candidate| is_executable_file(&candidate))
     })
+}
+
+fn binary_candidates(directory: &Path, binary_name: &str) -> Vec<std::path::PathBuf> {
+    #[cfg(windows)]
+    let mut candidates = vec![directory.join(binary_name)];
+    #[cfg(not(windows))]
+    let candidates = vec![directory.join(binary_name)];
+    #[cfg(windows)]
+    {
+        let lowercase_name = binary_name.to_ascii_lowercase();
+        candidates.extend(
+            windows_path_extensions()
+                .into_iter()
+                .filter(|extension| !lowercase_name.ends_with(&extension.to_ascii_lowercase()))
+                .map(|extension| directory.join(format!("{binary_name}{extension}"))),
+        );
+    }
+    candidates
+}
+
+#[cfg(windows)]
+fn windows_path_extensions() -> Vec<String> {
+    let path_ext = std::env::var_os("PATHEXT")
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| std::ffi::OsString::from(".COM;.EXE;.BAT;.CMD"));
+
+    path_ext
+        .to_string_lossy()
+        .split(';')
+        .filter_map(|extension| {
+            let trimmed = extension.trim();
+            if trimmed.is_empty() {
+                None
+            } else if trimmed.starts_with('.') {
+                Some(trimmed.to_owned())
+            } else {
+                Some(format!(".{trimmed}"))
+            }
+        })
+        .collect()
 }
 
 #[cfg(unix)]

--- a/installer/src/deps.rs
+++ b/installer/src/deps.rs
@@ -165,7 +165,12 @@ pub fn install_dylint_tools_with_options(
 
 fn is_tool_installed(executor: &dyn CommandExecutor, tool: &DependencyTool) -> bool {
     if tool == &DYLINT_LINK_TOOL {
-        return is_binary_on_path(tool.command);
+        if !is_binary_on_path(tool.command) {
+            return false;
+        }
+
+        return find_binary_on_path(tool.command)
+            .is_some_and(|binary_path| dylint_link_probe_succeeds(&binary_path));
     }
     command_succeeds(executor, tool.command, tool.args)
 }
@@ -175,15 +180,45 @@ fn is_binstall_available(executor: &dyn CommandExecutor) -> bool {
 }
 
 fn is_binary_on_path(binary_name: &str) -> bool {
-    let Some(path_var) = std::env::var_os("PATH") else {
-        return false;
-    };
+    find_binary_on_path(binary_name).is_some()
+}
 
-    std::env::split_paths(&path_var).any(|directory| {
-        binary_candidates(&directory, binary_name)
-            .into_iter()
-            .any(|candidate| is_executable_file(&candidate))
-    })
+fn find_binary_on_path(binary_name: &str) -> Option<std::path::PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+
+    std::env::split_paths(&path_var)
+        .find_map(|directory| find_binary_in_directory(&directory, binary_name))
+}
+
+fn find_binary_in_directory(directory: &Path, binary_name: &str) -> Option<std::path::PathBuf> {
+    binary_candidates(directory, binary_name)
+        .into_iter()
+        .find(|candidate| is_executable_file(candidate))
+}
+
+fn dylint_link_probe_succeeds(binary_path: &Path) -> bool {
+    let mut command = Command::new(binary_path);
+    command.arg("--help");
+
+    if let Some(toolchain) = dylint_link_probe_toolchain() {
+        command.env("RUSTUP_TOOLCHAIN", toolchain);
+    }
+
+    command.output().is_ok_and(|output| output.status.success())
+}
+
+fn dylint_link_probe_toolchain() -> Option<String> {
+    std::env::var("RUSTUP_TOOLCHAIN")
+        .ok()
+        .filter(|toolchain| !toolchain.trim().is_empty())
+        .or_else(|| {
+            host_target().map(|target| {
+                // `dylint-link` reads `RUSTUP_TOOLCHAIN` before it inspects CLI
+                // arguments, so the probe synthesizes a stable host toolchain
+                // when the caller did not provide one.
+                format!("stable-{}", target.as_str())
+            })
+        })
 }
 
 fn binary_candidates(directory: &Path, binary_name: &str) -> Vec<std::path::PathBuf> {

--- a/installer/src/deps/install_tests.rs
+++ b/installer/src/deps/install_tests.rs
@@ -1,14 +1,28 @@
 //! Tests for dependency-install status refresh behaviour.
 
 use super::*;
+use crate::test_support::env_test_guard;
 use rstest::rstest;
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
-fn dylint_link_probe_executor() -> crate::test_utils::StubExecutor {
-    crate::test_utils::StubExecutor::new(vec![crate::test_utils::ExpectedCall {
-        cmd: "dylint-link",
-        args: vec!["--version"],
-        result: Ok(crate::test_utils::success_output()),
-    }])
+fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -> T {
+    let _guard = env_test_guard();
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let binary_path = temp_dir.path().join(binary_name);
+    fs::write(&binary_path, []).expect("write fake binary");
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&binary_path)
+            .expect("read fake binary metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&binary_path, permissions).expect("mark fake binary executable");
+    }
+
+    let path = temp_dir.path().display().to_string();
+    temp_env::with_var("PATH", Some(path), run)
 }
 
 #[rstest]
@@ -17,17 +31,19 @@ fn dylint_link_probe_executor() -> crate::test_utils::StubExecutor {
 fn update_status_after_install_refreshes_link_for_local_cargo_dylint_installs(
     #[case] outcome: InstallOutcome,
 ) {
-    let executor = dylint_link_probe_executor();
-    let mut status = DylintToolStatus {
-        cargo_dylint: false,
-        dylint_link: false,
-    };
+    with_fake_binary_on_path("dylint-link", || {
+        let executor = crate::test_utils::StubExecutor::new(vec![]);
+        let mut status = DylintToolStatus {
+            cargo_dylint: false,
+            dylint_link: false,
+        };
 
-    update_status_after_install(&mut status, &executor, &CARGO_DYLINT_TOOL, outcome);
+        update_status_after_install(&mut status, &executor, &CARGO_DYLINT_TOOL, outcome);
 
-    assert!(status.cargo_dylint);
-    assert!(status.dylint_link);
-    executor.assert_finished();
+        assert!(status.cargo_dylint);
+        assert!(status.dylint_link);
+        executor.assert_finished();
+    });
 }
 
 #[test]

--- a/installer/src/deps/install_tests.rs
+++ b/installer/src/deps/install_tests.rs
@@ -1,29 +1,8 @@
 //! Tests for dependency-install status refresh behaviour.
 
 use super::*;
-use crate::test_support::env_test_guard;
+use crate::test_utils::dependency_binary_helpers::with_fake_binary_on_path;
 use rstest::rstest;
-use std::fs;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-
-fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -> T {
-    let _guard = env_test_guard();
-    let temp_dir = tempfile::tempdir().expect("create temp dir");
-    let binary_path = temp_dir.path().join(binary_name);
-    fs::write(&binary_path, []).expect("write fake binary");
-    #[cfg(unix)]
-    {
-        let mut permissions = fs::metadata(&binary_path)
-            .expect("read fake binary metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&binary_path, permissions).expect("mark fake binary executable");
-    }
-
-    let path = temp_dir.path().display().to_string();
-    temp_env::with_var("PATH", Some(path), run)
-}
 
 #[rstest]
 #[case(InstallOutcome::CargoBinstall)]

--- a/installer/src/deps/path_tests.rs
+++ b/installer/src/deps/path_tests.rs
@@ -1,0 +1,151 @@
+//! Tests for PATH-based dependency-binary discovery helpers.
+
+use super::*;
+use crate::test_support::env_test_guard;
+use crate::test_utils::dependency_binary_helpers::{
+    cargo_dylint_check_with_result, with_fake_binary_on_path, with_fake_path, write_fake_binary,
+    write_fake_binary_with_status,
+};
+use crate::test_utils::{StubExecutor, success_output};
+use temp_env::with_vars_unset;
+
+#[test]
+fn check_dylint_tools_reports_installed_tools() {
+    with_fake_binary_on_path("dylint-link", || {
+        let executor =
+            StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
+
+        let status = check_dylint_tools(&executor);
+
+        assert_eq!(
+            status,
+            DylintToolStatus {
+                cargo_dylint: true,
+                dylint_link: true,
+            }
+        );
+        executor.assert_finished();
+    });
+}
+
+#[test]
+fn check_dylint_tools_rejects_non_invocable_dylint_link_on_path() {
+    with_fake_path(
+        |directories| {
+            #[cfg(windows)]
+            let binary_path = directories[0].join("dylint-link.cmd");
+            #[cfg(not(windows))]
+            let binary_path = directories[0].join("dylint-link");
+
+            write_fake_binary_with_status(&binary_path, true, 1);
+        },
+        || {
+            let executor =
+                StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
+
+            let status = check_dylint_tools(&executor);
+
+            assert_eq!(
+                status,
+                DylintToolStatus {
+                    cargo_dylint: true,
+                    dylint_link: false,
+                }
+            );
+            executor.assert_finished();
+        },
+    );
+}
+
+#[test]
+fn is_binary_on_path_returns_false_when_path_is_unset() {
+    let _guard = env_test_guard();
+    with_vars_unset(["PATH"], || {
+        assert!(!is_binary_on_path("dylint-link"));
+    });
+}
+
+#[test]
+fn is_binary_on_path_returns_false_when_path_is_empty() {
+    let _guard = env_test_guard();
+    temp_env::with_var("PATH", Some(""), || {
+        assert!(!is_binary_on_path("dylint-link"));
+    });
+}
+
+#[test]
+fn is_binary_on_path_returns_false_when_binary_is_missing_from_all_directories() {
+    with_fake_path(
+        |_| {},
+        || {
+            assert!(!is_binary_on_path("dylint-link"));
+        },
+    );
+}
+
+#[test]
+fn is_binary_on_path_checks_multiple_directories() {
+    with_fake_path(
+        |directories| write_fake_binary(&directories[1].join("dylint-link"), true),
+        || {
+            assert!(is_binary_on_path("dylint-link"));
+        },
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn is_executable_file_rejects_non_executable_files() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let binary_path = temp_dir.path().join("dylint-link");
+    write_fake_binary(&binary_path, false);
+
+    assert!(!is_executable_file(&binary_path));
+}
+
+#[cfg(unix)]
+#[test]
+fn is_executable_file_accepts_executable_files() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let binary_path = temp_dir.path().join("dylint-link");
+    write_fake_binary(&binary_path, true);
+
+    assert!(is_executable_file(&binary_path));
+}
+
+#[cfg(windows)]
+#[test]
+fn is_binary_on_path_accepts_windows_executable_suffix() {
+    with_fake_path(
+        |directories| write_fake_binary(&directories[0].join("dylint-link.exe"), true),
+        || {
+            assert!(is_binary_on_path("dylint-link"));
+        },
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn check_dylint_tools_detects_dylint_link_via_pathext_suffix() {
+    let _guard = env_test_guard();
+    temp_env::with_var("PATHEXT", Some(".CMD;.BAT"), || {
+        with_fake_path(
+            |directories| write_fake_binary(&directories[0].join("dylint-link.cmd"), true),
+            || {
+                let executor =
+                    StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
+
+                let status = check_dylint_tools(&executor);
+
+                assert_eq!(
+                    status,
+                    DylintToolStatus {
+                        cargo_dylint: true,
+                        dylint_link: true,
+                    }
+                );
+                executor.assert_finished();
+            },
+        );
+    });
+}

--- a/installer/src/deps/tests.rs
+++ b/installer/src/deps/tests.rs
@@ -6,12 +6,11 @@ use crate::installer_packaging::TargetTriple;
 use crate::test_support::env_test_guard;
 use crate::test_utils::dependency_binary_helpers::{
     binstall_install, binstall_version_check_with_result, cargo_dylint_check_with_result,
+    with_fake_binary_on_path, with_fake_path, write_fake_binary,
 };
 use crate::test_utils::{ExpectedCall, StubDirs, StubExecutor, failure_output, success_output};
-use std::fs;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
+use temp_env::with_vars_unset;
 
 fn install_options<'a>(
     repository_installer: &'a dyn DependencyBinaryInstaller,
@@ -28,24 +27,6 @@ fn install_options<'a>(
         target: Some(target),
         quiet,
     }
-}
-
-fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -> T {
-    let _guard = env_test_guard();
-    let temp_dir = tempfile::tempdir().expect("create temp dir");
-    let binary_path = temp_dir.path().join(binary_name);
-    fs::write(&binary_path, []).expect("write fake binary");
-    #[cfg(unix)]
-    {
-        let mut permissions = fs::metadata(&binary_path)
-            .expect("read fake binary metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&binary_path, permissions).expect("mark fake binary executable");
-    }
-
-    let path = temp_dir.path().display().to_string();
-    temp_env::with_var("PATH", Some(path), run)
 }
 
 #[test]
@@ -75,6 +56,98 @@ fn check_dylint_tools_reports_installed_tools() {
             }
         );
         executor.assert_finished();
+    });
+}
+
+#[test]
+fn is_binary_on_path_returns_false_when_path_is_unset() {
+    with_vars_unset(["PATH"], || {
+        assert!(!is_binary_on_path("dylint-link"));
+    });
+}
+
+#[test]
+fn is_binary_on_path_returns_false_when_path_is_empty() {
+    let _guard = env_test_guard();
+    temp_env::with_var("PATH", Some(""), || {
+        assert!(!is_binary_on_path("dylint-link"));
+    });
+}
+
+#[test]
+fn is_binary_on_path_returns_false_when_binary_is_missing_from_all_directories() {
+    with_fake_path(
+        |_| {},
+        || {
+            assert!(!is_binary_on_path("dylint-link"));
+        },
+    );
+}
+
+#[test]
+fn is_binary_on_path_checks_multiple_directories() {
+    with_fake_path(
+        |directories| write_fake_binary(&directories[1].join("dylint-link"), true),
+        || {
+            assert!(is_binary_on_path("dylint-link"));
+        },
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn is_executable_file_rejects_non_executable_files() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let binary_path = temp_dir.path().join("dylint-link");
+    write_fake_binary(&binary_path, false);
+
+    assert!(!is_executable_file(&binary_path));
+}
+
+#[cfg(unix)]
+#[test]
+fn is_executable_file_accepts_executable_files() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let binary_path = temp_dir.path().join("dylint-link");
+    write_fake_binary(&binary_path, true);
+
+    assert!(is_executable_file(&binary_path));
+}
+
+#[cfg(windows)]
+#[test]
+fn is_binary_on_path_accepts_windows_executable_suffix() {
+    with_fake_path(
+        |directories| write_fake_binary(&directories[0].join("dylint-link.exe"), true),
+        || {
+            assert!(is_binary_on_path("dylint-link"));
+        },
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn check_dylint_tools_detects_dylint_link_via_pathext_suffix() {
+    let _guard = env_test_guard();
+    temp_env::with_var("PATHEXT", Some(".CMD;.BAT"), || {
+        with_fake_path(
+            |directories| write_fake_binary(&directories[0].join("dylint-link.cmd"), true),
+            || {
+                let executor =
+                    StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
+
+                let status = check_dylint_tools(&executor);
+
+                assert_eq!(
+                    status,
+                    DylintToolStatus {
+                        cargo_dylint: true,
+                        dylint_link: true,
+                    }
+                );
+                executor.assert_finished();
+            },
+        );
     });
 }
 

--- a/installer/src/deps/tests.rs
+++ b/installer/src/deps/tests.rs
@@ -6,7 +6,7 @@ use crate::installer_packaging::TargetTriple;
 use crate::test_support::env_test_guard;
 use crate::test_utils::dependency_binary_helpers::{
     binstall_install, binstall_version_check_with_result, cargo_dylint_check_with_result,
-    with_fake_binary_on_path, with_fake_path, write_fake_binary,
+    with_fake_binary_on_path, with_fake_path, write_fake_binary, write_fake_binary_with_status,
 };
 use crate::test_utils::{ExpectedCall, StubDirs, StubExecutor, failure_output, success_output};
 use std::path::PathBuf;
@@ -57,6 +57,35 @@ fn check_dylint_tools_reports_installed_tools() {
         );
         executor.assert_finished();
     });
+}
+
+#[test]
+fn check_dylint_tools_rejects_non_invocable_dylint_link_on_path() {
+    with_fake_path(
+        |directories| {
+            #[cfg(windows)]
+            let binary_path = directories[0].join("dylint-link.cmd");
+            #[cfg(not(windows))]
+            let binary_path = directories[0].join("dylint-link");
+
+            write_fake_binary_with_status(&binary_path, true, 1);
+        },
+        || {
+            let executor =
+                StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
+
+            let status = check_dylint_tools(&executor);
+
+            assert_eq!(
+                status,
+                DylintToolStatus {
+                    cargo_dylint: true,
+                    dylint_link: false,
+                }
+            );
+            executor.assert_finished();
+        },
+    );
 }
 
 #[test]

--- a/installer/src/deps/tests.rs
+++ b/installer/src/deps/tests.rs
@@ -3,11 +3,14 @@
 use super::*;
 use crate::dependency_binaries::{DependencyBinaryInstallError, MockDependencyBinaryInstaller};
 use crate::installer_packaging::TargetTriple;
+use crate::test_support::env_test_guard;
 use crate::test_utils::dependency_binary_helpers::{
     binstall_install, binstall_version_check_with_result, cargo_dylint_check_with_result,
-    dylint_link_check_with_result,
 };
 use crate::test_utils::{ExpectedCall, StubDirs, StubExecutor, failure_output, success_output};
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 fn install_options<'a>(
@@ -27,6 +30,24 @@ fn install_options<'a>(
     }
 }
 
+fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -> T {
+    let _guard = env_test_guard();
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let binary_path = temp_dir.path().join(binary_name);
+    fs::write(&binary_path, []).expect("write fake binary");
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&binary_path)
+            .expect("read fake binary metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&binary_path, permissions).expect("mark fake binary executable");
+    }
+
+    let path = temp_dir.path().display().to_string();
+    temp_env::with_var("PATH", Some(path), run)
+}
+
 #[test]
 fn dylint_tool_status_all_installed_when_both_present() {
     assert!(
@@ -40,21 +61,21 @@ fn dylint_tool_status_all_installed_when_both_present() {
 
 #[test]
 fn check_dylint_tools_reports_installed_tools() {
-    let executor = StubExecutor::new(vec![
-        cargo_dylint_check_with_result(Ok(success_output())),
-        dylint_link_check_with_result(Ok(success_output())),
-    ]);
+    with_fake_binary_on_path("dylint-link", || {
+        let executor =
+            StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
 
-    let status = check_dylint_tools(&executor);
+        let status = check_dylint_tools(&executor);
 
-    assert_eq!(
-        status,
-        DylintToolStatus {
-            cargo_dylint: true,
-            dylint_link: true,
-        }
-    );
-    executor.assert_finished();
+        assert_eq!(
+            status,
+            DylintToolStatus {
+                cargo_dylint: true,
+                dylint_link: true,
+            }
+        );
+        executor.assert_finished();
+    });
 }
 
 #[test]
@@ -275,20 +296,21 @@ fn install_dylint_tools_skips_dylint_link_when_cargo_dylint_source_build_install
             result: Ok(success_output()),
         },
         cargo_dylint_check_with_result(Ok(success_output())),
-        dylint_link_check_with_result(Ok(success_output())),
     ]);
     let mut stderr = Vec::new();
 
-    install_dylint_tools_with_options(
-        &executor,
-        &DylintToolStatus {
-            cargo_dylint: false,
-            dylint_link: false,
-        },
-        &mut stderr,
-        install_options(&repository_installer, false),
-    )
-    .expect("cargo-dylint source build should satisfy both tools");
+    with_fake_binary_on_path("dylint-link", || {
+        install_dylint_tools_with_options(
+            &executor,
+            &DylintToolStatus {
+                cargo_dylint: false,
+                dylint_link: false,
+            },
+            &mut stderr,
+            install_options(&repository_installer, false),
+        )
+        .expect("cargo-dylint source build should satisfy both tools");
+    });
 
     let output = String::from_utf8(stderr).expect("stderr should be UTF-8");
     assert!(output.contains("Installed cargo-dylint from source with cargo install."));

--- a/installer/src/deps/tests.rs
+++ b/installer/src/deps/tests.rs
@@ -3,14 +3,12 @@
 use super::*;
 use crate::dependency_binaries::{DependencyBinaryInstallError, MockDependencyBinaryInstaller};
 use crate::installer_packaging::TargetTriple;
-use crate::test_support::env_test_guard;
 use crate::test_utils::dependency_binary_helpers::{
     binstall_install, binstall_version_check_with_result, cargo_dylint_check_with_result,
-    with_fake_binary_on_path, with_fake_path, write_fake_binary, write_fake_binary_with_status,
+    with_fake_binary_on_path,
 };
 use crate::test_utils::{ExpectedCall, StubDirs, StubExecutor, failure_output, success_output};
 use std::path::PathBuf;
-use temp_env::with_vars_unset;
 
 fn install_options<'a>(
     repository_installer: &'a dyn DependencyBinaryInstaller,
@@ -38,146 +36,6 @@ fn dylint_tool_status_all_installed_when_both_present() {
         }
         .all_installed()
     );
-}
-
-#[test]
-fn check_dylint_tools_reports_installed_tools() {
-    with_fake_binary_on_path("dylint-link", || {
-        let executor =
-            StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
-
-        let status = check_dylint_tools(&executor);
-
-        assert_eq!(
-            status,
-            DylintToolStatus {
-                cargo_dylint: true,
-                dylint_link: true,
-            }
-        );
-        executor.assert_finished();
-    });
-}
-
-#[test]
-fn check_dylint_tools_rejects_non_invocable_dylint_link_on_path() {
-    with_fake_path(
-        |directories| {
-            #[cfg(windows)]
-            let binary_path = directories[0].join("dylint-link.cmd");
-            #[cfg(not(windows))]
-            let binary_path = directories[0].join("dylint-link");
-
-            write_fake_binary_with_status(&binary_path, true, 1);
-        },
-        || {
-            let executor =
-                StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
-
-            let status = check_dylint_tools(&executor);
-
-            assert_eq!(
-                status,
-                DylintToolStatus {
-                    cargo_dylint: true,
-                    dylint_link: false,
-                }
-            );
-            executor.assert_finished();
-        },
-    );
-}
-
-#[test]
-fn is_binary_on_path_returns_false_when_path_is_unset() {
-    with_vars_unset(["PATH"], || {
-        assert!(!is_binary_on_path("dylint-link"));
-    });
-}
-
-#[test]
-fn is_binary_on_path_returns_false_when_path_is_empty() {
-    let _guard = env_test_guard();
-    temp_env::with_var("PATH", Some(""), || {
-        assert!(!is_binary_on_path("dylint-link"));
-    });
-}
-
-#[test]
-fn is_binary_on_path_returns_false_when_binary_is_missing_from_all_directories() {
-    with_fake_path(
-        |_| {},
-        || {
-            assert!(!is_binary_on_path("dylint-link"));
-        },
-    );
-}
-
-#[test]
-fn is_binary_on_path_checks_multiple_directories() {
-    with_fake_path(
-        |directories| write_fake_binary(&directories[1].join("dylint-link"), true),
-        || {
-            assert!(is_binary_on_path("dylint-link"));
-        },
-    );
-}
-
-#[cfg(unix)]
-#[test]
-fn is_executable_file_rejects_non_executable_files() {
-    let temp_dir = tempfile::tempdir().expect("create temp dir");
-    let binary_path = temp_dir.path().join("dylint-link");
-    write_fake_binary(&binary_path, false);
-
-    assert!(!is_executable_file(&binary_path));
-}
-
-#[cfg(unix)]
-#[test]
-fn is_executable_file_accepts_executable_files() {
-    let temp_dir = tempfile::tempdir().expect("create temp dir");
-    let binary_path = temp_dir.path().join("dylint-link");
-    write_fake_binary(&binary_path, true);
-
-    assert!(is_executable_file(&binary_path));
-}
-
-#[cfg(windows)]
-#[test]
-fn is_binary_on_path_accepts_windows_executable_suffix() {
-    with_fake_path(
-        |directories| write_fake_binary(&directories[0].join("dylint-link.exe"), true),
-        || {
-            assert!(is_binary_on_path("dylint-link"));
-        },
-    );
-}
-
-#[cfg(windows)]
-#[test]
-fn check_dylint_tools_detects_dylint_link_via_pathext_suffix() {
-    let _guard = env_test_guard();
-    temp_env::with_var("PATHEXT", Some(".CMD;.BAT"), || {
-        with_fake_path(
-            |directories| write_fake_binary(&directories[0].join("dylint-link.cmd"), true),
-            || {
-                let executor =
-                    StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
-
-                let status = check_dylint_tools(&executor);
-
-                assert_eq!(
-                    status,
-                    DylintToolStatus {
-                        cargo_dylint: true,
-                        dylint_link: true,
-                    }
-                );
-                executor.assert_finished();
-            },
-        );
-    });
 }
 
 #[test]

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -20,6 +20,8 @@ use whitaker_installer::crate_name::CrateName;
 use whitaker_installer::deps::{
     CommandExecutor, SystemCommandExecutor, check_dylint_tools, install_dylint_tools_with_output,
 };
+#[cfg(test)]
+use whitaker_installer::deps::{DependencyInstallOptions, install_dylint_tools_with_options};
 use whitaker_installer::dirs::{BaseDirs, SystemBaseDirs};
 use whitaker_installer::error::{InstallerError, Result};
 use whitaker_installer::install_metrics::InstallMode;
@@ -66,26 +68,21 @@ fn run_install(args: &InstallArgs, stderr: &mut dyn Write) -> Result<()> {
     let dirs = SystemBaseDirs::new().ok_or_else(|| InstallerError::WorkspaceNotFound {
         reason: "could not determine platform directories".to_owned(),
     })?;
-
     if args.dry_run {
         return run_dry(args, &dirs, stderr);
     }
     let install_started = Instant::now();
-
     // Step 1: Check and install Dylint dependencies if needed
     if !args.skip_deps {
         ensure_dylint_tools(args.quiet, stderr)?;
     }
-
     // Step 2: Ensure workspace is available (clone if needed)
     let workspace_root = ensure_whitaker_workspace(args, &dirs, stderr)?;
-
     // Step 3: Resolve crates and toolchain
     let requested_crates = resolve_requested_crates(args)?;
     let toolchain = resolve_toolchain(&workspace_root, args.toolchain.as_deref())?;
     ensure_toolchain_installed(&toolchain, args.quiet, stderr)?;
     let target_dir = determine_target_dir(args.target_dir.as_deref())?;
-
     // Step 3.5: Attempt prebuilt download when install options allow it.
     let prebuilt_context = PrebuiltInstallationContext {
         args,
@@ -103,7 +100,6 @@ fn run_install(args: &InstallArgs, stderr: &mut dyn Write) -> Result<()> {
         };
         return finish_install_and_record_metrics(&finish_context, stderr);
     }
-
     if let Some(staging_path) = staged_suite::try_test_staged_suite_installation(
         &requested_crates,
         &toolchain,
@@ -118,7 +114,6 @@ fn run_install(args: &InstallArgs, stderr: &mut dyn Write) -> Result<()> {
         };
         return finish_install_and_record_metrics(&finish_context, stderr);
     }
-
     let context = PipelineContext {
         workspace_root: &workspace_root,
         toolchain: &toolchain,
@@ -128,11 +123,9 @@ fn run_install(args: &InstallArgs, stderr: &mut dyn Write) -> Result<()> {
         experimental: args.experimental,
         quiet: args.quiet,
     };
-
     // Step 4: Build and stage
     let build_results = perform_build(&context, &requested_crates, stderr)?;
     let staging_path = stage_libraries(&context, &build_results, stderr)?;
-
     // Step 5: Generate wrapper scripts if requested
     let finish_context = FinishInstallContext {
         args,
@@ -153,7 +146,6 @@ fn run_dry(args: &InstallArgs, dirs: &dyn BaseDirs, stderr: &mut dyn Write) -> R
     let toolchain = resolve_toolchain(&workspace_root, args.toolchain.as_deref())?;
     toolchain.verify_installed()?;
     let target_dir = determine_dry_run_target_dir(args, dirs, &toolchain, &requested_crates)?;
-
     let info = DryRunInfo {
         workspace_root: &workspace_root,
         toolchain: toolchain.channel(),
@@ -180,7 +172,6 @@ fn determine_dry_run_target_dir(
     if !args.should_attempt_prebuilt(requested_crates) {
         return Ok(build_target_dir);
     }
-
     let Ok(host_target) = detect_host_target() else {
         return Ok(build_target_dir);
     };
@@ -198,24 +189,42 @@ fn ensure_dylint_tools_with_executor(
     quiet: bool,
     stderr: &mut dyn Write,
 ) -> Result<()> {
-    let status = check_dylint_tools(executor);
+    ensure_dylint_tools_with_install(executor, quiet, stderr, |status, stderr| {
+        install_dylint_tools_with_output(executor, status, quiet, stderr)
+    })
+}
 
+fn ensure_dylint_tools_with_install(
+    executor: &dyn CommandExecutor,
+    quiet: bool,
+    stderr: &mut dyn Write,
+    install: impl FnOnce(&whitaker_installer::deps::DylintToolStatus, &mut dyn Write) -> Result<()>,
+) -> Result<()> {
+    let status = check_dylint_tools(executor);
     if status.all_installed() {
         return Ok(());
     }
-
     if !quiet {
         write_stderr_line(stderr, "Installing required Dylint tools...");
     }
-
-    install_dylint_tools_with_output(executor, &status, quiet, stderr)?;
-
+    install(&status, stderr)?;
     if !quiet {
         write_stderr_line(stderr, "Dylint tools installed successfully.");
         write_stderr_line(stderr, "");
     }
-
     Ok(())
+}
+
+#[cfg(test)]
+fn ensure_dylint_tools_with_executor_and_options(
+    executor: &dyn CommandExecutor,
+    quiet: bool,
+    stderr: &mut dyn Write,
+    options: DependencyInstallOptions<'_>,
+) -> Result<()> {
+    ensure_dylint_tools_with_install(executor, quiet, stderr, |status, stderr| {
+        install_dylint_tools_with_options(executor, status, stderr, options)
+    })
 }
 
 /// Ensures a Whitaker workspace is available.

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -20,8 +20,6 @@ use whitaker_installer::crate_name::CrateName;
 use whitaker_installer::deps::{
     CommandExecutor, SystemCommandExecutor, check_dylint_tools, install_dylint_tools_with_output,
 };
-#[cfg(test)]
-use whitaker_installer::deps::{DependencyInstallOptions, install_dylint_tools_with_options};
 use whitaker_installer::dirs::{BaseDirs, SystemBaseDirs};
 use whitaker_installer::error::{InstallerError, Result};
 use whitaker_installer::install_metrics::InstallMode;
@@ -181,16 +179,8 @@ fn determine_dry_run_target_dir(
 /// Checks for and installs Dylint tools if missing.
 fn ensure_dylint_tools(quiet: bool, stderr: &mut dyn Write) -> Result<()> {
     let executor = SystemCommandExecutor;
-    ensure_dylint_tools_with_executor(&executor, quiet, stderr)
-}
-
-fn ensure_dylint_tools_with_executor(
-    executor: &dyn CommandExecutor,
-    quiet: bool,
-    stderr: &mut dyn Write,
-) -> Result<()> {
-    ensure_dylint_tools_with_install(executor, quiet, stderr, |status, stderr| {
-        install_dylint_tools_with_output(executor, status, quiet, stderr)
+    ensure_dylint_tools_with_install(&executor, quiet, stderr, |status, stderr| {
+        install_dylint_tools_with_output(&executor, status, quiet, stderr)
     })
 }
 
@@ -213,18 +203,6 @@ fn ensure_dylint_tools_with_install(
         write_stderr_line(stderr, "");
     }
     Ok(())
-}
-
-#[cfg(test)]
-fn ensure_dylint_tools_with_executor_and_options(
-    executor: &dyn CommandExecutor,
-    quiet: bool,
-    stderr: &mut dyn Write,
-    options: DependencyInstallOptions<'_>,
-) -> Result<()> {
-    ensure_dylint_tools_with_install(executor, quiet, stderr, |status, stderr| {
-        install_dylint_tools_with_options(executor, status, stderr, options)
-    })
 }
 
 /// Ensures a Whitaker workspace is available.

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -18,7 +18,8 @@ use std::time::Instant;
 use whitaker_installer::cli::{Cli, Command, InstallArgs};
 use whitaker_installer::crate_name::CrateName;
 use whitaker_installer::deps::{
-    CommandExecutor, SystemCommandExecutor, check_dylint_tools, install_dylint_tools_with_output,
+    CommandExecutor, DylintToolStatus, SystemCommandExecutor, check_dylint_tools,
+    install_dylint_tools_with_output,
 };
 use whitaker_installer::dirs::{BaseDirs, SystemBaseDirs};
 use whitaker_installer::error::{InstallerError, Result};
@@ -188,7 +189,7 @@ fn ensure_dylint_tools_with_install(
     executor: &dyn CommandExecutor,
     quiet: bool,
     stderr: &mut dyn Write,
-    install: impl FnOnce(&whitaker_installer::deps::DylintToolStatus, &mut dyn Write) -> Result<()>,
+    install: impl FnOnce(&DylintToolStatus, &mut dyn Write) -> Result<()>,
 ) -> Result<()> {
     let status = check_dylint_tools(executor);
     if status.all_installed() {

--- a/installer/src/test_utils.rs
+++ b/installer/src/test_utils.rs
@@ -289,3 +289,5 @@ impl CommandExecutor for StubExecutor {
 /// Test helpers for dependency binary installation behaviour tests.
 #[cfg(any(test, feature = "test-support"))]
 pub mod dependency_binary_helpers;
+#[cfg(test)]
+mod dependency_binary_helpers_tests;

--- a/installer/src/test_utils/dependency_binary_helpers.rs
+++ b/installer/src/test_utils/dependency_binary_helpers.rs
@@ -84,32 +84,28 @@ fn dependency_version(tool: &str) -> &'static str {
 }
 
 /// Creates an expected call for verifying repository installation.
-pub fn repository_verification_call(tool: &str, verification_fails: bool) -> ExpectedCall {
+pub fn repository_verification_call(tool: &str, verification_fails: bool) -> Option<ExpectedCall> {
     let result = if verification_fails {
         Ok(failure_output("still missing"))
     } else {
         Ok(success_output())
     };
     match tool {
-        "cargo-dylint" => ExpectedCall {
+        "cargo-dylint" => Some(ExpectedCall {
             cmd: "cargo",
             args: vec!["dylint", "--version"],
             result,
-        },
-        "dylint-link" => ExpectedCall {
-            cmd: "dylint-link",
-            args: vec!["--version"],
-            result,
-        },
+        }),
+        "dylint-link" => None,
         other => panic!("unexpected tool: {other}"),
     }
 }
 
 /// Returns the expected verification call for a given tool.
-fn tool_verification_check(tool: &str) -> ExpectedCall {
+fn tool_verification_check(tool: &str) -> Option<ExpectedCall> {
     match tool {
-        "cargo-dylint" => cargo_dylint_check(),
-        "dylint-link" => dylint_link_check(),
+        "cargo-dylint" => Some(cargo_dylint_check()),
+        "dylint-link" => None,
         other => panic!("unexpected tool: {other}"),
     }
 }
@@ -145,7 +141,7 @@ fn repo_aware_cargo_install(
 /// Builds the sequence of calls that follow the primary install attempt.
 fn post_primary_calls(cfg: &PostPrimaryConfig) -> Vec<ExpectedCall> {
     if cfg.primary_succeeded {
-        return vec![tool_verification_check(&cfg.tool)];
+        return tool_verification_check(&cfg.tool).into_iter().collect();
     }
     if !cfg.use_binstall {
         return vec![];
@@ -158,7 +154,9 @@ fn post_primary_calls(cfg: &PostPrimaryConfig) -> Vec<ExpectedCall> {
             cfg.has_repository_context,
             Ok(success_output()),
         );
-        return vec![cargo_call, tool_verification_check(&cfg.tool)];
+        let mut calls = vec![cargo_call];
+        calls.extend(tool_verification_check(&cfg.tool));
+        return calls;
     }
     // binstall failed and cargo install also fails
     if let Some(message) = cfg.cargo_install_failure.as_deref() {
@@ -185,7 +183,9 @@ fn source_install_fallback_calls(
     );
     let install_call = cargo_source_install(tool_static, version, result);
     if config.cargo_install_failure.is_none() {
-        vec![install_call, tool_verification_check(tool)]
+        let mut calls = vec![install_call];
+        calls.extend(tool_verification_check(tool));
+        calls
     } else {
         vec![install_call]
     }
@@ -253,7 +253,7 @@ pub fn expected_calls(tool: &str, config: ExpectedCallConfig<'_>) -> Vec<Expecte
     let mut calls = vec![binstall_version_check(config.is_binstall_available)];
 
     if config.should_verify_repository_install {
-        calls.push(repository_verification_call(
+        calls.extend(repository_verification_call(
             tool,
             config.is_repository_verification_failing,
         ));
@@ -280,24 +280,6 @@ pub fn cargo_dylint_check_with_result(result: Result<Output>) -> ExpectedCall {
     ExpectedCall {
         cmd: "cargo",
         args: vec!["dylint", "--version"],
-        result,
-    }
-}
-
-/// Creates an expected call for verifying dylint-link installation.
-pub fn dylint_link_check() -> ExpectedCall {
-    ExpectedCall {
-        cmd: "dylint-link",
-        args: vec!["--version"],
-        result: Ok(success_output()),
-    }
-}
-
-/// Creates an expected call for verifying dylint-link with a fixed result.
-pub fn dylint_link_check_with_result(result: Result<Output>) -> ExpectedCall {
-    ExpectedCall {
-        cmd: "dylint-link",
-        args: vec!["--version"],
         result,
     }
 }

--- a/installer/src/test_utils/dependency_binary_helpers.rs
+++ b/installer/src/test_utils/dependency_binary_helpers.rs
@@ -1,9 +1,92 @@
 //! Test helpers for dependency binary installation tests.
 
 use crate::dependency_binaries::find_dependency_binary;
+#[cfg(any(test, feature = "test-support"))]
+use crate::dependency_binaries::{
+    DependencyBinary, DependencyBinaryInstallError, DependencyBinaryInstaller,
+};
+#[cfg(any(test, feature = "test-support"))]
+use crate::dirs::BaseDirs;
 use crate::error::Result;
+#[cfg(any(test, feature = "test-support"))]
+use crate::installer_packaging::TargetTriple;
+#[cfg(any(test, feature = "test-support"))]
+use crate::test_support::env_test_guard;
 use crate::test_utils::{ExpectedCall, failure_output, success_output};
+#[cfg(any(test, feature = "test-support"))]
+use std::fs;
+#[cfg(all(any(test, feature = "test-support"), unix))]
+use std::os::unix::fs::PermissionsExt;
+#[cfg(any(test, feature = "test-support"))]
+use std::path::{Path, PathBuf};
 use std::process::Output;
+
+/// Repository installer test double that always reports a missing archive.
+#[cfg(any(test, feature = "test-support"))]
+pub struct AlwaysNotFoundRepositoryInstaller;
+
+#[cfg(any(test, feature = "test-support"))]
+impl DependencyBinaryInstaller for AlwaysNotFoundRepositoryInstaller {
+    fn install(
+        &self,
+        dependency: &DependencyBinary,
+        target: &TargetTriple,
+        _dirs: &dyn BaseDirs,
+    ) -> std::result::Result<PathBuf, DependencyBinaryInstallError> {
+        Err(DependencyBinaryInstallError::NotFound {
+            url: format!(
+                "https://example.test/{}-{}-v{}.tgz",
+                dependency.package(),
+                target,
+                dependency.version()
+            ),
+        })
+    }
+}
+
+/// Writes an empty fake binary at `path`.
+#[cfg(any(test, feature = "test-support"))]
+pub fn write_fake_binary(path: &Path, is_executable: bool) {
+    fs::write(path, []).expect("write fake binary");
+    #[cfg(unix)]
+    {
+        let mode = if is_executable { 0o755 } else { 0o644 };
+        let mut permissions = fs::metadata(path)
+            .expect("read fake binary metadata")
+            .permissions();
+        permissions.set_mode(mode);
+        fs::set_permissions(path, permissions).expect("set fake binary permissions");
+    }
+    #[cfg(not(unix))]
+    let _ = is_executable;
+}
+
+/// Runs a closure with `PATH` pointing at one or more fake directories.
+#[cfg(any(test, feature = "test-support"))]
+pub fn with_fake_path<T>(setup: impl FnOnce(&[PathBuf]), run: impl FnOnce() -> T) -> T {
+    let _guard = env_test_guard();
+    let temp_dirs = [
+        tempfile::tempdir().expect("create temp dir"),
+        tempfile::tempdir().expect("create temp dir"),
+    ];
+    let path_dirs = temp_dirs
+        .iter()
+        .map(|dir| dir.path().to_path_buf())
+        .collect::<Vec<_>>();
+    setup(&path_dirs);
+    let path = std::env::join_paths(path_dirs.iter().map(PathBuf::as_path))
+        .expect("join fake PATH directories");
+    temp_env::with_var("PATH", Some(path), run)
+}
+
+/// Runs a closure with `PATH` containing a fake executable in the first entry.
+#[cfg(any(test, feature = "test-support"))]
+pub fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -> T {
+    with_fake_path(
+        |directories| write_fake_binary(&directories[0].join(binary_name), true),
+        run,
+    )
+}
 
 /// Configuration for generating expected calls in dependency binary tests.
 pub struct ExpectedCallConfig<'a> {

--- a/installer/src/test_utils/dependency_binary_helpers.rs
+++ b/installer/src/test_utils/dependency_binary_helpers.rs
@@ -44,10 +44,16 @@ impl DependencyBinaryInstaller for AlwaysNotFoundRepositoryInstaller {
     }
 }
 
-/// Writes an empty fake binary at `path`.
+/// Writes a fake binary at `path` that exits successfully.
 #[cfg(any(test, feature = "test-support"))]
 pub fn write_fake_binary(path: &Path, is_executable: bool) {
-    fs::write(path, []).expect("write fake binary");
+    write_fake_binary_with_status(path, is_executable, 0);
+}
+
+/// Writes a fake binary at `path` that exits with the supplied status code.
+#[cfg(any(test, feature = "test-support"))]
+pub fn write_fake_binary_with_status(path: &Path, is_executable: bool, exit_code: i32) {
+    fs::write(path, fake_binary_contents(exit_code)).expect("write fake binary");
     #[cfg(unix)]
     {
         let mode = if is_executable { 0o755 } else { 0o644 };
@@ -59,6 +65,18 @@ pub fn write_fake_binary(path: &Path, is_executable: bool) {
     }
     #[cfg(not(unix))]
     let _ = is_executable;
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn fake_binary_contents(exit_code: i32) -> Vec<u8> {
+    #[cfg(windows)]
+    {
+        format!("@echo off\r\nexit /b {exit_code}\r\n").into_bytes()
+    }
+    #[cfg(not(windows))]
+    {
+        format!("#!/bin/sh\nexit {exit_code}\n").into_bytes()
+    }
 }
 
 /// Runs a closure with `PATH` pointing at one or more fake directories.
@@ -83,9 +101,21 @@ pub fn with_fake_path<T>(setup: impl FnOnce(&[PathBuf]), run: impl FnOnce() -> T
 #[cfg(any(test, feature = "test-support"))]
 pub fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -> T {
     with_fake_path(
-        |directories| write_fake_binary(&directories[0].join(binary_name), true),
+        |directories| write_fake_binary(&path_binary_location(&directories[0], binary_name), true),
         run,
     )
+}
+
+#[cfg(any(test, feature = "test-support"))]
+fn path_binary_location(directory: &Path, binary_name: &str) -> PathBuf {
+    #[cfg(windows)]
+    {
+        directory.join(format!("{binary_name}.cmd"))
+    }
+    #[cfg(not(windows))]
+    {
+        directory.join(binary_name)
+    }
 }
 
 /// Configuration for generating expected calls in dependency binary tests.

--- a/installer/src/test_utils/dependency_binary_helpers_tests.rs
+++ b/installer/src/test_utils/dependency_binary_helpers_tests.rs
@@ -1,0 +1,64 @@
+//! Tests for dependency binary helper fixtures and expected call builders.
+
+use crate::test_utils::dependency_binary_helpers::{
+    ExpectedCallConfig, expected_calls, repository_verification_call,
+};
+
+#[test]
+fn repository_verification_call_returns_probe_for_cargo_dylint() {
+    let call = repository_verification_call("cargo-dylint", false);
+    let call = match call {
+        Some(call) => call,
+        None => panic!("cargo-dylint should use a verification probe"),
+    };
+
+    assert_eq!(call.cmd, "cargo");
+    assert_eq!(call.args, vec!["dylint", "--version"]);
+    assert!(call.result.is_ok());
+}
+
+#[test]
+fn repository_verification_call_skips_dylint_link_version_probe() {
+    assert!(repository_verification_call("dylint-link", false).is_none());
+    assert!(repository_verification_call("dylint-link", true).is_none());
+}
+
+#[test]
+fn expected_calls_include_repository_probe_for_cargo_dylint() {
+    let calls = expected_calls(
+        "cargo-dylint",
+        ExpectedCallConfig {
+            is_binstall_available: false,
+            has_repository_context: true,
+            is_repository_asset_missing: false,
+            should_verify_repository_install: true,
+            is_repository_verification_failing: false,
+            cargo_binstall_failure: None,
+            cargo_install_failure: None,
+        },
+    );
+
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[1].cmd, "cargo");
+    assert_eq!(calls[1].args, vec!["dylint", "--version"]);
+}
+
+#[test]
+fn expected_calls_skip_repository_probe_for_dylint_link() {
+    let calls = expected_calls(
+        "dylint-link",
+        ExpectedCallConfig {
+            is_binstall_available: false,
+            has_repository_context: true,
+            is_repository_asset_missing: false,
+            should_verify_repository_install: true,
+            is_repository_verification_failing: false,
+            cargo_binstall_failure: None,
+            cargo_install_failure: None,
+        },
+    );
+
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].cmd, "cargo");
+    assert_eq!(calls[0].args, vec!["binstall", "--version"]);
+}

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -11,7 +11,7 @@ use whitaker_installer::cli::InstallArgs;
 use whitaker_installer::dependency_binaries::{
     DependencyBinaryInstallError, DependencyBinaryInstaller,
 };
-use whitaker_installer::deps::DependencyInstallOptions;
+use whitaker_installer::deps::{DependencyInstallOptions, install_dylint_tools_with_options};
 use whitaker_installer::dirs::BaseDirs;
 use whitaker_installer::installer_packaging::TargetTriple;
 use whitaker_installer::test_support::env_test_guard;
@@ -153,12 +153,11 @@ fn ensure_dylint_tools_skips_install_when_installed() {
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
 
         let mut stderr = Vec::new();
-        let result = ensure_dylint_tools_with_executor_and_options(
-            &executor,
-            false,
-            &mut stderr,
-            dependency_install_options(&repository_installer, false),
-        );
+        let options = dependency_install_options(&repository_installer, false);
+        let result =
+            ensure_dylint_tools_with_install(&executor, false, &mut stderr, |status, stderr| {
+                install_dylint_tools_with_options(&executor, status, stderr, options)
+            });
 
         assert!(result.is_ok());
         assert!(stderr.is_empty());
@@ -204,12 +203,11 @@ fn ensure_dylint_tools_installs_missing_tools(
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
 
         let mut stderr = Vec::new();
-        let result = ensure_dylint_tools_with_executor_and_options(
-            &executor,
-            quiet,
-            &mut stderr,
-            dependency_install_options(&repository_installer, quiet),
-        );
+        let options = dependency_install_options(&repository_installer, quiet);
+        let result =
+            ensure_dylint_tools_with_install(&executor, quiet, &mut stderr, |status, stderr| {
+                install_dylint_tools_with_options(&executor, status, stderr, options)
+            });
 
         assert!(result.is_ok());
         let stderr_text = String::from_utf8(stderr).expect("stderr was not UTF-8");
@@ -255,13 +253,12 @@ fn ensure_dylint_tools_propagates_install_failures() {
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
 
         let mut stderr = Vec::new();
-        let err = ensure_dylint_tools_with_executor_and_options(
-            &executor,
-            false,
-            &mut stderr,
-            dependency_install_options(&repository_installer, false),
-        )
-        .expect_err("expected install failure");
+        let options = dependency_install_options(&repository_installer, false);
+        let err =
+            ensure_dylint_tools_with_install(&executor, false, &mut stderr, |status, stderr| {
+                install_dylint_tools_with_options(&executor, status, stderr, options)
+            })
+            .expect_err("expected install failure");
 
         assert!(matches!(
             err,

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -2,58 +2,17 @@
 
 use super::*;
 use rstest::rstest;
-use std::fs;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::time::Duration;
 use whitaker_installer::cli::InstallArgs;
-use whitaker_installer::dependency_binaries::{
-    DependencyBinaryInstallError, DependencyBinaryInstaller,
-};
+use whitaker_installer::dependency_binaries::DependencyBinaryInstaller;
 use whitaker_installer::deps::{DependencyInstallOptions, install_dylint_tools_with_options};
 use whitaker_installer::dirs::BaseDirs;
 use whitaker_installer::installer_packaging::TargetTriple;
-use whitaker_installer::test_support::env_test_guard;
+use whitaker_installer::test_utils::dependency_binary_helpers::{
+    AlwaysNotFoundRepositoryInstaller, with_fake_binary_on_path,
+};
 use whitaker_installer::test_utils::*;
-
-struct AlwaysNotFoundRepositoryInstaller;
-
-impl DependencyBinaryInstaller for AlwaysNotFoundRepositoryInstaller {
-    fn install(
-        &self,
-        dependency: &whitaker_installer::dependency_binaries::DependencyBinary,
-        target: &TargetTriple,
-        _dirs: &dyn BaseDirs,
-    ) -> std::result::Result<PathBuf, DependencyBinaryInstallError> {
-        Err(DependencyBinaryInstallError::NotFound {
-            url: format!(
-                "https://example.test/{}-{}-v{}.tgz",
-                dependency.package(),
-                target,
-                dependency.version()
-            ),
-        })
-    }
-}
-
-fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -> T {
-    let _guard = env_test_guard();
-    let temp_dir = tempfile::tempdir().expect("create temp dir");
-    let binary_path = temp_dir.path().join(binary_name);
-    fs::write(&binary_path, []).expect("write fake binary");
-    #[cfg(unix)]
-    {
-        let mut permissions = fs::metadata(&binary_path)
-            .expect("read fake binary metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&binary_path, permissions).expect("mark fake binary executable");
-    }
-
-    let path = temp_dir.path().display().to_string();
-    temp_env::with_var("PATH", Some(path), run)
-}
 
 fn dependency_install_options<'a>(
     repository_installer: &'a dyn DependencyBinaryInstaller,

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -2,11 +2,75 @@
 
 use super::*;
 use rstest::rstest;
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::time::Duration;
 use whitaker_installer::cli::InstallArgs;
+use whitaker_installer::dependency_binaries::{
+    DependencyBinaryInstallError, DependencyBinaryInstaller,
+};
+use whitaker_installer::deps::DependencyInstallOptions;
 use whitaker_installer::dirs::BaseDirs;
+use whitaker_installer::installer_packaging::TargetTriple;
+use whitaker_installer::test_support::env_test_guard;
 use whitaker_installer::test_utils::*;
+
+struct AlwaysNotFoundRepositoryInstaller;
+
+impl DependencyBinaryInstaller for AlwaysNotFoundRepositoryInstaller {
+    fn install(
+        &self,
+        dependency: &whitaker_installer::dependency_binaries::DependencyBinary,
+        target: &TargetTriple,
+        _dirs: &dyn BaseDirs,
+    ) -> std::result::Result<PathBuf, DependencyBinaryInstallError> {
+        Err(DependencyBinaryInstallError::NotFound {
+            url: format!(
+                "https://example.test/{}-{}-v{}.tgz",
+                dependency.package(),
+                target,
+                dependency.version()
+            ),
+        })
+    }
+}
+
+fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -> T {
+    let _guard = env_test_guard();
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let binary_path = temp_dir.path().join(binary_name);
+    fs::write(&binary_path, []).expect("write fake binary");
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&binary_path)
+            .expect("read fake binary metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&binary_path, permissions).expect("mark fake binary executable");
+    }
+
+    let path = temp_dir.path().display().to_string();
+    temp_env::with_var("PATH", Some(path), run)
+}
+
+fn dependency_install_options<'a>(
+    repository_installer: &'a dyn DependencyBinaryInstaller,
+    quiet: bool,
+) -> DependencyInstallOptions<'a> {
+    let dirs = TestBaseDirs {
+        home_dir: Some(PathBuf::from("/tmp")),
+        bin_dir: Some(PathBuf::from("/tmp/bin")),
+        data_dir: Some(PathBuf::from("/tmp")),
+    };
+    DependencyInstallOptions {
+        dirs: Box::leak(Box::new(dirs)),
+        repository_installer,
+        target: Some(TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid target")),
+        quiet,
+    }
+}
 
 #[test]
 fn exit_code_for_run_result_returns_zero_on_success() {
@@ -80,25 +144,26 @@ fn resolve_requested_crates_rejects_unknown_lints() {
 
 #[test]
 fn ensure_dylint_tools_skips_install_when_installed() {
-    let executor = StubExecutor::new(vec![
-        ExpectedCall {
+    with_fake_binary_on_path("dylint-link", || {
+        let executor = StubExecutor::new(vec![ExpectedCall {
             cmd: "cargo",
             args: vec!["dylint", "--version"],
             result: Ok(success_output()),
-        },
-        ExpectedCall {
-            cmd: "dylint-link",
-            args: vec!["--version"],
-            result: Ok(success_output()),
-        },
-    ]);
+        }]);
+        let repository_installer = AlwaysNotFoundRepositoryInstaller;
 
-    let mut stderr = Vec::new();
-    let result = ensure_dylint_tools_with_executor(&executor, false, &mut stderr);
+        let mut stderr = Vec::new();
+        let result = ensure_dylint_tools_with_executor_and_options(
+            &executor,
+            false,
+            &mut stderr,
+            dependency_install_options(&repository_installer, false),
+        );
 
-    assert!(result.is_ok());
-    assert!(stderr.is_empty());
-    executor.assert_finished();
+        assert!(result.is_ok());
+        assert!(stderr.is_empty());
+        executor.assert_finished();
+    });
 }
 
 #[rstest]
@@ -113,98 +178,99 @@ fn ensure_dylint_tools_installs_missing_tools(
     #[case] expected_start: &str,
     #[case] expected_end: &str,
 ) {
-    let executor = StubExecutor::new(vec![
-        ExpectedCall {
-            cmd: "cargo",
-            args: vec!["dylint", "--version"],
-            result: Ok(failure_output("missing cargo-dylint")),
-        },
-        ExpectedCall {
-            cmd: "dylint-link",
-            args: vec!["--version"],
-            result: Ok(failure_output("missing dylint-link")),
-        },
-        ExpectedCall {
-            cmd: "cargo",
-            args: vec!["binstall", "--version"],
-            result: Ok(success_output()),
-        },
-        ExpectedCall {
-            cmd: "cargo",
-            args: vec!["install", "--locked", "--version", "4.1.0", "cargo-dylint"],
-            result: Ok(success_output()),
-        },
-        ExpectedCall {
-            cmd: "cargo",
-            args: vec!["dylint", "--version"],
-            result: Ok(success_output()),
-        },
-        ExpectedCall {
-            cmd: "dylint-link",
-            args: vec!["--version"],
-            result: Ok(success_output()),
-        },
-    ]);
+    with_fake_binary_on_path("dylint-link", || {
+        let executor = StubExecutor::new(vec![
+            ExpectedCall {
+                cmd: "cargo",
+                args: vec!["dylint", "--version"],
+                result: Ok(failure_output("missing cargo-dylint")),
+            },
+            ExpectedCall {
+                cmd: "cargo",
+                args: vec!["binstall", "--version"],
+                result: Ok(success_output()),
+            },
+            ExpectedCall {
+                cmd: "cargo",
+                args: vec!["install", "--locked", "--version", "4.1.0", "cargo-dylint"],
+                result: Ok(success_output()),
+            },
+            ExpectedCall {
+                cmd: "cargo",
+                args: vec!["dylint", "--version"],
+                result: Ok(success_output()),
+            },
+        ]);
+        let repository_installer = AlwaysNotFoundRepositoryInstaller;
 
-    let mut stderr = Vec::new();
-    let result = ensure_dylint_tools_with_executor(&executor, quiet, &mut stderr);
+        let mut stderr = Vec::new();
+        let result = ensure_dylint_tools_with_executor_and_options(
+            &executor,
+            quiet,
+            &mut stderr,
+            dependency_install_options(&repository_installer, quiet),
+        );
 
-    assert!(result.is_ok());
-    let stderr_text = String::from_utf8(stderr).expect("stderr was not UTF-8");
-    if quiet {
-        assert!(
-            stderr_text.is_empty(),
-            "expected stderr to be empty when quiet, got {stderr_text:?}"
-        );
-    } else {
-        assert!(
-            stderr_text.starts_with(expected_start),
-            "expected stderr to start with {expected_start:?}, got {stderr_text:?}"
-        );
-        assert!(
-            stderr_text.ends_with(expected_end),
-            "expected stderr to end with {expected_end:?}, got {stderr_text:?}"
-        );
-    }
-    executor.assert_finished();
+        assert!(result.is_ok());
+        let stderr_text = String::from_utf8(stderr).expect("stderr was not UTF-8");
+        if quiet {
+            assert!(
+                stderr_text.is_empty(),
+                "expected stderr to be empty when quiet, got {stderr_text:?}"
+            );
+        } else {
+            assert!(
+                stderr_text.starts_with(expected_start),
+                "expected stderr to start with {expected_start:?}, got {stderr_text:?}"
+            );
+            assert!(
+                stderr_text.ends_with(expected_end),
+                "expected stderr to end with {expected_end:?}, got {stderr_text:?}"
+            );
+        }
+        executor.assert_finished();
+    });
 }
 
 #[test]
 fn ensure_dylint_tools_propagates_install_failures() {
-    let executor = StubExecutor::new(vec![
-        ExpectedCall {
-            cmd: "cargo",
-            args: vec!["dylint", "--version"],
-            result: Ok(failure_output("missing cargo-dylint")),
-        },
-        ExpectedCall {
-            cmd: "dylint-link",
-            args: vec!["--version"],
-            result: Ok(success_output()),
-        },
-        ExpectedCall {
-            cmd: "cargo",
-            args: vec!["binstall", "--version"],
-            result: Ok(success_output()),
-        },
-        ExpectedCall {
-            cmd: "cargo",
-            args: vec!["install", "--locked", "--version", "4.1.0", "cargo-dylint"],
-            result: Ok(failure_output("cargo install failed")),
-        },
-    ]);
+    with_fake_binary_on_path("dylint-link", || {
+        let executor = StubExecutor::new(vec![
+            ExpectedCall {
+                cmd: "cargo",
+                args: vec!["dylint", "--version"],
+                result: Ok(failure_output("missing cargo-dylint")),
+            },
+            ExpectedCall {
+                cmd: "cargo",
+                args: vec!["binstall", "--version"],
+                result: Ok(success_output()),
+            },
+            ExpectedCall {
+                cmd: "cargo",
+                args: vec!["install", "--locked", "--version", "4.1.0", "cargo-dylint"],
+                result: Ok(failure_output("cargo install failed")),
+            },
+        ]);
+        let repository_installer = AlwaysNotFoundRepositoryInstaller;
 
-    let mut stderr = Vec::new();
-    let err = ensure_dylint_tools_with_executor(&executor, false, &mut stderr)
+        let mut stderr = Vec::new();
+        let err = ensure_dylint_tools_with_executor_and_options(
+            &executor,
+            false,
+            &mut stderr,
+            dependency_install_options(&repository_installer, false),
+        )
         .expect_err("expected install failure");
 
-    assert!(matches!(
-        err,
-        InstallerError::DependencyInstall { tool, message }
-            if tool == "cargo-dylint"
-                && message == "cargo install failed"
-    ));
-    executor.assert_finished();
+        assert!(matches!(
+            err,
+            InstallerError::DependencyInstall { tool, message }
+                if tool == "cargo-dylint"
+                    && message == "cargo install failed"
+        ));
+        executor.assert_finished();
+    });
 }
 
 #[derive(Debug, Clone)]

--- a/installer/tests/behaviour_dependency_binaries.rs
+++ b/installer/tests/behaviour_dependency_binaries.rs
@@ -143,12 +143,7 @@ fn given_manifest_loaded(world: &mut DependencyBinaryWorld) {
         .to_vec();
 }
 
-#[when("dependency installation runs")]
-fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
-    let tool = world
-        .missing_tool
-        .clone()
-        .expect("missing tool should be configured");
+fn build_stub_executor(world: &DependencyBinaryWorld, tool: &str) -> StubExecutor {
     let is_repository_asset_missing = matches!(
         world.repository_behaviour,
         Some(RepositoryInstallerBehaviour::NotFound)
@@ -157,18 +152,8 @@ fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
         world.repository_behaviour,
         Some(RepositoryInstallerBehaviour::Success)
     ) && !world.is_unsupported_target;
-    let repository_installer = StubRepositoryInstaller {
-        behaviour: world.repository_behaviour.take().unwrap_or(
-            RepositoryInstallerBehaviour::Failure("missing repository".to_owned()),
-        ),
-    };
-    let status = DylintToolStatus {
-        cargo_dylint: tool != "cargo-dylint",
-        dylint_link: tool != "dylint-link",
-    };
-
-    let executor = StubExecutor::new(expected_calls(
-        &tool,
+    StubExecutor::new(expected_calls(
+        tool,
         ExpectedCallConfig {
             is_binstall_available: world.is_binstall_available,
             has_repository_context: !world.is_unsupported_target,
@@ -178,7 +163,25 @@ fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
             cargo_binstall_failure: world.cargo_binstall_failure.as_deref(),
             cargo_install_failure: world.cargo_install_failure.as_deref(),
         },
-    ));
+    ))
+}
+
+#[when("dependency installation runs")]
+fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
+    let tool = world
+        .missing_tool
+        .clone()
+        .expect("missing tool should be configured");
+    let executor = build_stub_executor(world, &tool);
+    let repository_installer = StubRepositoryInstaller {
+        behaviour: world.repository_behaviour.take().unwrap_or(
+            RepositoryInstallerBehaviour::Failure("missing repository".to_owned()),
+        ),
+    };
+    let status = DylintToolStatus {
+        cargo_dylint: tool != "cargo-dylint",
+        dylint_link: tool != "dylint-link",
+    };
 
     let target = if world.is_unsupported_target {
         None

--- a/installer/tests/behaviour_dependency_binaries.rs
+++ b/installer/tests/behaviour_dependency_binaries.rs
@@ -2,9 +2,6 @@
 
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
-use std::fs;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use whitaker_installer::dependency_binaries::{
     DependencyBinary, DependencyBinaryInstallError, DependencyBinaryInstaller,
@@ -16,10 +13,9 @@ use whitaker_installer::deps::{
 };
 use whitaker_installer::dirs::BaseDirs;
 use whitaker_installer::installer_packaging::TargetTriple;
-use whitaker_installer::test_support::env_test_guard;
 use whitaker_installer::test_utils::{
     StubDirs, StubExecutor,
-    dependency_binary_helpers::{ExpectedCallConfig, expected_calls},
+    dependency_binary_helpers::{ExpectedCallConfig, expected_calls, with_fake_binary_on_path},
 };
 
 enum RepositoryInstallerBehaviour {
@@ -68,6 +64,7 @@ struct DependencyBinaryWorld {
     missing_tool: Option<String>,
     repository_behaviour: Option<RepositoryInstallerBehaviour>,
     should_repository_verification_fail: bool,
+    expect_missing_dylint_link: bool,
     is_binstall_available: bool,
     cargo_binstall_failure: Option<String>,
     cargo_install_failure: Option<String>,
@@ -81,24 +78,6 @@ struct DependencyBinaryWorld {
 #[fixture]
 fn world() -> DependencyBinaryWorld {
     DependencyBinaryWorld::default()
-}
-
-fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -> T {
-    let _guard = env_test_guard();
-    let temp_dir = tempfile::tempdir().expect("create temp dir");
-    let binary_path = temp_dir.path().join(binary_name);
-    fs::write(&binary_path, []).expect("write fake binary");
-    #[cfg(unix)]
-    {
-        let mut permissions = fs::metadata(&binary_path)
-            .expect("read fake binary metadata")
-            .permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&binary_path, permissions).expect("mark fake binary executable");
-    }
-
-    let path = temp_dir.path().display().to_string();
-    temp_env::with_var("PATH", Some(path), run)
 }
 
 #[given("the missing tool is \"{tool}\"")]
@@ -124,6 +103,11 @@ fn given_repository_failure(world: &mut DependencyBinaryWorld, message: String) 
 fn given_repository_verification_failure(world: &mut DependencyBinaryWorld) {
     world.repository_behaviour = Some(RepositoryInstallerBehaviour::Success);
     world.should_repository_verification_fail = true;
+}
+
+#[given("dylint-link is missing from PATH after installation")]
+fn given_missing_dylint_link_on_path(world: &mut DependencyBinaryWorld) {
+    world.expect_missing_dylint_link = true;
 }
 
 #[given("cargo binstall is available")]
@@ -216,11 +200,13 @@ fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
             },
         )
     };
-    world.install_result = Some(if tool == "dylint-link" {
-        with_fake_binary_on_path("dylint-link", run_install)
-    } else {
-        run_install()
-    });
+    world.install_result = Some(
+        if tool == "dylint-link" && !world.expect_missing_dylint_link {
+            with_fake_binary_on_path("dylint-link", run_install)
+        } else {
+            run_install()
+        },
+    );
     executor.assert_finished();
 }
 
@@ -333,5 +319,10 @@ fn scenario_repository_success_without_binstall(world: DependencyBinaryWorld) {
 
 #[scenario(path = "tests/features/dependency_binaries.feature", index = 9)]
 fn scenario_provenance_lists_both_dependencies(world: DependencyBinaryWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/dependency_binaries.feature", index = 10)]
+fn scenario_dylint_link_missing_after_install_fails(world: DependencyBinaryWorld) {
     let _ = world;
 }

--- a/installer/tests/behaviour_dependency_binaries.rs
+++ b/installer/tests/behaviour_dependency_binaries.rs
@@ -3,6 +3,7 @@
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::path::PathBuf;
+use temp_env::with_var;
 use whitaker_installer::dependency_binaries::{
     DependencyBinary, DependencyBinaryInstallError, DependencyBinaryInstaller,
     required_dependency_binaries,
@@ -13,9 +14,10 @@ use whitaker_installer::deps::{
 };
 use whitaker_installer::dirs::BaseDirs;
 use whitaker_installer::installer_packaging::TargetTriple;
+use whitaker_installer::test_support::env_test_guard;
 use whitaker_installer::test_utils::{
     StubDirs, StubExecutor,
-    dependency_binary_helpers::{ExpectedCallConfig, expected_calls, with_fake_binary_on_path},
+    dependency_binary_helpers::{ExpectedCallConfig, expected_calls, write_fake_binary},
 };
 
 enum RepositoryInstallerBehaviour {
@@ -33,14 +35,13 @@ impl DependencyBinaryInstaller for StubRepositoryInstaller {
         &self,
         dependency: &DependencyBinary,
         target: &TargetTriple,
-        _dirs: &dyn BaseDirs,
+        dirs: &dyn BaseDirs,
     ) -> std::result::Result<PathBuf, DependencyBinaryInstallError> {
         match &self.behaviour {
-            RepositoryInstallerBehaviour::Success => Ok(PathBuf::from(format!(
-                "/tmp/bin/{}-{}",
-                dependency.package(),
-                target
-            ))),
+            RepositoryInstallerBehaviour::Success => dirs.bin_dir().map_or_else(
+                || Err(DependencyBinaryInstallError::MissingBinDir),
+                |bin_dir| Ok(bin_dir.join(format!("{}-{}", dependency.package(), target))),
+            ),
             RepositoryInstallerBehaviour::NotFound => Err(DependencyBinaryInstallError::NotFound {
                 url: format!(
                     "{}/releases/download/v{}/{}",
@@ -184,8 +185,10 @@ fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
     } else {
         Some(TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid target"))
     };
+    let bin_dir_temp = tempfile::tempdir().expect("bin dir tempdir should be created");
+    let bin_dir = bin_dir_temp.path().to_path_buf();
     let dirs = StubDirs {
-        bin_dir: Some(PathBuf::from("/tmp/bin")),
+        bin_dir: Some(bin_dir.clone()),
     };
     let run_install = || {
         install_dylint_tools_with_options(
@@ -202,7 +205,13 @@ fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
     };
     world.install_result = Some(
         if tool == "dylint-link" && !world.expect_missing_dylint_link {
-            with_fake_binary_on_path("dylint-link", run_install)
+            let _guard = env_test_guard();
+            #[cfg(windows)]
+            let dylint_link_path = bin_dir.join("dylint-link.cmd");
+            #[cfg(not(windows))]
+            let dylint_link_path = bin_dir.join("dylint-link");
+            write_fake_binary(&dylint_link_path, true);
+            with_var("PATH", Some(&bin_dir), run_install)
         } else {
             run_install()
         },

--- a/installer/tests/behaviour_dependency_binaries.rs
+++ b/installer/tests/behaviour_dependency_binaries.rs
@@ -2,6 +2,9 @@
 
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use whitaker_installer::dependency_binaries::{
     DependencyBinary, DependencyBinaryInstallError, DependencyBinaryInstaller,
@@ -13,6 +16,7 @@ use whitaker_installer::deps::{
 };
 use whitaker_installer::dirs::BaseDirs;
 use whitaker_installer::installer_packaging::TargetTriple;
+use whitaker_installer::test_support::env_test_guard;
 use whitaker_installer::test_utils::{
     StubDirs, StubExecutor,
     dependency_binary_helpers::{ExpectedCallConfig, expected_calls},
@@ -77,6 +81,24 @@ struct DependencyBinaryWorld {
 #[fixture]
 fn world() -> DependencyBinaryWorld {
     DependencyBinaryWorld::default()
+}
+
+fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -> T {
+    let _guard = env_test_guard();
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let binary_path = temp_dir.path().join(binary_name);
+    fs::write(&binary_path, []).expect("write fake binary");
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&binary_path)
+            .expect("read fake binary metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&binary_path, permissions).expect("mark fake binary executable");
+    }
+
+    let path = temp_dir.path().display().to_string();
+    temp_env::with_var("PATH", Some(path), run)
 }
 
 #[given("the missing tool is \"{tool}\"")]
@@ -181,17 +203,24 @@ fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
     let dirs = StubDirs {
         bin_dir: Some(PathBuf::from("/tmp/bin")),
     };
-    world.install_result = Some(install_dylint_tools_with_options(
-        &executor,
-        &status,
-        &mut world.stderr,
-        DependencyInstallOptions {
-            dirs: &dirs,
-            repository_installer: &repository_installer,
-            target,
-            quiet: false,
-        },
-    ));
+    let run_install = || {
+        install_dylint_tools_with_options(
+            &executor,
+            &status,
+            &mut world.stderr,
+            DependencyInstallOptions {
+                dirs: &dirs,
+                repository_installer: &repository_installer,
+                target,
+                quiet: false,
+            },
+        )
+    };
+    world.install_result = Some(if tool == "dylint-link" {
+        with_fake_binary_on_path("dylint-link", run_install)
+    } else {
+        run_install()
+    });
     executor.assert_finished();
 }
 

--- a/installer/tests/features/dependency_binaries.feature
+++ b/installer/tests/features/dependency_binaries.feature
@@ -79,3 +79,11 @@ Feature: Dependency binary installation
     Then the provenance contains "https://github.com/trailofbits/dylint"
     And the provenance contains "cargo-dylint"
     And the provenance contains "dylint-link"
+
+  Scenario: dylint-link remains unavailable after cargo install
+    Given the missing tool is "dylint-link"
+    And the repository installer fails with "not found"
+    And cargo binstall is unavailable
+    And dylint-link is missing from PATH after installation
+    When dependency installation runs
+    Then the install fails for "dylint-link" with message containing "still unavailable"


### PR DESCRIPTION
## Summary
Investigate dylint-link installation verification failure by introducing a PATH-based probe for the dylint-link binary and expanding test coverage to simulate binaries on PATH. Also aligns verification flow with upstream requirements and updates documentation accordingly.

## Changes
- Core logic
  - Add cross-platform PATH based binary detection for dylint-link in installer/src/deps.rs:
    - is_binary_on_path(binary_name) -> checks PATH for an executable named binary_name (and on Windows also .exe).
    - Platform-specific is_executable_file(path) implementations for Unix and non-Unix.
  - Special-casing for dylint-link in is_tool_installed so it uses the PATH-based check instead of a direct command execution.
- Documentation
  - docs/developers-guide.md updated to reflect the new verification approach:
    - cargo-dylint --version continues to verify cargo-dylint.
    - dylint-link verification now resolves the executable on PATH due to upstream requirements.
- Tests
  - Introduced with_fake_binary_on_path helper in multiple test modules to simulate a fake dylint-link binary on PATH.
  - Updated dependency install tests (installer/src/deps/install_tests.rs, installer/src/deps/tests.rs, installer/src/tests.rs, installer/tests/behaviour_dependency_binaries.rs) to use PATH-based fake binaries and adjust expectations accordingly.
  - Added AlwaysNotFoundRepositoryInstaller in installer/src/tests.rs to simulate repository install failures for test scenarios.
  - Adjusted test utilities to stop depending on explicit dylint-link version checks in certain flows and to accommodate PATH-based presence.
  - Added a test-only import in installer/src/main.rs to enable install_dylint_tools_with_options during tests.

## Why
- This change addresses failures where dylint-link verification cannot be reliably performed via a hard-coded repository artefact. By detecting the dylint-link tool on PATH, tests and runtime behavior better reflect real-world environments where PATH-based binaries are used.
- Cross-platform support for executable detection ensures Windows and Unix-like systems behave consistently.

## Test plan
- Run cargo test across all workspace crates.
- Focus tests that exercise dylint-tool verification paths:
  - Ensure presence on PATH leads to successful verification and skipping unnecessary installs.
  - Ensure when PATH lacks the binary, installation falls back to repository or binstall paths as appropriate.
- Verify Unix executable permissions for the fake binaries created in tests.

## Notes
- Runtime changes are guarded behind cfg(test) in several areas, so there should be no impact on production builds.
- Windows executable detection is supported via the new PATH lookup logic.
- The docs change is reader-facing and describes the updated verification semantics for dylint-link and cargo-dylint.


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/c99c0e48-805f-49a9-8779-cc6f915546fa

## Summary by Sourcery

Introduce PATH-based detection for the `dylint-link` binary and align dependency installation/verification flow and tests with this new behavior.

New Features:
- Add cross-platform PATH-based executable lookup to detect `dylint-link` without invoking it directly.
- Allow the Dylint tool installation flow to accept a pluggable install function for better test control.

Enhancements:
- Special-case `dylint-link` installation checks to rely on PATH resolution instead of running the binary, matching upstream requirements.
- Refine dependency installation helper logic to skip redundant verification steps for `dylint-link`.
- Improve doctest imports for dependency binary manifest APIs to use the public module surface.

Documentation:
- Document the updated verification semantics where `cargo-dylint` is checked via `cargo dylint --version` and `dylint-link` via PATH resolution.

Tests:
- Add helpers to create fake binaries on PATH and use them across installer and dependency tests to simulate `dylint-link` presence.
- Update Dylint dependency install tests and BDD-style dependency binary tests to exercise the new PATH-based verification behavior.
- Introduce a repository installer test double that always reports `NotFound` to cover repository-fallback scenarios in tests.