### PR TITLE
Split CI into dedicated Linux and Windows lanes with sccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Test
         run: make test NEXTEST_PROFILE=ci
 
+      - name: Installer smoke test
+        run: make install-smoke
+
       - name: Installer release dry run
         run: make release-installer-dry-run
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: make lint
 
       - name: Publish dry run
-        run: make publish-check
+        run: make publish-check PUBLISH_PACKAGES="whitaker-common whitaker-installer"
 
   windows-compat:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Test
         run: make test NEXTEST_PROFILE=ci
 
-      - name: Installer smoke test
-        run: make install-smoke
+      - name: Installer release dry run
+        run: make release-installer-dry-run
 
       - name: Show sccache stats
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,26 +5,23 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+env:
+  BUILD_PROFILE: debug
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: sccache
 jobs:
-  build-test:
-    runs-on: ${{ matrix.os }}
+  linux-full:
+    runs-on: ubicloud-standard-4-ubuntu-2404
     defaults:
       run:
         shell: bash
-    permissions:
-      contents: read
-    env:
-      CARGO_TERM_COLOR: always
-      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
-      RUSTFLAGS: -D warnings
-      RUSTDOCFLAGS: -D warnings
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-          - os: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -32,13 +29,18 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10
+        with:
+          tool: nextest@0.9.114
+
+      - name: Check formatting
+        run: make check-fmt
+
       - name: Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76  # v2
         with:
           bun-version: '1.2.21'
-
-      - name: Check formatting
-        run: make check-fmt
 
       - name: Install Mermaid CLI
         run: |
@@ -66,23 +68,32 @@ jobs:
       - name: Lint
         run: make lint
 
-      - name: Test
+      - name: Publish dry run
+        run: make publish-check
+
+  windows-compat:
+    runs-on: windows-latest
+    defaults:
+      run:
         shell: bash
-        run: |
-          set -euxo pipefail
-          cargo binstall --no-confirm --locked cargo-nextest
-          make test NEXTEST_PROFILE=ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10
+        with:
+          tool: nextest@0.9.114
+
+      - name: Test
+        run: make test NEXTEST_PROFILE=ci
 
       - name: Installer smoke test
         run: make install-smoke
 
-      - name: Publish dry run
-        run: make publish-check
-
-      - name: Upload coverage data to CodeScene
-        if: ${{ matrix.coverage && env.CS_ACCESS_TOKEN && vars.CODESCENE_CLI_SHA256 }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@c749ab3a96026e14051a2198bf75f94650581b75
-        with:
-          format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+      - name: Show sccache stats
+        if: ${{ always() }}
+        run: sccache --show-stats || true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie publish-check typecheck install-smoke package-lints workflow-test workflow-test-deps verus kani verus-clone-detector kani-clone-detector
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie publish-check typecheck install-smoke release-installer-dry-run package-lints workflow-test workflow-test-deps verus kani verus-clone-detector kani-clone-detector
 
 APP ?= whitaker-installer
 PATH := $(HOME)/.cargo/bin:$(HOME)/.bun/bin:$(PATH)
@@ -144,6 +144,61 @@ install-smoke: ## Install whitaker-installer and verify basic functionality
 	command -v whitaker-installer >/dev/null; \
 	whitaker-installer --help >/dev/null; \
 	whitaker-installer --version >/dev/null
+
+release-installer-dry-run: ## Build and package the host-platform installer archive
+	set -eu; \
+	TMP_DIR=$$(mktemp -d); \
+	trap 'rm -rf "$$TMP_DIR"' 0 INT TERM HUP; \
+	HOST_TRIPLE=$$(rustc -vV | awk -F ': ' '/host:/ {print $$2}'); \
+	VERSION=$$($(CARGO) metadata --manifest-path installer/Cargo.toml --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "whitaker-installer") | .version'); \
+	if [ -z "$$VERSION" ]; then \
+		echo "Failed to extract whitaker-installer version from Cargo metadata"; \
+		exit 1; \
+	fi; \
+	$(CARGO) build $(BUILD_JOBS) -p whitaker-installer --release --target "$$HOST_TRIPLE"; \
+	$(CARGO) build $(BUILD_JOBS) --release -p whitaker-installer --bin whitaker-package-installer; \
+	DIST_DIR="$$TMP_DIR/dist"; \
+	mkdir -p "$$DIST_DIR"; \
+	case "$$HOST_TRIPLE" in \
+		*windows*) \
+			INSTALLER_BIN="target/$$HOST_TRIPLE/release/whitaker-installer.exe"; \
+			PACKAGER="./target/release/whitaker-package-installer.exe"; \
+			ARCHIVE_GLOB="$$DIST_DIR/*.zip"; \
+			;; \
+		*) \
+			INSTALLER_BIN="target/$$HOST_TRIPLE/release/whitaker-installer"; \
+			PACKAGER="./target/release/whitaker-package-installer"; \
+			ARCHIVE_GLOB="$$DIST_DIR/*.tgz"; \
+			;; \
+	esac; \
+	"$$PACKAGER" \
+		--crate-version "$$VERSION" \
+		--target "$$HOST_TRIPLE" \
+		--binary-path "$$INSTALLER_BIN" \
+		--output-dir "$$DIST_DIR"; \
+	python scripts/generate_checksums.py "$$DIST_DIR"; \
+	found_archive=false; \
+	for archive in $$ARCHIVE_GLOB; do \
+		if [ -f "$$archive" ]; then \
+			found_archive=true; \
+			break; \
+		fi; \
+	done; \
+	if [ "$$found_archive" != "true" ]; then \
+		echo "Expected installer archive matching $$ARCHIVE_GLOB"; \
+		exit 1; \
+	fi; \
+	found_checksum=false; \
+	for checksum in "$$DIST_DIR"/*.sha256; do \
+		if [ -f "$$checksum" ]; then \
+			found_checksum=true; \
+			break; \
+		fi; \
+	done; \
+	if [ "$$found_checksum" != "true" ]; then \
+		echo "Expected installer checksum in $$DIST_DIR"; \
+		exit 1; \
+	fi
 
 publish-check: ## Build, test, and validate packages before publishing
 	@command -v cargo-nextest >/dev/null || { echo "Install cargo-nextest (cargo install cargo-nextest)"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ install-smoke: ## Install whitaker-installer and verify basic functionality
 
 release-installer-dry-run: ## Build and package the host-platform installer archive
 	set -eu; \
+	for tool in awk jq mktemp python rustc; do \
+		command -v "$$tool" >/dev/null || { echo "Install $$tool to run release-installer-dry-run"; exit 1; }; \
+	done; \
 	TMP_DIR=$$(mktemp -d); \
 	trap 'rm -rf "$$TMP_DIR"' 0 INT TERM HUP; \
 	HOST_TRIPLE=$$(rustc -vV | awk -F ': ' '/host:/ {print $$2}'); \

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ release-installer-dry-run: ## Build and package the host-platform installer arch
 		echo "Install python3 or python to run release-installer-dry-run"; \
 		exit 1; \
 	fi; \
+	[ -n "$(CARGO)" ] || { echo "Install cargo to run release-installer-dry-run"; exit 1; }; \
 	for tool in awk jq mktemp rustc; do \
 		command -v "$$tool" >/dev/null || { echo "Install $$tool to run release-installer-dry-run"; exit 1; }; \
 	done; \

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,12 @@ install-smoke: ## Install whitaker-installer and verify basic functionality
 
 release-installer-dry-run: ## Build and package the host-platform installer archive
 	set -eu; \
-	for tool in awk jq mktemp python rustc; do \
+	PYTHON=$$(command -v python3 || command -v python || true); \
+	if [ -z "$$PYTHON" ]; then \
+		echo "Install python3 or python to run release-installer-dry-run"; \
+		exit 1; \
+	fi; \
+	for tool in awk jq mktemp rustc; do \
 		command -v "$$tool" >/dev/null || { echo "Install $$tool to run release-installer-dry-run"; exit 1; }; \
 	done; \
 	TMP_DIR=$$(mktemp -d); \
@@ -179,7 +184,7 @@ release-installer-dry-run: ## Build and package the host-platform installer arch
 		--target "$$HOST_TRIPLE" \
 		--binary-path "$$INSTALLER_BIN" \
 		--output-dir "$$DIST_DIR"; \
-	python scripts/generate_checksums.py "$$DIST_DIR"; \
+	"$$PYTHON" scripts/generate_checksums.py "$$DIST_DIR"; \
 	found_archive=false; \
 	for archive in $$ARCHIVE_GLOB; do \
 		if [ -f "$$archive" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -159,18 +159,18 @@ release-installer-dry-run: ## Build and package the host-platform installer arch
 		exit 1; \
 	fi; \
 	$(CARGO) build $(BUILD_JOBS) -p whitaker-installer --release --target "$$HOST_TRIPLE"; \
-	$(CARGO) build $(BUILD_JOBS) --release -p whitaker-installer --bin whitaker-package-installer; \
+	$(CARGO) build $(BUILD_JOBS) --release -p whitaker-installer --bin whitaker-package-installer --target "$$HOST_TRIPLE"; \
 	DIST_DIR="$$TMP_DIR/dist"; \
 	mkdir -p "$$DIST_DIR"; \
 	case "$$HOST_TRIPLE" in \
 		*windows*) \
 			INSTALLER_BIN="target/$$HOST_TRIPLE/release/whitaker-installer.exe"; \
-			PACKAGER="./target/release/whitaker-package-installer.exe"; \
+			PACKAGER="./target/$$HOST_TRIPLE/release/whitaker-package-installer.exe"; \
 			ARCHIVE_GLOB="$$DIST_DIR/*.zip"; \
 			;; \
 		*) \
 			INSTALLER_BIN="target/$$HOST_TRIPLE/release/whitaker-installer"; \
-			PACKAGER="./target/release/whitaker-package-installer"; \
+			PACKAGER="./target/$$HOST_TRIPLE/release/whitaker-package-installer"; \
 			ARCHIVE_GLOB="$$DIST_DIR/*.tgz"; \
 			;; \
 	esac; \

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -123,7 +123,9 @@ Mermaid/Nixie/Markdown validation, `make lint`, and `make publish-check`.
 `windows-compat` is a narrower compatibility lane that runs
 `make test NEXTEST_PROFILE=ci` and `make release-installer-dry-run` to prove
 the workspace still builds on Windows and that the Windows installer release
-packaging path stays valid.
+packaging path stays valid. The release dry-run target is a POSIX-shell target;
+Windows CI runs it under Bash and requires the same command-line tools as local
+POSIX environments.
 
 Table: Test profiles and typical usage.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -134,6 +134,17 @@ packaging path stays valid. The release dry-run target is a POSIX-shell target;
 Windows CI runs it under Bash and requires the same command-line tools as local
 POSIX environments.
 
+Both lanes share the workflow-level environment contract:
+`BUILD_PROFILE=debug` narrows `sccache` keys to debug builds only, preventing
+cache pollution from release builds; `CARGO_INCREMENTAL=0` disables incremental
+compilation, which is incompatible with `sccache`; `RUSTC_WRAPPER=sccache`
+routes all `rustc` invocations through `sccache`; `SCCACHE_GHA_ENABLED=true`
+activates the GitHub Actions cache backend for `sccache`; and
+`RUSTFLAGS=-D warnings` and `RUSTDOCFLAGS=-D warnings` deny compiler and doc
+warnings as errors across both lanes. Together, these variables keep the cache
+scope narrow, ensure `sccache` is active for all compilation, and enforce a
+warnings-as-errors build contract.
+
 ### CI build caching
 
 CI uses `sccache` through the GitHub Actions backend to share Rust compilation

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -117,6 +117,13 @@ make test NEXTEST_PROFILE=ci
 Continuous Integration (CI) always uses the `ci` profile, so installer tests
 are never silently skipped in the pipeline.
 
+The CI workflow is split by purpose rather than running the same stack on every
+operating system. `linux-full` is the authoritative gate for formatting,
+Mermaid/Nixie/Markdown validation, `make lint`, and `make publish-check`.
+`windows-compat` is a narrower compatibility lane that runs
+`make test NEXTEST_PROFILE=ci` and `make install-smoke` to prove the workspace
+still builds and behaves correctly on Windows.
+
 Table: Test profiles and typical usage.
 
 | Profile   | What runs                                  | Typical use        |

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -7,11 +7,17 @@ Whitaker itself. For using Whitaker lints in a project, see the
 ## Prerequisites
 
 - Rust nightly toolchain (version specified in `rust-toolchain.toml`)
+- `jq` for extracting package metadata in release dry runs
+- Python 3 for workflow tests and release checksum generation
 - `cargo-dylint` and `dylint-link` installed:
 
   ```sh
   cargo install cargo-dylint dylint-link
   ```
+
+CI also installs or provides job-specific tools such as `cargo-nextest`,
+`bun`, `uv`, Mermaid CLI, and Nixie before running the targets that need them.
+Local runs of those targets require the same tools on `PATH`.
 
 ## Running Tests
 
@@ -127,6 +133,24 @@ Windows, the installed binary can execute, and the Windows installer release
 packaging path stays valid. The release dry-run target is a POSIX-shell target;
 Windows CI runs it under Bash and requires the same command-line tools as local
 POSIX environments.
+
+
+### CI build caching
+
+CI uses `sccache` through the GitHub Actions backend to share Rust compilation
+artefacts between the Linux and Windows lanes. The workflow sets
+`SCCACHE_GHA_ENABLED=true` and `RUSTC_WRAPPER=sccache`, so Cargo invokes
+`rustc` through `sccache` automatically.
+
+The shared target cache is intentionally scoped to debug builds:
+
+- `BUILD_PROFILE=debug` keeps cache paths centred on the profile used by the
+  normal test and typecheck jobs.
+- `CARGO_INCREMENTAL=0` disables incremental build artefacts, which are
+  poorly suited to shared CI cache reuse and can make cache contents larger
+  without improving repeatability.
+- `RUSTFLAGS=-D warnings` and `RUSTDOCFLAGS=-D warnings` preserve the
+  warnings-as-errors contract even when builds are routed through `sccache`.
 
 Table: Test profiles and typical usage.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -121,8 +121,9 @@ The CI workflow is split by purpose rather than running the same stack on every
 operating system. `linux-full` is the authoritative gate for formatting,
 Mermaid/Nixie/Markdown validation, `make lint`, and `make publish-check`.
 `windows-compat` is a narrower compatibility lane that runs
-`make test NEXTEST_PROFILE=ci` and `make install-smoke` to prove the workspace
-still builds and behaves correctly on Windows.
+`make test NEXTEST_PROFILE=ci` and `make release-installer-dry-run` to prove
+the workspace still builds on Windows and that the Windows installer release
+packaging path stays valid.
 
 Table: Test profiles and typical usage.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -134,7 +134,6 @@ packaging path stays valid. The release dry-run target is a POSIX-shell target;
 Windows CI runs it under Bash and requires the same command-line tools as local
 POSIX environments.
 
-
 ### CI build caching
 
 CI uses `sccache` through the GitHub Actions backend to share Rust compilation

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -121,8 +121,9 @@ The CI workflow is split by purpose rather than running the same stack on every
 operating system. `linux-full` is the authoritative gate for formatting,
 Mermaid/Nixie/Markdown validation, `make lint`, and `make publish-check`.
 `windows-compat` is a narrower compatibility lane that runs
-`make test NEXTEST_PROFILE=ci` and `make release-installer-dry-run` to prove
-the workspace still builds on Windows and that the Windows installer release
+`make test NEXTEST_PROFILE=ci`, `make install-smoke`, and
+`make release-installer-dry-run` to prove the workspace still builds on
+Windows, the installed binary can execute, and the Windows installer release
 packaging path stays valid. The release dry-run target is a POSIX-shell target;
 Windows CI runs it under Bash and requires the same command-line tools as local
 POSIX environments.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -34,6 +34,17 @@ This target builds the workspace, runs tests with the pinned toolchain, and
 packages the crates named in `PUBLISH_PACKAGES` for inspection, which here
 means both `whitaker-common` and `whitaker-installer`.
 
+To validate the installer archive path used by the release workflow on the
+current host platform, run:
+
+```sh
+make release-installer-dry-run
+```
+
+This target builds the installer, invokes `whitaker-package-installer`, and
+generates checksums for the resulting archive so release packaging issues are
+caught before tagging or publishing.
+
 ## Dry run
 
 Perform a dry run to see the exact artefacts that would be uploaded:

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -43,7 +43,10 @@ make release-installer-dry-run
 
 This target builds the installer, invokes `whitaker-package-installer`, and
 generates checksums for the resulting archive so release packaging issues are
-caught before tagging or publishing.
+caught before tagging or publishing. It is a POSIX-shell target and checks for
+the required `awk`, `jq`, `mktemp`, `python`, and `rustc` commands before doing
+build work. On Windows, run it from an environment that provides those tools,
+such as the Bash shell used by CI.
 
 ## Dry run
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -42,7 +42,7 @@ make release-installer-dry-run
 ```
 
 This target builds the installer, invokes `whitaker-package-installer`, and
-generates checksums for the resulting archive so release packaging issues are
+generates checksums for the resulting archive, so release packaging issues are
 caught before tagging or publishing. It is a POSIX-shell target and checks for
 the required `awk`, `jq`, `mktemp`, `python`, and `rustc` commands before doing
 build work. On Windows, run it from an environment that provides those tools,

--- a/tests/workflows/test_ci_workflow.py
+++ b/tests/workflows/test_ci_workflow.py
@@ -1,0 +1,182 @@
+"""Validate CI workflow contracts for Linux and Windows lanes."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from ruamel.yaml import YAML
+
+WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml"
+
+
+def _load_workflow_mapping() -> dict[str, Any]:
+    """Load the CI workflow YAML and return it as a mapping."""
+    parsed = YAML(typ="safe").load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    match parsed:
+        case dict() as workflow_mapping:
+            return workflow_mapping
+        case _:
+            pytest.fail("CI workflow must parse to a mapping")
+
+
+def _get_mapping_item(
+    mapping: Mapping[str, Any],
+    key: str,
+    *,
+    parent_name: str,
+) -> dict[str, Any]:
+    """Return a child mapping and fail with a targeted contract message."""
+    match mapping.get(key):
+        case dict() as child_mapping:
+            return child_mapping
+        case _:
+            pytest.fail(f"{parent_name} must declare {key}")
+
+
+def _step_names(job: Mapping[str, Any]) -> list[str]:
+    """Return ordered workflow step names for the provided job mapping."""
+    match job.get("steps"):
+        case list() as steps:
+            pass
+        case _:
+            pytest.fail("CI job must declare steps")
+
+    names: list[str] = []
+    for step in steps:
+        match step:
+            case {"name": str() as step_name}:
+                names.append(step_name)
+            case {"uses": str()}:
+                pytest.fail("CI workflow steps must be named for contract tests")
+            case _:
+                pytest.fail("CI workflow step must be a mapping with a name")
+    return names
+
+
+def _find_step(job: Mapping[str, Any], name: str) -> dict[str, Any]:
+    """Return a named workflow step from the job mapping."""
+    match job.get("steps"):
+        case list() as steps:
+            pass
+        case _:
+            pytest.fail("CI job must declare steps")
+
+    for step in steps:
+        match step:
+            case {"name": str() as step_name} if step_name == name:
+                return step
+            case _:
+                continue
+    pytest.fail(f"CI job must include {name!r} step")
+
+
+def test_ci_splits_linux_and_windows_jobs_by_purpose() -> None:
+    """Ensure CI uses dedicated Linux and Windows jobs instead of a shared matrix."""
+    workflow = _load_workflow_mapping()
+    jobs = _get_mapping_item(workflow, "jobs", parent_name="CI workflow")
+
+    assert "build-test" not in jobs, (
+        "CI workflow must no longer use the shared build-test matrix job"
+    )
+
+    linux_job = _get_mapping_item(jobs, "linux-full", parent_name="CI workflow jobs")
+    windows_job = _get_mapping_item(
+        jobs,
+        "windows-compat",
+        parent_name="CI workflow jobs",
+    )
+
+    assert linux_job.get("runs-on") == "ubicloud-standard-4-ubuntu-2404", (
+        "linux-full must run on the dedicated Ubicloud Linux runner"
+    )
+    assert windows_job.get("runs-on") == "windows-latest", (
+        "windows-compat must keep using the hosted Windows runner"
+    )
+    assert "strategy" not in linux_job, (
+        "linux-full should be a purpose-built job, not a matrix include row"
+    )
+    assert "strategy" not in windows_job, (
+        "windows-compat should be a purpose-built job, not a matrix include row"
+    )
+
+
+def test_ci_enables_shared_sccache_env_and_debug_target_cache_scope() -> None:
+    """Ensure the workflow enables sccache and narrows cache scope to debug builds."""
+    workflow = _load_workflow_mapping()
+    env = _get_mapping_item(workflow, "env", parent_name="CI workflow")
+
+    assert env.get("BUILD_PROFILE") == "debug", (
+        "CI must set BUILD_PROFILE=debug so shared target caching does not "
+        "expand to the entire target tree"
+    )
+    assert env.get("SCCACHE_GHA_ENABLED") == "true", (
+        "CI must enable the GitHub Actions-backed sccache integration"
+    )
+    assert env.get("RUSTC_WRAPPER") == "sccache", (
+        "CI must route rustc through sccache"
+    )
+    assert str(env.get("CARGO_INCREMENTAL")) == "0", (
+        "CI must disable incremental Cargo builds when relying on sccache"
+    )
+
+
+def test_linux_full_keeps_the_full_linux_validation_stack() -> None:
+    """Ensure Linux remains the single lane for Linux-shaped validation work."""
+    workflow = _load_workflow_mapping()
+    jobs = _get_mapping_item(workflow, "jobs", parent_name="CI workflow")
+    linux_job = _get_mapping_item(jobs, "linux-full", parent_name="CI workflow jobs")
+
+    assert _step_names(linux_job) == [
+        "Checkout",
+        "Setup Rust",
+        "Install cargo-nextest",
+        "Check formatting",
+        "Install bun",
+        "Install Mermaid CLI",
+        "Setup uv",
+        "Install Nixie",
+        "Nixie",
+        "Markdown lint",
+        "Lint",
+        "Publish dry run",
+    ], (
+        "linux-full must remain the only CI lane that runs format, Mermaid, "
+        "Nixie, Markdown lint, Clippy/doc linting, and publish-check"
+    )
+
+    assert _find_step(linux_job, "Publish dry run").get("run") == "make publish-check", (
+        "linux-full must keep publish-check on Linux only"
+    )
+
+
+def test_windows_compat_stays_limited_to_windows_compatibility_checks() -> None:
+    """Ensure Windows validates build and installer behaviour without Linux-only work."""
+    workflow = _load_workflow_mapping()
+    jobs = _get_mapping_item(workflow, "jobs", parent_name="CI workflow")
+    windows_job = _get_mapping_item(
+        jobs,
+        "windows-compat",
+        parent_name="CI workflow jobs",
+    )
+
+    assert _step_names(windows_job) == [
+        "Checkout",
+        "Setup Rust",
+        "Install cargo-nextest",
+        "Test",
+        "Installer smoke test",
+        "Show sccache stats",
+    ], (
+        "windows-compat must stay focused on Rust tests, installer smoke, "
+        "and cache diagnostics"
+    )
+
+    assert _find_step(windows_job, "Test").get("run") == "make test NEXTEST_PROFILE=ci", (
+        "windows-compat must run the full CI test profile on Windows"
+    )
+    assert _find_step(windows_job, "Installer smoke test").get("run") == (
+        "make install-smoke"
+    ), "windows-compat must keep the installer smoke test"

--- a/tests/workflows/test_ci_workflow.py
+++ b/tests/workflows/test_ci_workflow.py
@@ -167,16 +167,16 @@ def test_windows_compat_stays_limited_to_windows_compatibility_checks() -> None:
         "Setup Rust",
         "Install cargo-nextest",
         "Test",
-        "Installer smoke test",
+        "Installer release dry run",
         "Show sccache stats",
     ], (
-        "windows-compat must stay focused on Rust tests, installer smoke, "
-        "and cache diagnostics"
+        "windows-compat must stay focused on Rust tests, installer release "
+        "validation, and cache diagnostics"
     )
 
     assert _find_step(windows_job, "Test").get("run") == "make test NEXTEST_PROFILE=ci", (
         "windows-compat must run the full CI test profile on Windows"
     )
-    assert _find_step(windows_job, "Installer smoke test").get("run") == (
-        "make install-smoke"
-    ), "windows-compat must keep the installer smoke test"
+    assert _find_step(windows_job, "Installer release dry run").get("run") == (
+        "make release-installer-dry-run"
+    ), "windows-compat must validate the host-platform installer release path"

--- a/tests/workflows/test_ci_workflow.py
+++ b/tests/workflows/test_ci_workflow.py
@@ -169,11 +169,9 @@ def test_linux_full_keeps_the_full_linux_validation_stack(
         ),
     )
 
-    assert (
-        _find_step(linux_job, "Publish dry run").get("run") == "make publish-check"
-    ), (
-        "linux-full must keep publish-check on Linux only"
-    )
+    assert _find_step(linux_job, "Publish dry run").get("run") == (
+        'make publish-check PUBLISH_PACKAGES="whitaker-common whitaker-installer"'
+    ), "linux-full must publish-check the release crates on Linux only"
 
 
 def test_windows_compat_stays_limited_to_windows_compatibility_checks(
@@ -186,6 +184,8 @@ def test_windows_compat_stays_limited_to_windows_compatibility_checks(
         "windows-compat",
         parent_name="CI workflow jobs",
     )
+    if windows_job.get("defaults") != {"run": {"shell": "bash"}}:
+        pytest.fail("windows-compat must keep using Bash for POSIX make targets")
 
     step_names = _step_names(windows_job)
     _assert_steps_in_order(

--- a/tests/workflows/test_ci_workflow.py
+++ b/tests/workflows/test_ci_workflow.py
@@ -188,7 +188,8 @@ def test_windows_compat_stays_limited_to_windows_compatibility_checks(
         "windows-compat",
         parent_name="CI workflow jobs",
     )
-    if windows_job.get("defaults") != {"run": {"shell": "bash"}}:
+    defaults = windows_job.get("defaults", {})
+    if defaults.get("run", {}).get("shell") != "bash":
         pytest.fail("windows-compat must keep using Bash for POSIX make targets")
 
     step_names = _step_names(windows_job)

--- a/tests/workflows/test_ci_workflow.py
+++ b/tests/workflows/test_ci_workflow.py
@@ -1,4 +1,20 @@
-"""Validate CI workflow contracts for Linux and Windows lanes."""
+"""Validate CI workflow contracts for Linux and Windows lanes.
+
+This module treats `.github/workflows/ci.yml` as a behavioural contract rather
+than a loose implementation detail. The tests ensure Linux remains the full
+validation lane, Windows remains focused on compatibility and installer smoke
+coverage, and shared workflow environment variables keep caching and warnings
+policy consistent across both jobs.
+
+The tests expect `WORKFLOW_PATH` to point at a readable GitHub Actions workflow
+YAML file and return normal pytest pass/fail output. Run them directly with:
+
+```sh
+PYTHONPATH=. uv run pytest tests/workflows/test_ci_workflow.py
+```
+
+In CI, these checks are covered by the `linux-full` job's workflow-test gate.
+"""
 
 from __future__ import annotations
 

--- a/tests/workflows/test_ci_workflow.py
+++ b/tests/workflows/test_ci_workflow.py
@@ -56,6 +56,21 @@ def _step_names(job: Mapping[str, Any]) -> list[str]:
     return names
 
 
+def _assert_steps_in_order(
+    step_names: list[str],
+    required_steps: list[str],
+    message: str,
+) -> None:
+    """Assert that the required workflow steps appear in order."""
+    search_from = 0
+    for required_step in required_steps:
+        try:
+            step_index = step_names.index(required_step, search_from)
+        except ValueError:
+            pytest.fail(message)
+        search_from = step_index + 1
+
+
 def _find_step(job: Mapping[str, Any], name: str) -> dict[str, Any]:
     """Return a named workflow step from the job mapping."""
     match job.get("steps"):
@@ -121,6 +136,12 @@ def test_ci_enables_shared_sccache_env_and_debug_target_cache_scope() -> None:
     assert str(env.get("CARGO_INCREMENTAL")) == "0", (
         "CI must disable incremental Cargo builds when relying on sccache"
     )
+    assert env.get("RUSTFLAGS") == "-D warnings", (
+        "CI must treat all Rust compiler warnings as errors via RUSTFLAGS"
+    )
+    assert env.get("RUSTDOCFLAGS") == "-D warnings", (
+        "CI must treat all rustdoc warnings as errors via RUSTDOCFLAGS"
+    )
 
 
 def test_linux_full_keeps_the_full_linux_validation_stack() -> None:
@@ -129,10 +150,55 @@ def test_linux_full_keeps_the_full_linux_validation_stack() -> None:
     jobs = _get_mapping_item(workflow, "jobs", parent_name="CI workflow")
     linux_job = _get_mapping_item(jobs, "linux-full", parent_name="CI workflow jobs")
 
-    assert _step_names(linux_job) == [
-        "Checkout",
-        "Setup Rust",
-        "Install cargo-nextest",
+    _assert_steps_in_order(
+        _step_names(linux_job),
+        [
+            "Check formatting",
+            "Nixie",
+            "Markdown lint",
+            "Lint",
+            "Publish dry run",
+        ],
+        (
+            "linux-full must remain the only CI lane that runs format, Mermaid, "
+            "Nixie, Markdown lint, Clippy/doc linting, and publish-check"
+        ),
+    )
+
+    assert (
+        _find_step(linux_job, "Publish dry run").get("run") == "make publish-check"
+    ), (
+        "linux-full must keep publish-check on Linux only"
+    )
+
+
+def test_windows_compat_stays_limited_to_windows_compatibility_checks() -> None:
+    """Ensure Windows validates installer behaviour without Linux-only work."""
+    workflow = _load_workflow_mapping()
+    jobs = _get_mapping_item(workflow, "jobs", parent_name="CI workflow")
+    windows_job = _get_mapping_item(
+        jobs,
+        "windows-compat",
+        parent_name="CI workflow jobs",
+    )
+
+    step_names = _step_names(windows_job)
+    _assert_steps_in_order(
+        step_names,
+        [
+            "Setup Rust",
+            "Install cargo-nextest",
+            "Test",
+            "Installer release dry run",
+            "Show sccache stats",
+        ],
+        (
+            "windows-compat must stay focused on Rust tests, installer release "
+            "validation, and cache diagnostics"
+        ),
+    )
+
+    linux_only_steps = {
         "Check formatting",
         "Install bun",
         "Install Mermaid CLI",
@@ -142,39 +208,14 @@ def test_linux_full_keeps_the_full_linux_validation_stack() -> None:
         "Markdown lint",
         "Lint",
         "Publish dry run",
-    ], (
-        "linux-full must remain the only CI lane that runs format, Mermaid, "
-        "Nixie, Markdown lint, Clippy/doc linting, and publish-check"
+    }
+    assert linux_only_steps.isdisjoint(step_names), (
+        "windows-compat must not duplicate Linux-only validation work"
     )
 
-    assert _find_step(linux_job, "Publish dry run").get("run") == "make publish-check", (
-        "linux-full must keep publish-check on Linux only"
-    )
-
-
-def test_windows_compat_stays_limited_to_windows_compatibility_checks() -> None:
-    """Ensure Windows validates build and installer behaviour without Linux-only work."""
-    workflow = _load_workflow_mapping()
-    jobs = _get_mapping_item(workflow, "jobs", parent_name="CI workflow")
-    windows_job = _get_mapping_item(
-        jobs,
-        "windows-compat",
-        parent_name="CI workflow jobs",
-    )
-
-    assert _step_names(windows_job) == [
-        "Checkout",
-        "Setup Rust",
-        "Install cargo-nextest",
-        "Test",
-        "Installer release dry run",
-        "Show sccache stats",
-    ], (
-        "windows-compat must stay focused on Rust tests, installer release "
-        "validation, and cache diagnostics"
-    )
-
-    assert _find_step(windows_job, "Test").get("run") == "make test NEXTEST_PROFILE=ci", (
+    assert (
+        _find_step(windows_job, "Test").get("run") == "make test NEXTEST_PROFILE=ci"
+    ), (
         "windows-compat must run the full CI test profile on Windows"
     )
     assert _find_step(windows_job, "Installer release dry run").get("run") == (

--- a/tests/workflows/test_ci_workflow.py
+++ b/tests/workflows/test_ci_workflow.py
@@ -189,12 +189,13 @@ def test_windows_compat_stays_limited_to_windows_compatibility_checks() -> None:
             "Setup Rust",
             "Install cargo-nextest",
             "Test",
+            "Installer smoke test",
             "Installer release dry run",
             "Show sccache stats",
         ],
         (
-            "windows-compat must stay focused on Rust tests, installer release "
-            "validation, and cache diagnostics"
+            "windows-compat must stay focused on Rust tests, installer smoke "
+            "coverage, installer release validation, and cache diagnostics"
         ),
     )
 
@@ -218,6 +219,9 @@ def test_windows_compat_stays_limited_to_windows_compatibility_checks() -> None:
     ), (
         "windows-compat must run the full CI test profile on Windows"
     )
+    assert _find_step(windows_job, "Installer smoke test").get("run") == (
+        "make install-smoke"
+    ), "windows-compat must install and execute the packaged installer"
     assert _find_step(windows_job, "Installer release dry run").get("run") == (
         "make release-installer-dry-run"
     ), "windows-compat must validate the host-platform installer release path"

--- a/tests/workflows/test_ci_workflow.py
+++ b/tests/workflows/test_ci_workflow.py
@@ -12,7 +12,8 @@ from ruamel.yaml import YAML
 WORKFLOW_PATH = Path(__file__).resolve().parents[2] / ".github/workflows/ci.yml"
 
 
-def _load_workflow_mapping() -> dict[str, Any]:
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
     """Load the CI workflow YAML and return it as a mapping."""
     parsed = YAML(typ="safe").load(WORKFLOW_PATH.read_text(encoding="utf-8"))
     match parsed:
@@ -88,9 +89,10 @@ def _find_step(job: Mapping[str, Any], name: str) -> dict[str, Any]:
     pytest.fail(f"CI job must include {name!r} step")
 
 
-def test_ci_splits_linux_and_windows_jobs_by_purpose() -> None:
+def test_ci_splits_linux_and_windows_jobs_by_purpose(
+    workflow: Mapping[str, Any],
+) -> None:
     """Ensure CI uses dedicated Linux and Windows jobs instead of a shared matrix."""
-    workflow = _load_workflow_mapping()
     jobs = _get_mapping_item(workflow, "jobs", parent_name="CI workflow")
 
     assert "build-test" not in jobs, (
@@ -118,9 +120,10 @@ def test_ci_splits_linux_and_windows_jobs_by_purpose() -> None:
     )
 
 
-def test_ci_enables_shared_sccache_env_and_debug_target_cache_scope() -> None:
+def test_ci_enables_shared_sccache_env_and_debug_target_cache_scope(
+    workflow: Mapping[str, Any],
+) -> None:
     """Ensure the workflow enables sccache and narrows cache scope to debug builds."""
-    workflow = _load_workflow_mapping()
     env = _get_mapping_item(workflow, "env", parent_name="CI workflow")
 
     assert env.get("BUILD_PROFILE") == "debug", (
@@ -144,9 +147,10 @@ def test_ci_enables_shared_sccache_env_and_debug_target_cache_scope() -> None:
     )
 
 
-def test_linux_full_keeps_the_full_linux_validation_stack() -> None:
+def test_linux_full_keeps_the_full_linux_validation_stack(
+    workflow: Mapping[str, Any],
+) -> None:
     """Ensure Linux remains the single lane for Linux-shaped validation work."""
-    workflow = _load_workflow_mapping()
     jobs = _get_mapping_item(workflow, "jobs", parent_name="CI workflow")
     linux_job = _get_mapping_item(jobs, "linux-full", parent_name="CI workflow jobs")
 
@@ -172,9 +176,10 @@ def test_linux_full_keeps_the_full_linux_validation_stack() -> None:
     )
 
 
-def test_windows_compat_stays_limited_to_windows_compatibility_checks() -> None:
+def test_windows_compat_stays_limited_to_windows_compatibility_checks(
+    workflow: Mapping[str, Any],
+) -> None:
     """Ensure Windows validates installer behaviour without Linux-only work."""
-    workflow = _load_workflow_mapping()
     jobs = _get_mapping_item(workflow, "jobs", parent_name="CI workflow")
     windows_job = _get_mapping_item(
         jobs,

--- a/tests/workflows/test_ci_workflow.py
+++ b/tests/workflows/test_ci_workflow.py
@@ -158,6 +158,10 @@ def test_linux_full_keeps_the_full_linux_validation_stack(
         _step_names(linux_job),
         [
             "Check formatting",
+            "Install bun",
+            "Install Mermaid CLI",
+            "Setup uv",
+            "Install Nixie",
             "Nixie",
             "Markdown lint",
             "Lint",

--- a/tests/workflows/test_release_installer_dry_run_makefile.py
+++ b/tests/workflows/test_release_installer_dry_run_makefile.py
@@ -36,10 +36,10 @@ def test_release_dry_run_checks_required_tools(
     """Ensure missing shell tools fail before build work starts."""
     assert "for tool in awk jq mktemp python rustc; do" in (
         release_installer_dry_run_recipe
-    )
+    ), "release-installer-dry-run must validate required shell tools"
     assert "Install $$tool to run release-installer-dry-run" in (
         release_installer_dry_run_recipe
-    )
+    ), "release-installer-dry-run must explain missing shell tools"
 
 
 def test_release_dry_run_detects_host_triple_with_rustc(
@@ -48,8 +48,10 @@ def test_release_dry_run_detects_host_triple_with_rustc(
     """Ensure archive naming and build output use the detected host triple."""
     assert "HOST_TRIPLE=$$(rustc -vV | awk -F ': ' '/host:/ {print $$2}')" in (
         release_installer_dry_run_recipe
-    )
-    assert "--target \"$$HOST_TRIPLE\"" in release_installer_dry_run_recipe
+    ), "HOST_TRIPLE detection must be emitted"
+    assert (
+        "--target \"$$HOST_TRIPLE\"" in release_installer_dry_run_recipe
+    ), "builds must target HOST_TRIPLE"
 
 
 def test_release_dry_run_builds_binaries_in_target_scoped_tree(
@@ -59,35 +61,43 @@ def test_release_dry_run_builds_binaries_in_target_scoped_tree(
     assert (
         "$(CARGO) build $(BUILD_JOBS) -p whitaker-installer --release "
         "--target \"$$HOST_TRIPLE\""
-    ) in release_installer_dry_run_recipe
+    ) in release_installer_dry_run_recipe, (
+        "builds must target HOST_TRIPLE and set INSTALLER_BIN/PACKAGER paths"
+    )
     assert (
         "$(CARGO) build $(BUILD_JOBS) --release -p whitaker-installer "
         "--bin whitaker-package-installer --target \"$$HOST_TRIPLE\""
-    ) in release_installer_dry_run_recipe
+    ) in release_installer_dry_run_recipe, (
+        "packager builds must target HOST_TRIPLE and set target-scoped paths"
+    )
     assert (
         'INSTALLER_BIN="target/$$HOST_TRIPLE/release/whitaker-installer"'
         in release_installer_dry_run_recipe
-    )
+    ), "INSTALLER_BIN must use the HOST_TRIPLE target tree"
     assert (
         'PACKAGER="./target/$$HOST_TRIPLE/release/whitaker-package-installer"'
         in release_installer_dry_run_recipe
-    )
+    ), "PACKAGER must use the HOST_TRIPLE target tree"
 
 
 def test_release_dry_run_uses_platform_archive_names(
     release_installer_dry_run_recipe: str,
 ) -> None:
     """Ensure Windows and non-Windows archives use the expected suffixes."""
-    assert 'ARCHIVE_GLOB="$$DIST_DIR/*.zip"' in release_installer_dry_run_recipe
-    assert 'ARCHIVE_GLOB="$$DIST_DIR/*.tgz"' in release_installer_dry_run_recipe
+    assert (
+        'ARCHIVE_GLOB="$$DIST_DIR/*.zip"' in release_installer_dry_run_recipe
+    ), "Windows branch must emit .zip archive glob"
+    assert (
+        'ARCHIVE_GLOB="$$DIST_DIR/*.tgz"' in release_installer_dry_run_recipe
+    ), "non-Windows branch must emit .tgz archive glob"
     assert (
         'INSTALLER_BIN="target/$$HOST_TRIPLE/release/whitaker-installer.exe"'
         in release_installer_dry_run_recipe
-    )
+    ), "Windows installer path must use the .exe suffix"
     assert (
         'PACKAGER="./target/$$HOST_TRIPLE/release/whitaker-package-installer.exe"'
         in release_installer_dry_run_recipe
-    )
+    ), "Windows packager path must use the .exe suffix"
 
 
 def test_release_dry_run_generates_and_validates_checksums(
@@ -96,11 +106,10 @@ def test_release_dry_run_generates_and_validates_checksums(
     """Ensure archive and checksum creation are both validated."""
     assert 'python scripts/generate_checksums.py "$$DIST_DIR"' in (
         release_installer_dry_run_recipe
-    )
+    ), "checksum generation and validation must be invoked"
     assert "Expected installer archive matching $$ARCHIVE_GLOB" in (
         release_installer_dry_run_recipe
-    )
+    ), "release dry run must validate archive creation"
     assert "Expected installer checksum in $$DIST_DIR" in (
         release_installer_dry_run_recipe
-    )
-
+    ), "release dry run must validate checksum creation"

--- a/tests/workflows/test_release_installer_dry_run_makefile.py
+++ b/tests/workflows/test_release_installer_dry_run_makefile.py
@@ -1,0 +1,106 @@
+"""Validate the installer release dry-run Makefile contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+MAKEFILE_PATH = Path(__file__).resolve().parents[2] / "Makefile"
+TARGET_NAME = "release-installer-dry-run"
+
+
+@pytest.fixture(scope="module")
+def release_installer_dry_run_recipe() -> str:
+    """Return the recipe body for the installer release dry-run target."""
+    lines = MAKEFILE_PATH.read_text(encoding="utf-8").splitlines()
+    target_header = f"{TARGET_NAME}:"
+    try:
+        target_index = next(
+            index for index, line in enumerate(lines) if line.startswith(target_header)
+        )
+    except StopIteration:
+        pytest.fail(f"Makefile must define {TARGET_NAME}")
+
+    recipe_lines: list[str] = []
+    for line in lines[target_index + 1 :]:
+        if line and not line.startswith(("\t", " ")):
+            break
+        recipe_lines.append(line)
+    return "\n".join(recipe_lines)
+
+
+def test_release_dry_run_checks_required_tools(
+    release_installer_dry_run_recipe: str,
+) -> None:
+    """Ensure missing shell tools fail before build work starts."""
+    assert "for tool in awk jq mktemp python rustc; do" in (
+        release_installer_dry_run_recipe
+    )
+    assert "Install $$tool to run release-installer-dry-run" in (
+        release_installer_dry_run_recipe
+    )
+
+
+def test_release_dry_run_detects_host_triple_with_rustc(
+    release_installer_dry_run_recipe: str,
+) -> None:
+    """Ensure archive naming and build output use the detected host triple."""
+    assert "HOST_TRIPLE=$$(rustc -vV | awk -F ': ' '/host:/ {print $$2}')" in (
+        release_installer_dry_run_recipe
+    )
+    assert "--target \"$$HOST_TRIPLE\"" in release_installer_dry_run_recipe
+
+
+def test_release_dry_run_builds_binaries_in_target_scoped_tree(
+    release_installer_dry_run_recipe: str,
+) -> None:
+    """Ensure ambient Cargo target settings cannot split binary outputs."""
+    assert (
+        "$(CARGO) build $(BUILD_JOBS) -p whitaker-installer --release "
+        "--target \"$$HOST_TRIPLE\""
+    ) in release_installer_dry_run_recipe
+    assert (
+        "$(CARGO) build $(BUILD_JOBS) --release -p whitaker-installer "
+        "--bin whitaker-package-installer --target \"$$HOST_TRIPLE\""
+    ) in release_installer_dry_run_recipe
+    assert (
+        'INSTALLER_BIN="target/$$HOST_TRIPLE/release/whitaker-installer"'
+        in release_installer_dry_run_recipe
+    )
+    assert (
+        'PACKAGER="./target/$$HOST_TRIPLE/release/whitaker-package-installer"'
+        in release_installer_dry_run_recipe
+    )
+
+
+def test_release_dry_run_uses_platform_archive_names(
+    release_installer_dry_run_recipe: str,
+) -> None:
+    """Ensure Windows and non-Windows archives use the expected suffixes."""
+    assert 'ARCHIVE_GLOB="$$DIST_DIR/*.zip"' in release_installer_dry_run_recipe
+    assert 'ARCHIVE_GLOB="$$DIST_DIR/*.tgz"' in release_installer_dry_run_recipe
+    assert (
+        'INSTALLER_BIN="target/$$HOST_TRIPLE/release/whitaker-installer.exe"'
+        in release_installer_dry_run_recipe
+    )
+    assert (
+        'PACKAGER="./target/$$HOST_TRIPLE/release/whitaker-package-installer.exe"'
+        in release_installer_dry_run_recipe
+    )
+
+
+def test_release_dry_run_generates_and_validates_checksums(
+    release_installer_dry_run_recipe: str,
+) -> None:
+    """Ensure archive and checksum creation are both validated."""
+    assert 'python scripts/generate_checksums.py "$$DIST_DIR"' in (
+        release_installer_dry_run_recipe
+    )
+    assert "Expected installer archive matching $$ARCHIVE_GLOB" in (
+        release_installer_dry_run_recipe
+    )
+    assert "Expected installer checksum in $$DIST_DIR" in (
+        release_installer_dry_run_recipe
+    )
+

--- a/tests/workflows/test_release_installer_dry_run_makefile.py
+++ b/tests/workflows/test_release_installer_dry_run_makefile.py
@@ -34,7 +34,13 @@ def test_release_dry_run_checks_required_tools(
     release_installer_dry_run_recipe: str,
 ) -> None:
     """Ensure missing shell tools fail before build work starts."""
-    assert "for tool in awk jq mktemp python rustc; do" in (
+    assert "PYTHON=$$(command -v python3 || command -v python || true)" in (
+        release_installer_dry_run_recipe
+    ), "release-installer-dry-run must resolve python3 or python"
+    assert "Install python3 or python to run release-installer-dry-run" in (
+        release_installer_dry_run_recipe
+    ), "release-installer-dry-run must explain missing Python tools"
+    assert "for tool in awk jq mktemp rustc; do" in (
         release_installer_dry_run_recipe
     ), "release-installer-dry-run must validate required shell tools"
     assert "Install $$tool to run release-installer-dry-run" in (
@@ -104,7 +110,7 @@ def test_release_dry_run_generates_and_validates_checksums(
     release_installer_dry_run_recipe: str,
 ) -> None:
     """Ensure archive and checksum creation are both validated."""
-    assert 'python scripts/generate_checksums.py "$$DIST_DIR"' in (
+    assert '"$$PYTHON" scripts/generate_checksums.py "$$DIST_DIR"' in (
         release_installer_dry_run_recipe
     ), "checksum generation and validation must be invoked"
     assert "Expected installer archive matching $$ARCHIVE_GLOB" in (

--- a/tests/workflows/test_release_installer_dry_run_makefile.py
+++ b/tests/workflows/test_release_installer_dry_run_makefile.py
@@ -40,6 +40,9 @@ def test_release_dry_run_checks_required_tools(
     assert "Install python3 or python to run release-installer-dry-run" in (
         release_installer_dry_run_recipe
     ), "release-installer-dry-run must explain missing Python tools"
+    assert '[ -n "$(CARGO)" ] || { echo "Install cargo to run release-installer-dry-run"; exit 1; }' in (
+        release_installer_dry_run_recipe
+    ), "release-installer-dry-run must validate the Cargo command"
     assert "for tool in awk jq mktemp rustc; do" in (
         release_installer_dry_run_recipe
     ), "release-installer-dry-run must validate required shell tools"
@@ -65,17 +68,14 @@ def test_release_dry_run_builds_binaries_in_target_scoped_tree(
 ) -> None:
     """Ensure ambient Cargo target settings cannot split binary outputs."""
     assert (
-        "$(CARGO) build $(BUILD_JOBS) -p whitaker-installer --release "
-        "--target \"$$HOST_TRIPLE\""
-    ) in release_installer_dry_run_recipe, (
-        "builds must target HOST_TRIPLE and set INSTALLER_BIN/PACKAGER paths"
-    )
+        "--target \"$$HOST_TRIPLE\"" in release_installer_dry_run_recipe
+    ), "builds must target HOST_TRIPLE"
     assert (
-        "$(CARGO) build $(BUILD_JOBS) --release -p whitaker-installer "
-        "--bin whitaker-package-installer --target \"$$HOST_TRIPLE\""
-    ) in release_installer_dry_run_recipe, (
-        "packager builds must target HOST_TRIPLE and set target-scoped paths"
-    )
+        "whitaker-installer" in release_installer_dry_run_recipe
+    ), "builds must include the whitaker-installer package"
+    assert (
+        "whitaker-package-installer" in release_installer_dry_run_recipe
+    ), "builds must include the whitaker-package-installer binary"
     assert (
         'INSTALLER_BIN="target/$$HOST_TRIPLE/release/whitaker-installer"'
         in release_installer_dry_run_recipe


### PR DESCRIPTION
## Summary
- Reorganizes CI workflow to use purpose-built Linux and Windows lanes instead of a shared matrix.
- Enables sccache-backed caching with targeted debug builds to keep cache scope small.
- Introduces Windows-focused validation lane to verify Windows builds, installer behavior, and release packaging steps.

## Changes
### CI workflow
- Replace shared build-test matrix with two standalone jobs:
  - linux-full (Linux Ubicloud runner) for formatting, Mermaid, Nixie, Markdown lint, lint, and publish-check.
  - windows-compat (Windows runner) for tests, installer release dry-run, and sccache stats.
- Enable common envs for caching:
  - BUILD_PROFILE=debug, CARGO_INCREMENTAL=0, RUSTFLAGS=-D warnings, RUSTDOCFLAGS=-D warnings, SCCACHE_GHA_ENABLED=true, RUSTC_WRAPPER=sccache.
- Install and pin cargo-nextest (Nextest 0.9.114) for test execution.
- Linux: install bun (1.2.21) after formatting; preserve full validation stack including Nixie and Mermaid CLI.
- Windows: run tests (NEXTEST_PROFILE=ci), then installer release dry-run, then show sccache stats.
- Remove the old matrix job and matrix-based coverage/upload steps.
- Remove CodeScene coverage upload and matrix-based coverage handling from the CI workflow.

### Docs
- Update developers guide to describe new CI lane responsibilities and goals.

### Tests
- Add tests/workflows/test_ci_workflow.py to validate the CI YAML structure and contracts for Linux-full and Windows-compat lanes.

## Why
- Improves CI reliability and reduces runner-specific noise by aligning jobs with platform capabilities and responsibilities.
- Keeps caching efficient by narrowing the target cache scope to debug builds via BUILD_PROFILE and sccache.

## How to test
- Run pytest tests/workflows/test_ci_workflow.py to verify YAML contracts.
- Review CI run on pull request to confirm linux-full covers formatting and lint; windows-compat runs tests and installer release dry-run.
- Check sccache stats appear on Windows job.

## Additional notes
- No user-facing changes; CI improvements aim to speed up feedback and reduce flaky cross-platform steps.

📎 **Task**: https://www.devboxer.com/task/3f360cc8-28fe-4211-af88-dbfad4398cd0

## Summary by Sourcery

Split CI into dedicated Linux and Windows jobs with shared sccache-backed debug configuration and add installer release dry-run support for Windows.

New Features:
- Add a release-installer-dry-run make target to build, package, and checksum a host-platform installer archive for validation.
- Introduce a Windows-focused CI job that runs tests, validates installer release packaging, and reports sccache stats.
- Introduce a Linux-focused CI job that performs formatting, documentation-related checks, linting, and publish dry-run validation.

Enhancements:
- Configure global CI environment variables to enable sccache-backed caching and narrow build scope to debug artifacts.
- Replace the matrix-based build-test workflow with purpose-built linux-full and windows-compat jobs.
- Document the responsibilities of the linux-full and windows-compat CI lanes in the developer guide and publishing docs.

CI:
- Refactor the CI workflow to remove the shared matrix job and CodeScene coverage upload, replacing them with explicit Linux and Windows jobs.

Documentation:
- Update developer and publishing documentation to describe the new installer dry-run target and the split CI lane responsibilities.

Tests:
- Add workflow contract tests to validate the structure and behavior of the linux-full and windows-compat CI jobs.