### PR TITLE
Fix Windows CI test failure in path_checks

### DIFF
--- a/installer/src/deps/path_tests.rs
+++ b/installer/src/deps/path_tests.rs
@@ -133,6 +133,17 @@ fn is_binary_on_path_accepts_windows_executable_suffix() {
 
 #[cfg(windows)]
 #[test]
+fn is_binary_on_path_ignores_files_without_executable_suffix() {
+    with_fake_path(
+        |directories| write_fake_binary(&directories[1].join("dylint-link"), true),
+        || {
+            assert!(!is_binary_on_path("dylint-link"));
+        },
+    );
+}
+
+#[cfg(windows)]
+#[test]
 fn check_dylint_tools_detects_dylint_link_via_pathext_suffix() {
     let _guard = env_test_guard();
     temp_env::with_var("PATHEXT", Some(".CMD;.BAT"), || {

--- a/installer/src/deps/path_tests.rs
+++ b/installer/src/deps/path_tests.rs
@@ -145,13 +145,12 @@ fn is_binary_on_path_ignores_files_without_executable_suffix() {
 #[cfg(windows)]
 #[test]
 fn check_dylint_tools_detects_dylint_link_via_pathext_suffix() {
-    let _guard = env_test_guard();
-    temp_env::with_var("PATHEXT", Some(".CMD;.BAT"), || {
-        with_fake_path(
-            |directories| {
-                write_fake_binary_with_status(&directories[0].join("dylint-link.cmd"), true, 0)
-            },
-            || {
+    with_fake_path(
+        |directories| {
+            write_fake_binary_with_status(&directories[0].join("dylint-link.cmd"), true, 0)
+        },
+        || {
+            temp_env::with_var("PATHEXT", Some(".CMD;.BAT"), || {
                 let executor =
                     StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
 
@@ -165,7 +164,7 @@ fn check_dylint_tools_detects_dylint_link_via_pathext_suffix() {
                     }
                 );
                 executor.assert_finished();
-            },
-        );
-    });
+            });
+        },
+    );
 }

--- a/installer/src/deps/path_tests.rs
+++ b/installer/src/deps/path_tests.rs
@@ -121,23 +121,18 @@ fn is_executable_file_accepts_executable_files() {
 }
 
 #[cfg(windows)]
-#[test]
-fn is_binary_on_path_accepts_windows_executable_suffix() {
+#[rstest::rstest]
+#[case("dylint-link.exe", 0, true)]
+#[case("dylint-link", 1, false)]
+fn is_binary_on_path_handles_windows_executable_suffixes(
+    #[case] binary_name: &str,
+    #[case] dir_index: usize,
+    #[case] expected: bool,
+) {
     with_fake_path(
-        |directories| write_fake_binary(&directories[0].join("dylint-link.exe"), true),
+        |directories| write_fake_binary(&directories[dir_index].join(binary_name), true),
         || {
-            assert!(is_binary_on_path("dylint-link"));
-        },
-    );
-}
-
-#[cfg(windows)]
-#[test]
-fn is_binary_on_path_ignores_files_without_executable_suffix() {
-    with_fake_path(
-        |directories| write_fake_binary(&directories[1].join("dylint-link"), true),
-        || {
-            assert!(!is_binary_on_path("dylint-link"));
+            assert_eq!(is_binary_on_path(binary_name), expected);
         },
     );
 }

--- a/installer/src/deps/path_tests.rs
+++ b/installer/src/deps/path_tests.rs
@@ -86,7 +86,14 @@ fn is_binary_on_path_returns_false_when_binary_is_missing_from_all_directories()
 #[test]
 fn is_binary_on_path_checks_multiple_directories() {
     with_fake_path(
-        |directories| write_fake_binary(&directories[1].join("dylint-link"), true),
+        |directories| {
+            #[cfg(windows)]
+            let binary_path = directories[1].join("dylint-link.exe");
+            #[cfg(not(windows))]
+            let binary_path = directories[1].join("dylint-link");
+
+            write_fake_binary(&binary_path, true);
+        },
         || {
             assert!(is_binary_on_path("dylint-link"));
         },

--- a/installer/src/deps/path_tests.rs
+++ b/installer/src/deps/path_tests.rs
@@ -148,7 +148,9 @@ fn check_dylint_tools_detects_dylint_link_via_pathext_suffix() {
     let _guard = env_test_guard();
     temp_env::with_var("PATHEXT", Some(".CMD;.BAT"), || {
         with_fake_path(
-            |directories| write_fake_binary(&directories[0].join("dylint-link.cmd"), true),
+            |directories| {
+                write_fake_binary_with_status(&directories[0].join("dylint-link.cmd"), true, 0)
+            },
             || {
                 let executor =
                     StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);


### PR DESCRIPTION
## Summary
- Improve Windows CI path checks by using platform-appropriate executable suffix when simulating binaries on PATH, and add tests for Windows-specific suffix handling and PATHEXT semantics.

## Changes

### Tests
- In `installer/src/deps/path_tests.rs`:
  - Update `is_binary_on_path_checks_multiple_directories` to instantiate the fake binary with a platform-appropriate name:
    - On Windows: `directories[1].join("dylint-link.exe")`
    - On non-Windows: `directories[1].join("dylint-link")`
  - Adds Windows-specific test to ensure PATH search ignores files without executable suffix:
    - New test: `is_binary_on_path_handles_windows_executable_suffixes` (Windows only)
      - Parameterized to cover both with and without executable suffix (e.g., `dylint-link.exe` should be found, `dylint-link` should not).
  - Keeps existing behavior for non-Windows environments while ensuring Windows uses the `.exe` extension.

- Windows PATH extension handling (PATHEXT)
  - Tests now consider Windows executable suffixes via PATHEXT, ensuring path resolution respects Windows conventions (e.g., `.exe`, `.cmd`). For example, the test `check_dylint_tools_detects_dylint_link_via_pathext_suffix` is adjusted to simulate executables with suffixes under a PATHEXT-enabled environment.

### Why
- Windows CI uses executable extensions; previously the test wrote a file named `dylint-link` without an extension, which caused the path check to fail on Windows.

### Compatibility
- No API changes; test-only adjustment.

### Test plan
- [x] Windows CI path test passes
- [x] Local tests pass on Linux/macOS
- [x] Ensure no regression for path checks across platforms


📎 **Task**: https://www.devboxer.com/task/7c4d0f24-854b-43e8-8444-00d156263b05