### PR TITLE
Support provisioning rustc-codegen-cranelift in installer

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -981,6 +981,66 @@ libraries = [
 
 This skips building entirely, providing faster lint runs during development.
 
+### Installer internal architecture
+
+`installer/src/main.rs` co-ordinates the install workflow through a small
+set of focused private helpers. Understanding them is useful when extending
+the install pipeline.
+
+#### `resolve_additional_components`
+
+```rust
+fn resolve_additional_components(args: &InstallArgs) -> &'static [&'static str]
+```
+
+Translates CLI flags into the extra rustup component slice passed to
+`ensure_toolchain_installed`. At present the only flag it handles is
+`--cranelift`, which adds `rustc-codegen-cranelift` to the component set.
+Adding a new optional component requires a new CLI flag on `InstallArgs` and
+a new arm in this function; no other callers need to change.
+
+#### `FastPathContext`
+
+```rust
+struct FastPathContext<'a> {
+    args: &'a InstallArgs,
+    dirs: &'a dyn BaseDirs,
+    requested_crates: &'a [CrateName],
+    toolchain: &'a Toolchain,
+    target_dir: &'a Utf8PathBuf,
+}
+```
+
+A parameter-object struct that bundles the five immutable inputs consumed by
+`try_fast_path_installation`. This follows the same idiom used elsewhere in
+the codebase (`FinishInstallContext`, `PrebuiltInstallationContext`,
+`MetricsWriteContext`) to keep function argument counts within the project
+threshold of four. Construct it in `run_install` before calling
+`try_fast_path_installation`.
+
+#### `try_fast_path_installation`
+
+```rust
+fn try_fast_path_installation(
+    context: &FastPathContext<'_>,
+    stderr: &mut dyn Write,
+) -> Result<Option<(Utf8PathBuf, InstallMode)>>
+```
+
+Attempts both fast paths in order and returns `Some((staging_path, mode))`
+if either succeeds, or `None` if `run_install` should proceed to a full
+build:
+
+1. **Prebuilt download** (`InstallMode::Download`) — delegates to
+   `try_prebuilt_installation` inside `install_flow`.
+2. **Staged-suite shortcut** (`InstallMode::Build`) — delegates to
+   `staged_suite::try_test_staged_suite_installation`, which is only active
+   when `WHITAKER_INSTALLER_TEST_STAGE_SUITE=1` is set (debug builds only).
+
+When `try_fast_path_installation` returns `Some`, `run_install` constructs a
+`FinishInstallContext` from the returned values and delegates to
+`finish_install_and_record_metrics`, skipping the full build pipeline.
+
 ## Standard vs Experimental Lints
 
 Whitaker categorizes lints into two tiers:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -983,9 +983,9 @@ This skips building entirely, providing faster lint runs during development.
 
 ### Installer internal architecture
 
-`installer/src/main.rs` co-ordinates the install workflow through a small
-set of focused private helpers. Understanding them is useful when extending
-the install pipeline.
+`installer/src/main.rs` coordinates the installation workflow through a small
+set of focused private helpers. Understanding them is useful when extending the
+installation pipeline.
 
 #### `resolve_additional_components`
 
@@ -994,10 +994,10 @@ fn resolve_additional_components(args: &InstallArgs) -> &'static [&'static str]
 ```
 
 Translates CLI flags into the extra rustup component slice passed to
-`ensure_toolchain_installed`. At present the only flag it handles is
+`ensure_toolchain_installed`. At present, the only flag it handles is
 `--cranelift`, which adds `rustc-codegen-cranelift` to the component set.
-Adding a new optional component requires a new CLI flag on `InstallArgs` and
-a new arm in this function; no other callers need to change.
+Adding a new optional component requires a new CLI flag on `InstallArgs` and a
+new arm in this function; no other callers need to change.
 
 #### `FastPathContext`
 
@@ -1012,8 +1012,8 @@ struct FastPathContext<'a> {
 ```
 
 A parameter-object struct that bundles the five immutable inputs consumed by
-`try_fast_path_installation`. This follows the same idiom used elsewhere in
-the codebase (`FinishInstallContext`, `PrebuiltInstallationContext`,
+`try_fast_path_installation`. This follows the same idiom used elsewhere in the
+codebase (`FinishInstallContext`, `PrebuiltInstallationContext`,
 `MetricsWriteContext`) to keep function argument counts within the project
 threshold of four. Construct it in `run_install` before calling
 `try_fast_path_installation`.
@@ -1027,9 +1027,8 @@ fn try_fast_path_installation(
 ) -> Result<Option<(Utf8PathBuf, InstallMode)>>
 ```
 
-Attempts both fast paths in order and returns `Some((staging_path, mode))`
-if either succeeds, or `None` if `run_install` should proceed to a full
-build:
+Attempts both fast paths in order and returns `Some((staging_path, mode))` if
+either succeeds, or `None` if `run_install` should proceed to a full build:
 
 1. **Prebuilt download** (`InstallMode::Download`) — delegates to
    `try_prebuilt_installation` inside `install_flow`.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -944,6 +944,7 @@ Whitaker data directory keyed by toolchain and target:
 - `--individual-lints` — Build individual crates instead of the suite
 - `--experimental` — Include experimental lints in the build (none currently)
 - `--toolchain TOOLCHAIN` — Override the detected toolchain
+- `--cranelift` — Install `rustc-codegen-cranelift` for the selected toolchain
 - `-j, --jobs N` — Number of parallel build jobs
 - `--dry-run` — Show what would be done without running
 - `-v, --verbose` — Increase output verbosity (repeatable)

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -64,13 +64,12 @@ environment-variable workaround.
 
 **Options:**
 
-- `--cranelift` — Install `rustc-codegen-cranelift` for the selected
-  toolchain. `rustc-codegen-cranelift` is an alternative Rust compiler
-  back-end based on the Cranelift code generator. It is not bundled with
-  the standard nightly toolchain components and must be added explicitly via
-  `rustup component add`. Use this flag when your project or CI environment
-  requires the Cranelift back-end, or when a `rustc-codegen-cranelift`
-  component add step would otherwise need to precede the installer invocation.
+- `--cranelift` — Tell the installer to add the
+  `rustc-codegen-cranelift` component via `rustup component add`. The
+  `rustc-codegen-cranelift` component is not included in the standard nightly
+  toolchain, so enable `--cranelift` when your project or CI requires the
+  Cranelift back-end and you would otherwise need an explicit
+  `rustc-codegen-cranelift` component-add step before running the installer.
 - `--skip-deps` — Skip `cargo-dylint`/`dylint-link` installation check
 - `--skip-wrapper` — Skip wrapper script generation (prints
   `DYLINT_LIBRARY_PATH` instructions instead)

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -64,7 +64,13 @@ environment-variable workaround.
 
 **Options:**
 
-- `--cranelift` — Install `rustc-codegen-cranelift` for the selected toolchain
+- `--cranelift` — Install `rustc-codegen-cranelift` for the selected
+  toolchain. `rustc-codegen-cranelift` is an alternative Rust compiler
+  back-end based on the Cranelift code generator. It is not bundled with
+  the standard nightly toolchain components and must be added explicitly via
+  `rustup component add`. Use this flag when your project or CI environment
+  requires the Cranelift back-end, or when a `rustc-codegen-cranelift`
+  component add step would otherwise need to precede the installer invocation.
 - `--skip-deps` — Skip `cargo-dylint`/`dylint-link` installation check
 - `--skip-wrapper` — Skip wrapper script generation (prints
   `DYLINT_LIBRARY_PATH` instructions instead)

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -64,6 +64,7 @@ environment-variable workaround.
 
 **Options:**
 
+- `--cranelift` — Install `rustc-codegen-cranelift` for the selected toolchain
 - `--skip-deps` — Skip `cargo-dylint`/`dylint-link` installation check
 - `--skip-wrapper` — Skip wrapper script generation (prints
   `DYLINT_LIBRARY_PATH` instructions instead)

--- a/installer/README.md
+++ b/installer/README.md
@@ -8,12 +8,12 @@ builds, links, and stages the lint libraries for local use, avoiding the need
 to rebuild from source on each `cargo dylint` invocation. It also ensures the
 pinned Rust toolchain and required components are installed via rustup.
 
-Pass `--cranelift` when the selected Rust toolchain requires the
-`rustc-codegen-cranelift` rustup component. `rustc-codegen-cranelift` is an
-alternative compiler back-end that uses the Cranelift code generator instead
-of LLVM, which can produce faster debug builds. Some Whitaker configurations
-(or CI environments that pre-install it) require it to be available alongside
-the standard toolchain components. Without `--cranelift`, the installer only
+Pass `--cranelift` when your project, CI, or build configuration requires the
+Cranelift back-end (`rustc-codegen-cranelift`). `rustc-codegen-cranelift` is an
+alternative compiler back-end that uses the Cranelift code generator instead of
+LLVM, which can produce faster debug builds. Some Whitaker configurations (or
+CI environments that pre-install it) require it to be available alongside the
+standard toolchain components. Without `--cranelift`, the installer only
 provisions `REQUIRED_COMPONENTS`; the flag adds `rustc-codegen-cranelift` to
 that set so `rustup component add` includes it in a single step.
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -14,9 +14,9 @@ alternative compiler back-end that uses the Cranelift code generator instead of
 LLVM, which can produce faster debug builds. Some Whitaker configurations (or
 CI environments that pre-install it) require it to be available alongside the
 standard toolchain components. Without `--cranelift`, the installer only
-provisions the standard required toolchain components (`rust-src`, `rustc-dev`,
-and `llvm-tools-preview`); the flag adds `rustc-codegen-cranelift` to that set
-so `rustup component add` includes it in a single step.
+provisions the standard required toolchain components; the flag adds
+`rustc-codegen-cranelift` to that set so `rustup component add` includes it in
+a single step.
 
 ## Installation
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -8,8 +8,14 @@ builds, links, and stages the lint libraries for local use, avoiding the need
 to rebuild from source on each `cargo dylint` invocation. It also ensures the
 pinned Rust toolchain and required components are installed via rustup.
 
-Pass `--cranelift` when the selected toolchain also needs the
-`rustc-codegen-cranelift` rustup component.
+Pass `--cranelift` when the selected Rust toolchain requires the
+`rustc-codegen-cranelift` rustup component. `rustc-codegen-cranelift` is an
+alternative compiler back-end that uses the Cranelift code generator instead
+of LLVM, which can produce faster debug builds. Some Whitaker configurations
+(or CI environments that pre-install it) require it to be available alongside
+the standard toolchain components. Without `--cranelift`, the installer only
+provisions `REQUIRED_COMPONENTS`; the flag adds `rustc-codegen-cranelift` to
+that set so `rustup component add` includes it in a single step.
 
 ## Installation
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -8,6 +8,9 @@ builds, links, and stages the lint libraries for local use, avoiding the need
 to rebuild from source on each `cargo dylint` invocation. It also ensures the
 pinned Rust toolchain and required components are installed via rustup.
 
+Pass `--cranelift` when the selected toolchain also needs the
+`rustc-codegen-cranelift` rustup component.
+
 ## Installation
 
 ```bash

--- a/installer/README.md
+++ b/installer/README.md
@@ -14,8 +14,9 @@ alternative compiler back-end that uses the Cranelift code generator instead of
 LLVM, which can produce faster debug builds. Some Whitaker configurations (or
 CI environments that pre-install it) require it to be available alongside the
 standard toolchain components. Without `--cranelift`, the installer only
-provisions `REQUIRED_COMPONENTS`; the flag adds `rustc-codegen-cranelift` to
-that set so `rustup component add` includes it in a single step.
+provisions the standard required toolchain components (`rust-src`, `rustc-dev`,
+and `llvm-tools-preview`); the flag adds `rustc-codegen-cranelift` to that set
+so `rustup component add` includes it in a single step.
 
 ## Installation
 

--- a/installer/src/cli.rs
+++ b/installer/src/cli.rs
@@ -100,11 +100,7 @@ pub struct InstallArgs {
     pub toolchain: Option<String>,
 
     /// Install rustc-codegen-cranelift via rustup.
-    #[arg(
-        long,
-        default_value_t = false,
-        help = "Install rustc-codegen-cranelift via rustup"
-    )]
+    #[arg(long, default_value_t = false)]
     pub cranelift: bool,
 
     /// Show configuration and exit without building.

--- a/installer/src/cli.rs
+++ b/installer/src/cli.rs
@@ -99,6 +99,14 @@ pub struct InstallArgs {
     #[arg(long, value_name = "TOOLCHAIN")]
     pub toolchain: Option<String>,
 
+    /// Install rustc-codegen-cranelift via rustup.
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Install rustc-codegen-cranelift via rustup"
+    )]
+    pub cranelift: bool,
+
     /// Show configuration and exit without building.
     #[arg(long)]
     pub dry_run: bool,
@@ -207,6 +215,7 @@ impl Default for InstallArgs {
             experimental: false,
             jobs: None,
             toolchain: None,
+            cranelift: false,
             dry_run: false,
             verbosity: 0,
             quiet: false,

--- a/installer/src/cli_tests.rs
+++ b/installer/src/cli_tests.rs
@@ -11,6 +11,7 @@ fn cli_parses_defaults() {
     assert!(cli.install.lint.is_empty());
     assert!(!cli.install.individual_lints);
     assert!(!cli.install.experimental);
+    assert!(!cli.install.cranelift);
     assert!(!cli.install.dry_run);
     assert_eq!(cli.install.verbosity, 0);
     assert!(!cli.install.quiet);
@@ -129,6 +130,7 @@ fn should_attempt_prebuilt_true_for_stable_bumpy_road_requests() {
 #[rstest]
 #[case::individual_lints(&["whitaker-installer", "--individual-lints"], |cli: &Cli| cli.install.individual_lints)]
 #[case::experimental(&["whitaker-installer", "--experimental"], |cli: &Cli| cli.install.experimental)]
+#[case::cranelift(&["whitaker-installer", "--cranelift"], |cli: &Cli| cli.install.cranelift)]
 #[case::dry_run(&["whitaker-installer", "--dry-run"], |cli: &Cli| cli.install.dry_run)]
 #[case::verbose(&["whitaker-installer", "-v"], |cli: &Cli| cli.install.verbosity > 0)]
 #[case::quiet(&["whitaker-installer", "-q"], |cli: &Cli| cli.install.quiet)]
@@ -165,6 +167,7 @@ fn install_args_default_is_valid() {
     let args = InstallArgs::default();
     assert!(!args.individual_lints);
     assert!(!args.experimental);
+    assert!(!args.cranelift);
     assert!(!args.skip_deps);
 }
 

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -66,30 +66,24 @@ fn resolve_additional_components(args: &InstallArgs) -> &'static [&'static str] 
 ///
 /// Returns `Some((staging_path, mode))` if either succeeds, or `None` if
 /// the caller should proceed to a full build.
-#[allow(
-    clippy::too_many_arguments,
-    reason = "The requested helper signature is part of the task contract."
-)]
 fn try_fast_path_installation(
-    args: &InstallArgs,
-    dirs: &dyn BaseDirs,
-    requested_crates: &[CrateName],
-    toolchain: &Toolchain,
-    target_dir: &Utf8PathBuf,
+    context: &FastPathContext<'_>,
     stderr: &mut dyn Write,
 ) -> Result<Option<(Utf8PathBuf, InstallMode)>> {
     let prebuilt_context = PrebuiltInstallationContext {
-        args,
-        dirs,
-        requested_crates,
-        toolchain_channel: toolchain.channel(),
+        args: context.args,
+        dirs: context.dirs,
+        requested_crates: context.requested_crates,
+        toolchain_channel: context.toolchain.channel(),
     };
     if let Some(staging_path) = try_prebuilt_installation(&prebuilt_context, stderr)? {
         return Ok(Some((staging_path, InstallMode::Download)));
     }
-    if let Some(staging_path) =
-        staged_suite::try_test_staged_suite_installation(requested_crates, toolchain, target_dir)?
-    {
+    if let Some(staging_path) = staged_suite::try_test_staged_suite_installation(
+        context.requested_crates,
+        context.toolchain,
+        context.target_dir,
+    )? {
         return Ok(Some((staging_path, InstallMode::Build)));
     }
     Ok(None)
@@ -129,14 +123,16 @@ fn run_install(args: &InstallArgs, stderr: &mut dyn Write) -> Result<()> {
     )?;
     let target_dir = determine_target_dir(args.target_dir.as_deref())?;
     // Step 3.5: Attempt prebuilt download or staged-suite fast path.
-    if let Some((staging_path, install_mode)) = try_fast_path_installation(
+    let fast_path_context = FastPathContext {
         args,
-        &dirs,
-        &requested_crates,
-        &toolchain,
-        &target_dir,
-        stderr,
-    )? {
+        dirs: &dirs,
+        requested_crates: &requested_crates,
+        toolchain: &toolchain,
+        target_dir: &target_dir,
+    };
+    if let Some((staging_path, install_mode)) =
+        try_fast_path_installation(&fast_path_context, stderr)?
+    {
         let finish_context = FinishInstallContext {
             args,
             dirs: &dirs,
@@ -302,6 +298,15 @@ struct FinishInstallContext<'a> {
     staging_path: &'a Utf8Path,
     install_mode: InstallMode,
     install_started: Instant,
+}
+
+/// Aggregates the immutable inputs for fast-path installation attempts.
+struct FastPathContext<'a> {
+    args: &'a InstallArgs,
+    dirs: &'a dyn BaseDirs,
+    requested_crates: &'a [CrateName],
+    toolchain: &'a Toolchain,
+    target_dir: &'a Utf8PathBuf,
 }
 
 /// Finalise installation and record aggregate installer metrics.

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -79,12 +79,12 @@ fn run_install(args: &InstallArgs, stderr: &mut dyn Write) -> Result<()> {
     // Step 3: Resolve crates and toolchain
     let requested_crates = resolve_requested_crates(args)?;
     let toolchain = resolve_toolchain(&workspace_root, args.toolchain.as_deref())?;
-    let additional_components: &[&str] = if args.cranelift {
-        &["rustc-codegen-cranelift"]
-    } else {
-        &[]
-    };
-    ensure_toolchain_installed(&toolchain, additional_components, args.quiet, stderr)?;
+    ensure_toolchain_installed(
+        &toolchain,
+        resolve_additional_components(args),
+        args.quiet,
+        stderr,
+    )?;
     let target_dir = determine_target_dir(args.target_dir.as_deref())?;
     // Step 3.5: Attempt prebuilt download when install options allow it.
     let prebuilt_context = PrebuiltInstallationContext {
@@ -230,6 +230,15 @@ fn resolve_toolchain(
     match override_channel {
         Some(channel) => Ok(Toolchain::with_override(workspace_root, channel)),
         None => Toolchain::detect(workspace_root),
+    }
+}
+
+/// Returns the set of additional rustup components requested by the CLI flags.
+fn resolve_additional_components(args: &InstallArgs) -> &'static [&'static str] {
+    if args.cranelift {
+        &["rustc-codegen-cranelift"]
+    } else {
+        &[]
     }
 }
 

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -53,6 +53,48 @@ fn run(cli: &Cli, stdout: &mut dyn Write, stderr: &mut dyn Write) -> Result<()> 
     }
 }
 
+/// Returns the set of additional rustup components requested by the CLI flags.
+fn resolve_additional_components(args: &InstallArgs) -> &'static [&'static str] {
+    if args.cranelift {
+        &["rustc-codegen-cranelift"]
+    } else {
+        &[]
+    }
+}
+
+/// Attempts prebuilt download and staged-suite fast paths.
+///
+/// Returns `Some((staging_path, mode))` if either succeeds, or `None` if
+/// the caller should proceed to a full build.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "The requested helper signature is part of the task contract."
+)]
+fn try_fast_path_installation(
+    args: &InstallArgs,
+    dirs: &dyn BaseDirs,
+    requested_crates: &[CrateName],
+    toolchain: &Toolchain,
+    target_dir: &Utf8PathBuf,
+    stderr: &mut dyn Write,
+) -> Result<Option<(Utf8PathBuf, InstallMode)>> {
+    let prebuilt_context = PrebuiltInstallationContext {
+        args,
+        dirs,
+        requested_crates,
+        toolchain_channel: toolchain.channel(),
+    };
+    if let Some(staging_path) = try_prebuilt_installation(&prebuilt_context, stderr)? {
+        return Ok(Some((staging_path, InstallMode::Download)));
+    }
+    if let Some(staging_path) =
+        staged_suite::try_test_staged_suite_installation(requested_crates, toolchain, target_dir)?
+    {
+        return Ok(Some((staging_path, InstallMode::Build)));
+    }
+    Ok(None)
+}
+
 /// Runs the install command to build and stage lint libraries.
 ///
 /// Workflow: (1) check/install Dylint dependencies, (2) locate/clone workspace,
@@ -86,33 +128,20 @@ fn run_install(args: &InstallArgs, stderr: &mut dyn Write) -> Result<()> {
         stderr,
     )?;
     let target_dir = determine_target_dir(args.target_dir.as_deref())?;
-    // Step 3.5: Attempt prebuilt download when install options allow it.
-    let prebuilt_context = PrebuiltInstallationContext {
+    // Step 3.5: Attempt prebuilt download or staged-suite fast path.
+    if let Some((staging_path, install_mode)) = try_fast_path_installation(
         args,
-        dirs: &dirs,
-        requested_crates: &requested_crates,
-        toolchain_channel: toolchain.channel(),
-    };
-    if let Some(staging_path) = try_prebuilt_installation(&prebuilt_context, stderr)? {
-        let finish_context = FinishInstallContext {
-            args,
-            dirs: &dirs,
-            staging_path: &staging_path,
-            install_mode: InstallMode::Download,
-            install_started,
-        };
-        return finish_install_and_record_metrics(&finish_context, stderr);
-    }
-    if let Some(staging_path) = staged_suite::try_test_staged_suite_installation(
+        &dirs,
         &requested_crates,
         &toolchain,
         &target_dir,
+        stderr,
     )? {
         let finish_context = FinishInstallContext {
             args,
             dirs: &dirs,
             staging_path: &staging_path,
-            install_mode: InstallMode::Build,
+            install_mode,
             install_started,
         };
         return finish_install_and_record_metrics(&finish_context, stderr);
@@ -230,15 +259,6 @@ fn resolve_toolchain(
     match override_channel {
         Some(channel) => Ok(Toolchain::with_override(workspace_root, channel)),
         None => Toolchain::detect(workspace_root),
-    }
-}
-
-/// Returns the set of additional rustup components requested by the CLI flags.
-fn resolve_additional_components(args: &InstallArgs) -> &'static [&'static str] {
-    if args.cranelift {
-        &["rustc-codegen-cranelift"]
-    } else {
-        &[]
     }
 }
 

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -79,7 +79,12 @@ fn run_install(args: &InstallArgs, stderr: &mut dyn Write) -> Result<()> {
     // Step 3: Resolve crates and toolchain
     let requested_crates = resolve_requested_crates(args)?;
     let toolchain = resolve_toolchain(&workspace_root, args.toolchain.as_deref())?;
-    ensure_toolchain_installed(&toolchain, args.quiet, stderr)?;
+    let additional_components: &[&str] = if args.cranelift {
+        &["rustc-codegen-cranelift"]
+    } else {
+        &[]
+    };
+    ensure_toolchain_installed(&toolchain, additional_components, args.quiet, stderr)?;
     let target_dir = determine_target_dir(args.target_dir.as_deref())?;
     // Step 3.5: Attempt prebuilt download when install options allow it.
     let prebuilt_context = PrebuiltInstallationContext {
@@ -230,10 +235,11 @@ fn resolve_toolchain(
 
 fn ensure_toolchain_installed(
     toolchain: &Toolchain,
+    additional_components: &[&str],
     quiet: bool,
     stderr: &mut dyn Write,
 ) -> Result<()> {
-    let status = toolchain.ensure_installed()?;
+    let status = toolchain.ensure_installed(additional_components)?;
     if status.installed_toolchain() && !quiet {
         write_stderr_line(
             stderr,

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -161,6 +161,7 @@ fn try_fast_path_installation_returns_none_when_prebuilt_disabled() {
 
     let _guard = env_test_guard();
     let args = InstallArgs {
+        is_build_only: true,
         lint: vec!["module_max_lines".to_owned()],
         ..InstallArgs::default()
     };

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -4,11 +4,13 @@ use super::*;
 use rstest::{fixture, rstest};
 use std::path::PathBuf;
 use std::time::Duration;
+use temp_env::with_var_unset;
 use whitaker_installer::cli::InstallArgs;
 use whitaker_installer::dependency_binaries::DependencyBinaryInstaller;
 use whitaker_installer::deps::DependencyInstallOptions;
 use whitaker_installer::dirs::BaseDirs;
 use whitaker_installer::installer_packaging::TargetTriple;
+use whitaker_installer::test_support::{TEST_STAGE_SUITE_ENV, env_test_guard};
 use whitaker_installer::test_utils::dependency_binary_helpers::{
     AlwaysNotFoundRepositoryInstaller, with_fake_binary_on_path,
 };
@@ -104,6 +106,93 @@ fn resolve_requested_crates_rejects_unknown_lints() {
         err,
         InstallerError::LintCrateNotFound { name } if name == CrateName::from("nonexistent_lint")
     ));
+}
+
+#[test]
+fn resolve_additional_components_returns_empty_when_cranelift_false() {
+    let args = InstallArgs::default();
+    assert!(resolve_additional_components(&args).is_empty());
+}
+
+#[test]
+fn resolve_additional_components_returns_cranelift_when_flag_set() {
+    let args = InstallArgs {
+        cranelift: true,
+        ..InstallArgs::default()
+    };
+    let components = resolve_additional_components(&args);
+    assert_eq!(components, &["rustc-codegen-cranelift"]);
+}
+
+#[test]
+fn fast_path_context_holds_supplied_values() {
+    use camino::Utf8PathBuf;
+    use whitaker_installer::toolchain::Toolchain;
+
+    let args = InstallArgs::default();
+    let dirs = TestBaseDirs {
+        home_dir: Some("/tmp".into()),
+        bin_dir: Some("/tmp/bin".into()),
+        data_dir: Some("/tmp".into()),
+    };
+    let toolchain = Toolchain {
+        channel: "nightly-2025-09-18".to_owned(),
+        workspace_root: Utf8PathBuf::from("."),
+    };
+    let target_dir = Utf8PathBuf::from("/tmp/target");
+    let crates: Vec<whitaker_installer::crate_name::CrateName> = vec![];
+
+    let ctx = FastPathContext {
+        args: &args,
+        dirs: &dirs,
+        requested_crates: &crates,
+        toolchain: &toolchain,
+        target_dir: &target_dir,
+    };
+
+    assert!(std::ptr::eq(ctx.args, &args));
+    assert_eq!(ctx.dirs.home_dir(), Some(PathBuf::from("/tmp")));
+    assert_eq!(ctx.toolchain.channel(), "nightly-2025-09-18");
+    assert_eq!(ctx.target_dir, &Utf8PathBuf::from("/tmp/target"));
+    assert!(ctx.requested_crates.is_empty());
+}
+
+#[test]
+fn try_fast_path_installation_returns_none_when_prebuilt_disabled() {
+    use camino::Utf8PathBuf;
+    use whitaker_installer::toolchain::Toolchain;
+
+    let _guard = env_test_guard();
+    let args = InstallArgs {
+        lint: vec!["module_max_lines".to_owned()],
+        ..InstallArgs::default()
+    };
+    let dirs = TestBaseDirs {
+        home_dir: Some("/tmp".into()),
+        bin_dir: Some("/tmp/bin".into()),
+        data_dir: Some("/tmp".into()),
+    };
+    let toolchain = Toolchain {
+        channel: "nightly-2025-09-18".to_owned(),
+        workspace_root: Utf8PathBuf::from("."),
+    };
+    let target_dir = Utf8PathBuf::from("/tmp/target");
+    let crates = vec![whitaker_installer::crate_name::CrateName::from(
+        "module_max_lines",
+    )];
+    let ctx = FastPathContext {
+        args: &args,
+        dirs: &dirs,
+        requested_crates: &crates,
+        toolchain: &toolchain,
+        target_dir: &target_dir,
+    };
+
+    with_var_unset(TEST_STAGE_SUITE_ENV, || {
+        let mut stderr = Vec::new();
+        let result = try_fast_path_installation(&ctx, &mut stderr).expect("should not error");
+        assert!(result.is_none());
+    });
 }
 
 #[rstest]

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -126,7 +126,7 @@ fn resolve_additional_components_returns_cranelift_when_flag_set() {
 
 #[test]
 fn fast_path_context_holds_supplied_values() {
-    use camino::Utf8PathBuf;
+    use camino::{Utf8Path, Utf8PathBuf};
     use whitaker_installer::toolchain::Toolchain;
 
     let args = InstallArgs::default();
@@ -135,10 +135,7 @@ fn fast_path_context_holds_supplied_values() {
         bin_dir: Some("/tmp/bin".into()),
         data_dir: Some("/tmp".into()),
     };
-    let toolchain = Toolchain {
-        channel: "nightly-2025-09-18".to_owned(),
-        workspace_root: Utf8PathBuf::from("."),
-    };
+    let toolchain = Toolchain::with_override(Utf8Path::new("."), "nightly-2025-09-18");
     let target_dir = Utf8PathBuf::from("/tmp/target");
     let crates: Vec<whitaker_installer::crate_name::CrateName> = vec![];
 
@@ -159,7 +156,7 @@ fn fast_path_context_holds_supplied_values() {
 
 #[test]
 fn try_fast_path_installation_returns_none_when_prebuilt_disabled() {
-    use camino::Utf8PathBuf;
+    use camino::{Utf8Path, Utf8PathBuf};
     use whitaker_installer::toolchain::Toolchain;
 
     let _guard = env_test_guard();
@@ -172,10 +169,7 @@ fn try_fast_path_installation_returns_none_when_prebuilt_disabled() {
         bin_dir: Some("/tmp/bin".into()),
         data_dir: Some("/tmp".into()),
     };
-    let toolchain = Toolchain {
-        channel: "nightly-2025-09-18".to_owned(),
-        workspace_root: Utf8PathBuf::from("."),
-    };
+    let toolchain = Toolchain::with_override(Utf8Path::new("."), "nightly-2025-09-18");
     let target_dir = Utf8PathBuf::from("/tmp/target");
     let crates = vec![whitaker_installer::crate_name::CrateName::from(
         "module_max_lines",

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -1,16 +1,16 @@
 //! Tests for the installer CLI entrypoint.
 
+mod fast_path;
+
 use super::*;
 use rstest::{fixture, rstest};
 use std::path::PathBuf;
 use std::time::Duration;
-use temp_env::with_var_unset;
 use whitaker_installer::cli::InstallArgs;
 use whitaker_installer::dependency_binaries::DependencyBinaryInstaller;
 use whitaker_installer::deps::DependencyInstallOptions;
 use whitaker_installer::dirs::BaseDirs;
 use whitaker_installer::installer_packaging::TargetTriple;
-use whitaker_installer::test_support::{TEST_STAGE_SUITE_ENV, env_test_guard};
 use whitaker_installer::test_utils::dependency_binary_helpers::{
     AlwaysNotFoundRepositoryInstaller, with_fake_binary_on_path,
 };
@@ -106,88 +106,6 @@ fn resolve_requested_crates_rejects_unknown_lints() {
         err,
         InstallerError::LintCrateNotFound { name } if name == CrateName::from("nonexistent_lint")
     ));
-}
-
-#[test]
-fn resolve_additional_components_returns_empty_when_cranelift_false() {
-    let args = InstallArgs::default();
-    assert!(resolve_additional_components(&args).is_empty());
-}
-
-#[test]
-fn resolve_additional_components_returns_cranelift_when_flag_set() {
-    let args = InstallArgs {
-        cranelift: true,
-        ..InstallArgs::default()
-    };
-    let components = resolve_additional_components(&args);
-    assert_eq!(components, &["rustc-codegen-cranelift"]);
-}
-
-#[test]
-fn fast_path_context_holds_supplied_values() {
-    use camino::{Utf8Path, Utf8PathBuf};
-    use whitaker_installer::toolchain::Toolchain;
-
-    let args = InstallArgs::default();
-    let dirs = TestBaseDirs {
-        home_dir: Some("/tmp".into()),
-        bin_dir: Some("/tmp/bin".into()),
-        data_dir: Some("/tmp".into()),
-    };
-    let toolchain = Toolchain::with_override(Utf8Path::new("."), "nightly-2025-09-18");
-    let target_dir = Utf8PathBuf::from("/tmp/target");
-    let crates: Vec<whitaker_installer::crate_name::CrateName> = vec![];
-
-    let ctx = FastPathContext {
-        args: &args,
-        dirs: &dirs,
-        requested_crates: &crates,
-        toolchain: &toolchain,
-        target_dir: &target_dir,
-    };
-
-    assert!(std::ptr::eq(ctx.args, &args));
-    assert_eq!(ctx.dirs.home_dir(), Some(PathBuf::from("/tmp")));
-    assert_eq!(ctx.toolchain.channel(), "nightly-2025-09-18");
-    assert_eq!(ctx.target_dir, &Utf8PathBuf::from("/tmp/target"));
-    assert!(ctx.requested_crates.is_empty());
-}
-
-#[test]
-fn try_fast_path_installation_returns_none_when_prebuilt_disabled() {
-    use camino::{Utf8Path, Utf8PathBuf};
-    use whitaker_installer::toolchain::Toolchain;
-
-    let _guard = env_test_guard();
-    let args = InstallArgs {
-        is_build_only: true,
-        lint: vec!["module_max_lines".to_owned()],
-        ..InstallArgs::default()
-    };
-    let dirs = TestBaseDirs {
-        home_dir: Some("/tmp".into()),
-        bin_dir: Some("/tmp/bin".into()),
-        data_dir: Some("/tmp".into()),
-    };
-    let toolchain = Toolchain::with_override(Utf8Path::new("."), "nightly-2025-09-18");
-    let target_dir = Utf8PathBuf::from("/tmp/target");
-    let crates = vec![whitaker_installer::crate_name::CrateName::from(
-        "module_max_lines",
-    )];
-    let ctx = FastPathContext {
-        args: &args,
-        dirs: &dirs,
-        requested_crates: &crates,
-        toolchain: &toolchain,
-        target_dir: &target_dir,
-    };
-
-    with_var_unset(TEST_STAGE_SUITE_ENV, || {
-        let mut stderr = Vec::new();
-        let result = try_fast_path_installation(&ctx, &mut stderr).expect("should not error");
-        assert!(result.is_none());
-    });
 }
 
 #[rstest]

--- a/installer/src/tests/fast_path.rs
+++ b/installer/src/tests/fast_path.rs
@@ -1,0 +1,87 @@
+//! Tests for fast-path installer helper behaviour.
+
+use super::*;
+use camino::{Utf8Path, Utf8PathBuf};
+use rstest::{fixture, rstest};
+use temp_env::with_var_unset;
+use whitaker_installer::crate_name::CrateName;
+use whitaker_installer::test_support::{TEST_STAGE_SUITE_ENV, env_test_guard};
+use whitaker_installer::toolchain::Toolchain;
+
+struct FastPathFixture {
+    args: InstallArgs,
+    dirs: TestBaseDirs,
+    toolchain: Toolchain,
+    target_dir: Utf8PathBuf,
+    requested_crates: Vec<CrateName>,
+}
+
+impl FastPathFixture {
+    fn context(&self) -> FastPathContext<'_> {
+        FastPathContext {
+            args: &self.args,
+            dirs: &self.dirs,
+            requested_crates: &self.requested_crates,
+            toolchain: &self.toolchain,
+            target_dir: &self.target_dir,
+        }
+    }
+}
+
+#[fixture]
+fn fast_path_fixture() -> FastPathFixture {
+    FastPathFixture {
+        args: InstallArgs::default(),
+        dirs: TestBaseDirs {
+            home_dir: Some("/tmp".into()),
+            bin_dir: Some("/tmp/bin".into()),
+            data_dir: Some("/tmp".into()),
+        },
+        toolchain: Toolchain::with_override(Utf8Path::new("."), "nightly-2025-09-18"),
+        target_dir: Utf8PathBuf::from("/tmp/target"),
+        requested_crates: vec![],
+    }
+}
+
+#[rstest]
+#[case::without_cranelift(false, &[])]
+#[case::with_cranelift(true, &["rustc-codegen-cranelift"])]
+fn resolve_additional_components_parametrised(#[case] cranelift: bool, #[case] expected: &[&str]) {
+    let args = InstallArgs {
+        cranelift,
+        ..InstallArgs::default()
+    };
+
+    assert_eq!(super::resolve_additional_components(&args), expected);
+}
+
+#[rstest]
+fn fast_path_context_holds_supplied_values(fast_path_fixture: FastPathFixture) {
+    let ctx = fast_path_fixture.context();
+
+    assert!(std::ptr::eq(ctx.args, &fast_path_fixture.args));
+    assert_eq!(ctx.dirs.home_dir(), Some(PathBuf::from("/tmp")));
+    assert_eq!(ctx.toolchain.channel(), "nightly-2025-09-18");
+    assert_eq!(ctx.target_dir, &Utf8PathBuf::from("/tmp/target"));
+    assert!(ctx.requested_crates.is_empty());
+}
+
+#[rstest]
+fn try_fast_path_installation_returns_none_when_prebuilt_disabled(
+    mut fast_path_fixture: FastPathFixture,
+) {
+    let _guard = env_test_guard();
+    fast_path_fixture.args = InstallArgs {
+        is_build_only: true,
+        lint: vec!["module_max_lines".to_owned()],
+        ..InstallArgs::default()
+    };
+    fast_path_fixture.requested_crates = vec![CrateName::from("module_max_lines")];
+
+    with_var_unset(TEST_STAGE_SUITE_ENV, || {
+        let ctx = fast_path_fixture.context();
+        let mut stderr = Vec::new();
+        let result = try_fast_path_installation(&ctx, &mut stderr).expect("should not error");
+        assert!(result.is_none());
+    });
+}

--- a/installer/src/tests/fast_path.rs
+++ b/installer/src/tests/fast_path.rs
@@ -85,3 +85,34 @@ fn try_fast_path_installation_returns_none_when_prebuilt_disabled(
         assert!(result.is_none());
     });
 }
+
+#[rstest]
+fn try_fast_path_installation_returns_some_build_path_when_staged_suite_enabled(
+    mut fast_path_fixture: FastPathFixture,
+) {
+    use temp_env::with_var;
+    use whitaker_installer::test_support::TEST_STAGE_SUITE_ENV;
+
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    fast_path_fixture.target_dir =
+        Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).expect("temp dir is valid UTF-8");
+    // Suite-only request satisfies is_suite_only_request
+    fast_path_fixture.requested_crates = vec![CrateName::from("whitaker_suite")];
+    // Disable the prebuilt path so only the staged-suite branch fires
+    fast_path_fixture.args = InstallArgs {
+        is_build_only: true,
+        ..InstallArgs::default()
+    };
+
+    with_var(TEST_STAGE_SUITE_ENV, Some("1"), || {
+        let ctx = fast_path_fixture.context();
+        let mut stderr = Vec::new();
+        let result = try_fast_path_installation(&ctx, &mut stderr).expect("should not error");
+        assert!(
+            result.is_some(),
+            "expected Some((path, InstallMode::Build)), got None"
+        );
+        let (_, mode) = result.expect("staged suite should produce a build-mode fast path");
+        assert_eq!(mode, InstallMode::Build);
+    });
+}

--- a/installer/src/toolchain.rs
+++ b/installer/src/toolchain.rs
@@ -122,15 +122,22 @@ impl Toolchain {
     ///
     /// Returns an error if rustup fails to install the toolchain or required
     /// components.
-    pub fn ensure_installed(&self) -> Result<ToolchainInstallStatus> {
+    pub fn ensure_installed(
+        &self,
+        additional_components: &[&str],
+    ) -> Result<ToolchainInstallStatus> {
         let runner = SystemCommandRunner;
-        self.ensure_installed_with(&runner)
+        self.ensure_installed_with(&runner, additional_components)
     }
 
-    fn ensure_installed_with(&self, runner: &dyn CommandRunner) -> Result<ToolchainInstallStatus> {
+    fn ensure_installed_with(
+        &self,
+        runner: &dyn CommandRunner,
+        additional_components: &[&str],
+    ) -> Result<ToolchainInstallStatus> {
         if self.is_installed_with(runner)? {
             // Toolchain already present - just ensure components are installed
-            self.install_components_with(runner)?;
+            self.install_components_with(runner, additional_components)?;
             return Ok(ToolchainInstallStatus {
                 installed_toolchain: false,
             });
@@ -138,7 +145,7 @@ impl Toolchain {
 
         // Toolchain not installed - attempt installation then verify
         self.install_toolchain_with(runner)?;
-        self.install_components_with(runner)?;
+        self.install_components_with(runner, additional_components)?;
 
         // Verify the newly installed toolchain is actually usable
         if !self.is_installed_with(runner)? {
@@ -182,9 +189,18 @@ impl Toolchain {
         })
     }
 
-    fn install_components_with(&self, runner: &dyn CommandRunner) -> Result<()> {
+    fn install_components_with(
+        &self,
+        runner: &dyn CommandRunner,
+        additional_components: &[&str],
+    ) -> Result<()> {
+        let component_list: Vec<&str> = REQUIRED_COMPONENTS
+            .iter()
+            .copied()
+            .chain(additional_components.iter().copied())
+            .collect();
         let mut args: Vec<&str> = vec!["component", "add", "--toolchain", &self.channel];
-        args.extend(REQUIRED_COMPONENTS);
+        args.extend(component_list.iter().copied());
 
         let output = run_rustup(runner, &args)?;
 
@@ -194,7 +210,7 @@ impl Toolchain {
 
         Err(InstallerError::ToolchainComponentInstallFailed {
             toolchain: self.channel.clone(),
-            components: REQUIRED_COMPONENTS.join(", "),
+            components: component_list.join(", "),
             message: stderr_message(&output),
         })
     }

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -11,7 +11,6 @@ use crate::toolchain::tests::test_helpers::{
 pub(super) enum InstallFailure {
     ToolchainInstall,
     ComponentAdd,
-    CraneliftComponentAdd,
     ToolchainUnusableAfterInstall,
 }
 
@@ -65,22 +64,6 @@ fn setup_component_add_failure_mocks_inner(
         .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
 }
 
-fn setup_component_add_failure_mocks(
-    runner: &mut MockCommandRunner,
-    seq: &mut mockall::Sequence,
-    channel: &str,
-) {
-    setup_component_add_failure_mocks_inner(runner, seq, channel, &[]);
-}
-
-fn setup_cranelift_component_add_failure_mocks(
-    runner: &mut MockCommandRunner,
-    seq: &mut mockall::Sequence,
-    channel: &str,
-) {
-    setup_component_add_failure_mocks_inner(runner, seq, channel, &[CRANELIFT_COMPONENT]);
-}
-
 fn setup_toolchain_unusable_failure_mocks(
     runner: &mut MockCommandRunner,
     seq: &mut mockall::Sequence,
@@ -119,10 +102,12 @@ pub(super) fn setup_failure_mocks(
             setup_toolchain_install_failure_mocks(runner, seq, channel);
         }
         InstallFailure::ComponentAdd => {
-            setup_component_add_failure_mocks(runner, seq, channel);
-        }
-        InstallFailure::CraneliftComponentAdd => {
-            setup_cranelift_component_add_failure_mocks(runner, seq, channel);
+            setup_component_add_failure_mocks_inner(
+                runner,
+                seq,
+                channel,
+                setup.additional_components,
+            );
         }
         InstallFailure::ToolchainUnusableAfterInstall => {
             setup_toolchain_unusable_failure_mocks(
@@ -143,21 +128,16 @@ where
     assert!(predicate(err), "expected {description}, got {err:?}");
 }
 
-fn expected_standard_components() -> String {
-    REQUIRED_COMPONENTS.join(", ")
+fn expected_components(additional_components: &[&str]) -> String {
+    [REQUIRED_COMPONENTS, additional_components].concat().join(", ")
 }
 
-fn expected_cranelift_components() -> String {
-    [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]]
-        .concat()
-        .join(", ")
-}
-
-fn is_toolchain_component_install_failed(
+fn is_component_install_failed(
     err: &InstallerError,
     channel: &str,
-    expected_components: &str,
+    additional_components: &[&str],
 ) -> bool {
+    let expected = expected_components(additional_components);
     let InstallerError::ToolchainComponentInstallFailed {
         toolchain,
         components,
@@ -170,19 +150,16 @@ fn is_toolchain_component_install_failed(
     if toolchain != channel {
         return false;
     }
-    if components != expected_components {
-        return false;
-    }
-    message.contains("component failed")
+    toolchain == channel && components == &expected && message.contains("component failed")
 }
 
 pub(super) fn assert_failure_error(
     err: InstallerError,
     channel: ToolchainChannel<'_>,
-    failure: InstallFailure,
+    setup: FailureSetup<'_>,
 ) {
     let channel = channel.as_str();
-    match failure {
+    match setup.failure {
         InstallFailure::ToolchainInstall => assert_error_matches(
             &err,
             &format!("ToolchainInstallFailed for {channel}"),
@@ -197,24 +174,7 @@ pub(super) fn assert_failure_error(
         InstallFailure::ComponentAdd => assert_error_matches(
             &err,
             &format!("ToolchainComponentInstallFailed for {channel}"),
-            |e| {
-                is_toolchain_component_install_failed(
-                    e,
-                    channel,
-                    &expected_standard_components(),
-                )
-            },
-        ),
-        InstallFailure::CraneliftComponentAdd => assert_error_matches(
-            &err,
-            &format!("ToolchainComponentInstallFailed with cranelift for {channel}"),
-            |e| {
-                is_toolchain_component_install_failed(
-                    e,
-                    channel,
-                    &expected_cranelift_components(),
-                )
-            },
+            |e| is_component_install_failed(e, channel, setup.additional_components),
         ),
         InstallFailure::ToolchainUnusableAfterInstall => {
             assert_error_matches(&err, &format!("ToolchainNotInstalled for {channel}"), |e| {

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -1,0 +1,182 @@
+//! Failure-oriented test helpers for toolchain installation tests.
+
+use super::*;
+use crate::toolchain::tests::test_helpers::{
+    ToolchainInstallExpectation, expect_rustc_version, expect_toolchain_install,
+    matches_multi_component_add, output_with_status, output_with_stderr,
+};
+
+/// Describes the type of installation failure being tested.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum InstallFailure {
+    ToolchainInstall,
+    ComponentAdd,
+    CraneliftComponentAdd,
+    ToolchainUnusableAfterInstall,
+}
+
+fn setup_toolchain_install_failure_mocks(
+    runner: &mut MockCommandRunner,
+    seq: &mut mockall::Sequence,
+    channel: &str,
+) {
+    expect_rustc_version(runner, seq, channel, 1);
+    expect_toolchain_install(
+        runner,
+        seq,
+        ToolchainInstallExpectation {
+            channel,
+            exit_code: 1,
+            stderr: Some("network down"),
+        },
+    );
+}
+
+fn setup_component_add_failure_mocks(
+    runner: &mut MockCommandRunner,
+    seq: &mut mockall::Sequence,
+    channel: &str,
+) {
+    expect_rustc_version(runner, seq, channel, 0);
+    runner
+        .expect_run()
+        .withf(|program, args| {
+            program == "rustup" && args.len() >= 4 && args[0] == "component" && args[1] == "add"
+        })
+        .times(1)
+        .in_sequence(seq)
+        .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
+}
+
+fn setup_cranelift_component_add_failure_mocks(
+    runner: &mut MockCommandRunner,
+    seq: &mut mockall::Sequence,
+    channel: &str,
+) {
+    let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
+    expect_rustc_version(runner, seq, channel, 0);
+    runner
+        .expect_run()
+        .withf(matches_multi_component_add(channel, &expected_components))
+        .times(1)
+        .in_sequence(seq)
+        .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
+}
+
+fn setup_toolchain_unusable_failure_mocks(
+    runner: &mut MockCommandRunner,
+    seq: &mut mockall::Sequence,
+    channel: &str,
+) {
+    expect_rustc_version(runner, seq, channel, 1);
+    expect_toolchain_install(
+        runner,
+        seq,
+        ToolchainInstallExpectation {
+            channel,
+            exit_code: 0,
+            stderr: None,
+        },
+    );
+    runner
+        .expect_run()
+        .withf(|program, args| {
+            program == "rustup" && args.len() >= 4 && args[0] == "component" && args[1] == "add"
+        })
+        .times(1)
+        .in_sequence(seq)
+        .returning(|_, _| Ok(output_with_status(0)));
+    expect_rustc_version(runner, seq, channel, 1);
+}
+
+pub(super) fn setup_failure_mocks(
+    runner: &mut MockCommandRunner,
+    seq: &mut mockall::Sequence,
+    channel: &str,
+    failure: InstallFailure,
+) {
+    match failure {
+        InstallFailure::ToolchainInstall => {
+            setup_toolchain_install_failure_mocks(runner, seq, channel);
+        }
+        InstallFailure::ComponentAdd => {
+            setup_component_add_failure_mocks(runner, seq, channel);
+        }
+        InstallFailure::CraneliftComponentAdd => {
+            setup_cranelift_component_add_failure_mocks(runner, seq, channel);
+        }
+        InstallFailure::ToolchainUnusableAfterInstall => {
+            setup_toolchain_unusable_failure_mocks(runner, seq, channel);
+        }
+    }
+}
+
+/// Asserts that `err` satisfies `predicate`, printing `description` on failure.
+fn assert_error_matches<F>(err: &InstallerError, description: &str, predicate: F)
+where
+    F: FnOnce(&InstallerError) -> bool,
+{
+    assert!(predicate(err), "expected {description}, got {err:?}");
+}
+
+fn is_cranelift_component_install_failed(err: &InstallerError, channel: &str) -> bool {
+    let InstallerError::ToolchainComponentInstallFailed {
+        toolchain,
+        components,
+        message,
+    } = err
+    else {
+        return false;
+    };
+    if toolchain != channel {
+        return false;
+    }
+    if !components.contains(CRANELIFT_COMPONENT) {
+        return false;
+    }
+    message.contains("component failed")
+}
+
+pub(super) fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFailure) {
+    match failure {
+        InstallFailure::ToolchainInstall => assert_error_matches(
+            &err,
+            &format!("ToolchainInstallFailed for {channel}"),
+            |e| {
+                matches!(
+                    e,
+                    InstallerError::ToolchainInstallFailed { toolchain, message }
+                        if toolchain == channel && message.contains("network down")
+                )
+            },
+        ),
+        InstallFailure::ComponentAdd => assert_error_matches(
+            &err,
+            &format!("ToolchainComponentInstallFailed for {channel}"),
+            |e| {
+                matches!(
+                    e,
+                    InstallerError::ToolchainComponentInstallFailed {
+                        toolchain,
+                        message,
+                        ..
+                    } if toolchain == channel && message.contains("component failed")
+                )
+            },
+        ),
+        InstallFailure::CraneliftComponentAdd => assert_error_matches(
+            &err,
+            &format!("ToolchainComponentInstallFailed with cranelift for {channel}"),
+            |e| is_cranelift_component_install_failed(e, channel),
+        ),
+        InstallFailure::ToolchainUnusableAfterInstall => {
+            assert_error_matches(&err, &format!("ToolchainNotInstalled for {channel}"), |e| {
+                matches!(
+                    e,
+                    InstallerError::ToolchainNotInstalled { toolchain }
+                        if toolchain == channel
+                )
+            })
+        }
+    }
+}

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -153,9 +153,11 @@ fn expected_cranelift_components() -> String {
         .join(", ")
 }
 
-fn is_component_install_failed(err: &InstallerError, channel: ToolchainChannel<'_>) -> bool {
-    let channel = channel.as_str();
-    let expected_components = expected_standard_components();
+fn is_toolchain_component_install_failed(
+    err: &InstallerError,
+    channel: &str,
+    expected_components: &str,
+) -> bool {
     let InstallerError::ToolchainComponentInstallFailed {
         toolchain,
         components,
@@ -168,30 +170,7 @@ fn is_component_install_failed(err: &InstallerError, channel: ToolchainChannel<'
     if toolchain != channel {
         return false;
     }
-    if components != &expected_components {
-        return false;
-    }
-    message.contains("component failed")
-}
-
-fn is_cranelift_component_install_failed(
-    err: &InstallerError,
-    channel: ToolchainChannel<'_>,
-) -> bool {
-    let channel = channel.as_str();
-    let expected_components = expected_cranelift_components();
-    let InstallerError::ToolchainComponentInstallFailed {
-        toolchain,
-        components,
-        message,
-    } = err
-    else {
-        return false;
-    };
-    if toolchain != channel {
-        return false;
-    }
-    if components != &expected_components {
+    if components != expected_components {
         return false;
     }
     message.contains("component failed")
@@ -218,12 +197,24 @@ pub(super) fn assert_failure_error(
         InstallFailure::ComponentAdd => assert_error_matches(
             &err,
             &format!("ToolchainComponentInstallFailed for {channel}"),
-            |e| is_component_install_failed(e, ToolchainChannel(channel)),
+            |e| {
+                is_toolchain_component_install_failed(
+                    e,
+                    channel,
+                    &expected_standard_components(),
+                )
+            },
         ),
         InstallFailure::CraneliftComponentAdd => assert_error_matches(
             &err,
             &format!("ToolchainComponentInstallFailed with cranelift for {channel}"),
-            |e| is_cranelift_component_install_failed(e, ToolchainChannel(channel)),
+            |e| {
+                is_toolchain_component_install_failed(
+                    e,
+                    channel,
+                    &expected_cranelift_components(),
+                )
+            },
         ),
         InstallFailure::ToolchainUnusableAfterInstall => {
             assert_error_matches(&err, &format!("ToolchainNotInstalled for {channel}"), |e| {

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -129,7 +129,9 @@ where
 }
 
 fn expected_components(additional_components: &[&str]) -> String {
-    [REQUIRED_COMPONENTS, additional_components].concat().join(", ")
+    [REQUIRED_COMPONENTS, additional_components]
+        .concat()
+        .join(", ")
 }
 
 fn is_component_install_failed(

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -132,7 +132,18 @@ where
     assert!(predicate(err), "expected {description}, got {err:?}");
 }
 
+fn expected_standard_components() -> String {
+    REQUIRED_COMPONENTS.join(", ")
+}
+
+fn expected_cranelift_components() -> String {
+    [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]]
+        .concat()
+        .join(", ")
+}
+
 fn is_cranelift_component_install_failed(err: &InstallerError, channel: &str) -> bool {
+    let expected_components = expected_cranelift_components();
     let InstallerError::ToolchainComponentInstallFailed {
         toolchain,
         components,
@@ -144,7 +155,7 @@ fn is_cranelift_component_install_failed(err: &InstallerError, channel: &str) ->
     if toolchain != channel {
         return false;
     }
-    if !components.contains(CRANELIFT_COMPONENT) {
+    if components != &expected_components {
         return false;
     }
     message.contains("component failed")
@@ -167,13 +178,17 @@ pub(super) fn assert_failure_error(err: InstallerError, channel: &str, failure: 
             &err,
             &format!("ToolchainComponentInstallFailed for {channel}"),
             |e| {
+                let expected_components = expected_standard_components();
                 matches!(
                     e,
                     InstallerError::ToolchainComponentInstallFailed {
                         toolchain,
+                        components,
                         message,
                         ..
-                    } if toolchain == channel && message.contains("component failed")
+                    } if toolchain == channel
+                        && components == &expected_components
+                        && message.contains("component failed")
                 )
             },
         ),

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -22,6 +22,16 @@ pub(super) struct FailureSetup<'a> {
     pub(super) additional_components: &'a [&'a str],
 }
 
+/// A typed toolchain channel identifier (e.g. `"nightly-2025-09-18"`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct ToolchainChannel<'a>(pub(super) &'a str);
+
+impl<'a> ToolchainChannel<'a> {
+    pub(super) fn as_str(self) -> &'a str {
+        self.0
+    }
+}
+
 fn setup_toolchain_install_failure_mocks(
     runner: &mut MockCommandRunner,
     seq: &mut mockall::Sequence,
@@ -100,9 +110,10 @@ fn setup_toolchain_unusable_failure_mocks(
 pub(super) fn setup_failure_mocks(
     runner: &mut MockCommandRunner,
     seq: &mut mockall::Sequence,
-    channel: &str,
+    channel: ToolchainChannel<'_>,
     setup: FailureSetup<'_>,
 ) {
+    let channel = channel.as_str();
     match setup.failure {
         InstallFailure::ToolchainInstall => {
             setup_toolchain_install_failure_mocks(runner, seq, channel);
@@ -142,7 +153,8 @@ fn expected_cranelift_components() -> String {
         .join(", ")
 }
 
-fn is_component_install_failed(err: &InstallerError, channel: &str) -> bool {
+fn is_component_install_failed(err: &InstallerError, channel: ToolchainChannel<'_>) -> bool {
+    let channel = channel.as_str();
     let expected_components = expected_standard_components();
     let InstallerError::ToolchainComponentInstallFailed {
         toolchain,
@@ -162,7 +174,11 @@ fn is_component_install_failed(err: &InstallerError, channel: &str) -> bool {
     message.contains("component failed")
 }
 
-fn is_cranelift_component_install_failed(err: &InstallerError, channel: &str) -> bool {
+fn is_cranelift_component_install_failed(
+    err: &InstallerError,
+    channel: ToolchainChannel<'_>,
+) -> bool {
+    let channel = channel.as_str();
     let expected_components = expected_cranelift_components();
     let InstallerError::ToolchainComponentInstallFailed {
         toolchain,
@@ -181,7 +197,12 @@ fn is_cranelift_component_install_failed(err: &InstallerError, channel: &str) ->
     message.contains("component failed")
 }
 
-pub(super) fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFailure) {
+pub(super) fn assert_failure_error(
+    err: InstallerError,
+    channel: ToolchainChannel<'_>,
+    failure: InstallFailure,
+) {
+    let channel = channel.as_str();
     match failure {
         InstallFailure::ToolchainInstall => assert_error_matches(
             &err,
@@ -197,12 +218,12 @@ pub(super) fn assert_failure_error(err: InstallerError, channel: &str, failure: 
         InstallFailure::ComponentAdd => assert_error_matches(
             &err,
             &format!("ToolchainComponentInstallFailed for {channel}"),
-            |e| is_component_install_failed(e, channel),
+            |e| is_component_install_failed(e, ToolchainChannel(channel)),
         ),
         InstallFailure::CraneliftComponentAdd => assert_error_matches(
             &err,
             &format!("ToolchainComponentInstallFailed with cranelift for {channel}"),
-            |e| is_cranelift_component_install_failed(e, channel),
+            |e| is_cranelift_component_install_failed(e, ToolchainChannel(channel)),
         ),
         InstallFailure::ToolchainUnusableAfterInstall => {
             assert_error_matches(&err, &format!("ToolchainNotInstalled for {channel}"), |e| {

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -69,7 +69,6 @@ fn setup_toolchain_unusable_failure_mocks(
     seq: &mut mockall::Sequence,
     channel: &str,
 ) {
-    let expected_components = REQUIRED_COMPONENTS;
     expect_rustc_version(runner, seq, channel, 1);
     expect_toolchain_install(
         runner,
@@ -82,7 +81,7 @@ fn setup_toolchain_unusable_failure_mocks(
     );
     runner
         .expect_run()
-        .withf(matches_multi_component_add(channel, expected_components))
+        .withf(matches_multi_component_add(channel, REQUIRED_COMPONENTS))
         .times(1)
         .in_sequence(seq)
         .returning(|_, _| Ok(output_with_status(0)));

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -32,19 +32,28 @@ fn setup_toolchain_install_failure_mocks(
     );
 }
 
+fn setup_component_add_failure_mocks_inner(
+    runner: &mut MockCommandRunner,
+    seq: &mut mockall::Sequence,
+    channel: &str,
+    extra_components: &[&str],
+) {
+    let components = [REQUIRED_COMPONENTS, extra_components].concat();
+    expect_rustc_version(runner, seq, channel, 0);
+    runner
+        .expect_run()
+        .withf(matches_multi_component_add(channel, &components))
+        .times(1)
+        .in_sequence(seq)
+        .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
+}
+
 fn setup_component_add_failure_mocks(
     runner: &mut MockCommandRunner,
     seq: &mut mockall::Sequence,
     channel: &str,
 ) {
-    let expected_components = REQUIRED_COMPONENTS;
-    expect_rustc_version(runner, seq, channel, 0);
-    runner
-        .expect_run()
-        .withf(matches_multi_component_add(channel, expected_components))
-        .times(1)
-        .in_sequence(seq)
-        .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
+    setup_component_add_failure_mocks_inner(runner, seq, channel, &[]);
 }
 
 fn setup_cranelift_component_add_failure_mocks(
@@ -52,14 +61,7 @@ fn setup_cranelift_component_add_failure_mocks(
     seq: &mut mockall::Sequence,
     channel: &str,
 ) {
-    let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
-    expect_rustc_version(runner, seq, channel, 0);
-    runner
-        .expect_run()
-        .withf(matches_multi_component_add(channel, &expected_components))
-        .times(1)
-        .in_sequence(seq)
-        .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
+    setup_component_add_failure_mocks_inner(runner, seq, channel, &[CRANELIFT_COMPONENT]);
 }
 
 fn setup_toolchain_unusable_failure_mocks(

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -37,12 +37,11 @@ fn setup_component_add_failure_mocks(
     seq: &mut mockall::Sequence,
     channel: &str,
 ) {
+    let expected_components = REQUIRED_COMPONENTS;
     expect_rustc_version(runner, seq, channel, 0);
     runner
         .expect_run()
-        .withf(|program, args| {
-            program == "rustup" && args.len() >= 4 && args[0] == "component" && args[1] == "add"
-        })
+        .withf(matches_multi_component_add(channel, expected_components))
         .times(1)
         .in_sequence(seq)
         .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
@@ -68,6 +67,7 @@ fn setup_toolchain_unusable_failure_mocks(
     seq: &mut mockall::Sequence,
     channel: &str,
 ) {
+    let expected_components = REQUIRED_COMPONENTS;
     expect_rustc_version(runner, seq, channel, 1);
     expect_toolchain_install(
         runner,
@@ -80,9 +80,7 @@ fn setup_toolchain_unusable_failure_mocks(
     );
     runner
         .expect_run()
-        .withf(|program, args| {
-            program == "rustup" && args.len() >= 4 && args[0] == "component" && args[1] == "add"
-        })
+        .withf(matches_multi_component_add(channel, expected_components))
         .times(1)
         .in_sequence(seq)
         .returning(|_, _| Ok(output_with_status(0)));

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -142,6 +142,26 @@ fn expected_cranelift_components() -> String {
         .join(", ")
 }
 
+fn is_component_install_failed(err: &InstallerError, channel: &str) -> bool {
+    let expected_components = expected_standard_components();
+    let InstallerError::ToolchainComponentInstallFailed {
+        toolchain,
+        components,
+        message,
+        ..
+    } = err
+    else {
+        return false;
+    };
+    if toolchain != channel {
+        return false;
+    }
+    if components != &expected_components {
+        return false;
+    }
+    message.contains("component failed")
+}
+
 fn is_cranelift_component_install_failed(err: &InstallerError, channel: &str) -> bool {
     let expected_components = expected_cranelift_components();
     let InstallerError::ToolchainComponentInstallFailed {
@@ -177,20 +197,7 @@ pub(super) fn assert_failure_error(err: InstallerError, channel: &str, failure: 
         InstallFailure::ComponentAdd => assert_error_matches(
             &err,
             &format!("ToolchainComponentInstallFailed for {channel}"),
-            |e| {
-                let expected_components = expected_standard_components();
-                matches!(
-                    e,
-                    InstallerError::ToolchainComponentInstallFailed {
-                        toolchain,
-                        components,
-                        message,
-                        ..
-                    } if toolchain == channel
-                        && components == &expected_components
-                        && message.contains("component failed")
-                )
-            },
+            |e| is_component_install_failed(e, channel),
         ),
         InstallFailure::CraneliftComponentAdd => assert_error_matches(
             &err,

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -15,6 +15,13 @@ pub(super) enum InstallFailure {
     ToolchainUnusableAfterInstall,
 }
 
+/// Bundles the failure mode with any extra components requested for the test.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct FailureSetup<'a> {
+    pub(super) failure: InstallFailure,
+    pub(super) additional_components: &'a [&'a str],
+}
+
 fn setup_toolchain_install_failure_mocks(
     runner: &mut MockCommandRunner,
     seq: &mut mockall::Sequence,
@@ -68,7 +75,9 @@ fn setup_toolchain_unusable_failure_mocks(
     runner: &mut MockCommandRunner,
     seq: &mut mockall::Sequence,
     channel: &str,
+    additional_components: &[&str],
 ) {
+    let components = [REQUIRED_COMPONENTS, additional_components].concat();
     expect_rustc_version(runner, seq, channel, 1);
     expect_toolchain_install(
         runner,
@@ -81,7 +90,7 @@ fn setup_toolchain_unusable_failure_mocks(
     );
     runner
         .expect_run()
-        .withf(matches_multi_component_add(channel, REQUIRED_COMPONENTS))
+        .withf(matches_multi_component_add(channel, &components))
         .times(1)
         .in_sequence(seq)
         .returning(|_, _| Ok(output_with_status(0)));
@@ -92,9 +101,9 @@ pub(super) fn setup_failure_mocks(
     runner: &mut MockCommandRunner,
     seq: &mut mockall::Sequence,
     channel: &str,
-    failure: InstallFailure,
+    setup: FailureSetup<'_>,
 ) {
-    match failure {
+    match setup.failure {
         InstallFailure::ToolchainInstall => {
             setup_toolchain_install_failure_mocks(runner, seq, channel);
         }
@@ -105,7 +114,12 @@ pub(super) fn setup_failure_mocks(
             setup_cranelift_component_add_failure_mocks(runner, seq, channel);
         }
         InstallFailure::ToolchainUnusableAfterInstall => {
-            setup_toolchain_unusable_failure_mocks(runner, seq, channel);
+            setup_toolchain_unusable_failure_mocks(
+                runner,
+                seq,
+                channel,
+                setup.additional_components,
+            );
         }
     }
 }

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -12,6 +12,17 @@ use test_helpers::{
 
 const CRANELIFT_COMPONENT: &str = "rustc-codegen-cranelift";
 
+/// A typed toolchain channel identifier for use in tests
+/// (e.g. `"nightly-2025-09-18"`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ToolchainChannel<'a>(&'a str);
+
+impl<'a> ToolchainChannel<'a> {
+    fn as_str(self) -> &'a str {
+        self.0
+    }
+}
+
 // Asserts that a parsing function rejects invalid contents with an
 // InvalidToolchainFile error containing the expected reason substring.
 fn assert_parse_fails_with_reason<F, T>(contents: &str, expected_reason: &str, parse_fn: F)
@@ -138,9 +149,10 @@ enum InstallFailure {
 fn setup_failure_mocks(
     runner: &mut MockCommandRunner,
     seq: &mut mockall::Sequence,
-    channel: &str,
+    channel: ToolchainChannel<'_>,
     failure: InstallFailure,
 ) {
+    let channel = channel.as_str();
     match failure {
         InstallFailure::ToolchainInstall => {
             expect_rustc_version(runner, seq, channel, 1);
@@ -205,7 +217,8 @@ fn setup_failure_mocks(
     }
 }
 
-fn assert_toolchain_install_failed(err: InstallerError, channel: &str) {
+fn assert_toolchain_install_failed(err: InstallerError, channel: ToolchainChannel<'_>) {
+    let channel = channel.as_str();
     assert!(
         matches!(
             err,
@@ -216,7 +229,8 @@ fn assert_toolchain_install_failed(err: InstallerError, channel: &str) {
     );
 }
 
-fn assert_component_add_failed(err: InstallerError, channel: &str) {
+fn assert_component_add_failed(err: InstallerError, channel: ToolchainChannel<'_>) {
+    let channel = channel.as_str();
     assert!(
         matches!(
             err,
@@ -230,7 +244,8 @@ fn assert_component_add_failed(err: InstallerError, channel: &str) {
     );
 }
 
-fn assert_cranelift_component_add_failed(err: InstallerError, channel: &str) {
+fn assert_cranelift_component_add_failed(err: InstallerError, channel: ToolchainChannel<'_>) {
+    let channel = channel.as_str();
     assert!(
         matches!(
             err,
@@ -246,7 +261,8 @@ fn assert_cranelift_component_add_failed(err: InstallerError, channel: &str) {
     );
 }
 
-fn assert_toolchain_not_installed(err: InstallerError, channel: &str) {
+fn assert_toolchain_not_installed(err: InstallerError, channel: ToolchainChannel<'_>) {
+    let channel = channel.as_str();
     assert!(
         matches!(
             err,
@@ -257,15 +273,20 @@ fn assert_toolchain_not_installed(err: InstallerError, channel: &str) {
     );
 }
 
-fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFailure) {
+fn assert_failure_error(err: InstallerError, channel: ToolchainChannel<'_>, failure: InstallFailure) {
+    let channel = channel.as_str();
     match failure {
-        InstallFailure::ToolchainInstall => assert_toolchain_install_failed(err, channel),
-        InstallFailure::ComponentAdd => assert_component_add_failed(err, channel),
+        InstallFailure::ToolchainInstall => {
+            assert_toolchain_install_failed(err, ToolchainChannel(channel))
+        }
+        InstallFailure::ComponentAdd => {
+            assert_component_add_failed(err, ToolchainChannel(channel))
+        }
         InstallFailure::CraneliftComponentAdd => {
-            assert_cranelift_component_add_failed(err, channel)
+            assert_cranelift_component_add_failed(err, ToolchainChannel(channel))
         }
         InstallFailure::ToolchainUnusableAfterInstall => {
-            assert_toolchain_not_installed(err, channel)
+            assert_toolchain_not_installed(err, ToolchainChannel(channel))
         }
     }
 }
@@ -276,8 +297,8 @@ fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFail
 #[case::cranelift_component_add_fails(InstallFailure::CraneliftComponentAdd)]
 #[case::toolchain_unusable_after_install(InstallFailure::ToolchainUnusableAfterInstall)]
 fn ensure_installed_reports_failure(#[case] failure: InstallFailure) {
-    let channel = "nightly-2025-09-18";
-    let toolchain = test_toolchain(channel);
+    let channel = ToolchainChannel("nightly-2025-09-18");
+    let toolchain = test_toolchain(channel.as_str());
     let additional_components = match failure {
         InstallFailure::CraneliftComponentAdd => &[CRANELIFT_COMPONENT][..],
         _ => &[],

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -58,11 +58,9 @@ fn rejects_invalid_toolchain_file(#[case] contents: &str, #[case] expected_reaso
     assert_parse_fails_with_reason(contents, expected_reason, parse_toolchain_channel);
 }
 
-#[test]
-fn ensure_installed_installs_missing_toolchain() {
+fn run_missing_toolchain_install_test(extra: &[&str], expected_components: &[&str]) {
     let channel = "nightly-2025-09-18";
     let toolchain = test_toolchain(channel);
-
     let mut runner = MockCommandRunner::new();
     let mut seq = mockall::Sequence::new();
 
@@ -77,10 +75,9 @@ fn ensure_installed_installs_missing_toolchain() {
         },
     );
 
-    // Expect required components to be installed
     runner
         .expect_run()
-        .withf(matches_multi_component_add(channel, REQUIRED_COMPONENTS))
+        .withf(matches_multi_component_add(channel, expected_components))
         .times(1)
         .in_sequence(&mut seq)
         .returning(|_, _| Ok(output_with_status(0)));
@@ -88,46 +85,26 @@ fn ensure_installed_installs_missing_toolchain() {
     expect_rustc_version(&mut runner, &mut seq, channel, 0);
 
     let status = toolchain
-        .ensure_installed_with(&runner, &[])
+        .ensure_installed_with(&runner, extra)
         .expect("toolchain should install");
 
     assert!(status.installed_toolchain());
 }
 
-#[test]
-fn ensure_installed_adds_required_and_additional_components_when_toolchain_missing() {
-    let channel = "nightly-2025-09-18";
-    let toolchain = test_toolchain(channel);
-
-    let mut runner = MockCommandRunner::new();
-    let mut seq = mockall::Sequence::new();
-
-    expect_rustc_version(&mut runner, &mut seq, channel, 1);
-    expect_toolchain_install(
-        &mut runner,
-        &mut seq,
-        ToolchainInstallExpectation {
-            channel,
-            exit_code: 0,
-            stderr: None,
-        },
-    );
-
-    let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
-    runner
-        .expect_run()
-        .withf(matches_multi_component_add(channel, &expected_components))
-        .times(1)
-        .in_sequence(&mut seq)
-        .returning(|_, _| Ok(output_with_status(0)));
-
-    expect_rustc_version(&mut runner, &mut seq, channel, 0);
-
-    let status = toolchain
-        .ensure_installed_with(&runner, &[CRANELIFT_COMPONENT])
-        .expect("toolchain should install");
-
-    assert!(status.installed_toolchain());
+#[rstest]
+#[case::no_extras(
+    vec![],
+    REQUIRED_COMPONENTS.to_vec(),
+)]
+#[case::with_cranelift(
+    vec![CRANELIFT_COMPONENT],
+    [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat(),
+)]
+fn ensure_installed_installs_missing_toolchain(
+    #[case] extra: Vec<&'static str>,
+    #[case] expected_components: Vec<&'static str>,
+) {
+    run_missing_toolchain_install_test(&extra, &expected_components);
 }
 
 fn run_component_installation_test(extra: &[&str], expected: &[&str]) {

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -275,17 +275,15 @@ fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFail
             &format!("ToolchainComponentInstallFailed with cranelift for {channel}"),
             |e| is_cranelift_component_install_failed(e, channel),
         ),
-        InstallFailure::ToolchainUnusableAfterInstall => assert_error_matches(
-            &err,
-            &format!("ToolchainNotInstalled for {channel}"),
-            |e| {
+        InstallFailure::ToolchainUnusableAfterInstall => {
+            assert_error_matches(&err, &format!("ToolchainNotInstalled for {channel}"), |e| {
                 matches!(
                     e,
                     InstallerError::ToolchainNotInstalled { toolchain }
                         if toolchain == channel
                 )
-            },
-        ),
+            })
+        }
     }
 }
 

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -92,73 +92,38 @@ fn ensure_installed_installs_missing_toolchain() {
     assert!(status.installed_toolchain());
 }
 
-#[test]
-fn ensure_installed_adds_required_components_when_toolchain_present() {
+fn run_component_installation_test(extra: &[&str], expected: &[&str]) {
     let channel = "nightly-2025-09-18";
     let toolchain = test_toolchain(channel);
     let mut runner = MockCommandRunner::new();
     let mut seq = mockall::Sequence::new();
 
     expect_rustc_version(&mut runner, &mut seq, channel, 0);
-
-    // Expect required components to be installed
     runner
         .expect_run()
-        .withf(matches_multi_component_add(channel, REQUIRED_COMPONENTS))
+        .withf(matches_multi_component_add(channel, expected))
         .times(1)
         .in_sequence(&mut seq)
         .returning(|_, _| Ok(output_with_status(0)));
 
     let status = toolchain
-        .ensure_installed_with(&runner, &[])
+        .ensure_installed_with(&runner, extra)
         .expect("toolchain should be ready");
 
     assert!(!status.installed_toolchain());
 }
 
-#[test]
-fn ensure_installed_adds_cranelift_component_when_requested() {
-    let channel = "nightly-2025-09-18";
-    let toolchain = test_toolchain(channel);
-    let mut runner = MockCommandRunner::new();
-    let mut seq = mockall::Sequence::new();
-    let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
-
-    expect_rustc_version(&mut runner, &mut seq, channel, 0);
-    runner
-        .expect_run()
-        .withf(matches_multi_component_add(channel, &expected_components))
-        .times(1)
-        .in_sequence(&mut seq)
-        .returning(|_, _| Ok(output_with_status(0)));
-
-    let status = toolchain
-        .ensure_installed_with(&runner, &[CRANELIFT_COMPONENT])
-        .expect("toolchain should be ready");
-
-    assert!(!status.installed_toolchain());
-}
-
-#[test]
-fn ensure_installed_adds_only_required_components_when_no_extras_requested() {
-    let channel = "nightly-2025-09-18";
-    let toolchain = test_toolchain(channel);
-    let mut runner = MockCommandRunner::new();
-    let mut seq = mockall::Sequence::new();
-
-    expect_rustc_version(&mut runner, &mut seq, channel, 0);
-    runner
-        .expect_run()
-        .withf(matches_multi_component_add(channel, REQUIRED_COMPONENTS))
-        .times(1)
-        .in_sequence(&mut seq)
-        .returning(|_, _| Ok(output_with_status(0)));
-
-    let status = toolchain
-        .ensure_installed_with(&runner, &[])
-        .expect("toolchain should be ready");
-
-    assert!(!status.installed_toolchain());
+#[rstest]
+#[case::no_extras(vec![], REQUIRED_COMPONENTS.to_vec())]
+#[case::with_cranelift(
+    vec![CRANELIFT_COMPONENT],
+    [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat()
+)]
+fn ensure_installed_adds_correct_components(
+    #[case] extra: Vec<&'static str>,
+    #[case] expected: Vec<&'static str>,
+) {
+    run_component_installation_test(&extra, &expected);
 }
 
 // Describes the type of installation failure being tested.

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -193,10 +193,7 @@ fn install_components_with_failure_reports_all_components() {
 #[rstest]
 #[case::toolchain_install_fails(InstallFailure::ToolchainInstall, &[])]
 #[case::component_add_fails(InstallFailure::ComponentAdd, &[])]
-#[case::cranelift_component_add_fails(
-    InstallFailure::CraneliftComponentAdd,
-    &[CRANELIFT_COMPONENT],
-)]
+#[case::cranelift_component_add_fails(InstallFailure::ComponentAdd, &[CRANELIFT_COMPONENT])]
 #[case::toolchain_unusable_after_install(
     InstallFailure::ToolchainUnusableAfterInstall,
     &[],
@@ -211,22 +208,16 @@ fn ensure_installed_reports_failure(
 ) {
     let channel = ToolchainChannel("nightly-2025-09-18");
     let toolchain = test_toolchain(channel.as_str());
+    let setup = FailureSetup {
+        failure,
+        additional_components,
+    };
 
     test_helpers::assert_install_fails_with(
         toolchain,
-        |runner, seq| {
-            setup_failure_mocks(
-                runner,
-                seq,
-                channel,
-                FailureSetup {
-                    failure,
-                    additional_components,
-                },
-            )
-        },
+        |runner, seq| setup_failure_mocks(runner, seq, channel, setup),
         |toolchain, runner| toolchain.ensure_installed_with(runner, additional_components),
-        |err| assert_failure_error(err, channel, failure),
+        |err| assert_failure_error(err, channel, setup),
     );
 }
 

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -4,6 +4,7 @@ mod test_helpers;
 
 use super::*;
 use rstest::rstest;
+use std::cell::RefCell;
 use test_helpers::{
     ToolchainInstallExpectation, assert_install_fails_with, expect_rustc_version,
     expect_toolchain_install, matches_multi_component_add, output_with_status, output_with_stderr,
@@ -103,6 +104,42 @@ fn ensure_installed_installs_missing_toolchain() {
     assert!(status.installed_toolchain());
 }
 
+#[test]
+fn ensure_installed_adds_required_and_additional_components_when_toolchain_missing() {
+    let channel = "nightly-2025-09-18";
+    let toolchain = test_toolchain(channel);
+
+    let mut runner = MockCommandRunner::new();
+    let mut seq = mockall::Sequence::new();
+
+    expect_rustc_version(&mut runner, &mut seq, channel, 1);
+    expect_toolchain_install(
+        &mut runner,
+        &mut seq,
+        ToolchainInstallExpectation {
+            channel,
+            exit_code: 0,
+            stderr: None,
+        },
+    );
+
+    let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
+    runner
+        .expect_run()
+        .withf(matches_multi_component_add(channel, &expected_components))
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|_, _| Ok(output_with_status(0)));
+
+    expect_rustc_version(&mut runner, &mut seq, channel, 0);
+
+    let status = toolchain
+        .ensure_installed_with(&runner, &[CRANELIFT_COMPONENT])
+        .expect("toolchain should install");
+
+    assert!(status.installed_toolchain());
+}
+
 fn run_component_installation_test(extra: &[&str], expected: &[&str]) {
     let channel = "nightly-2025-09-18";
     let toolchain = test_toolchain(channel);
@@ -135,6 +172,79 @@ fn ensure_installed_adds_correct_components(
     #[case] expected: Vec<&'static str>,
 ) {
     run_component_installation_test(&extra, &expected);
+}
+
+struct CapturingCommandRunner {
+    calls: RefCell<Vec<(String, Vec<String>)>>,
+    output: Output,
+}
+
+impl CapturingCommandRunner {
+    fn new(output: Output) -> Self {
+        Self {
+            calls: RefCell::new(Vec::new()),
+            output,
+        }
+    }
+
+    fn recorded_calls(&self) -> Vec<(String, Vec<String>)> {
+        self.calls.borrow().clone()
+    }
+}
+
+impl CommandRunner for CapturingCommandRunner {
+    fn run<'a>(&self, program: &str, args: &[&'a str]) -> std::io::Result<Output> {
+        self.calls.borrow_mut().push((
+            program.to_owned(),
+            args.iter().map(|arg| (*arg).to_owned()).collect(),
+        ));
+        Ok(self.output.clone())
+    }
+}
+
+#[test]
+fn install_components_with_additional_components_assembles_rustup_args_in_order() {
+    let toolchain = test_toolchain("nightly-2025-09-18");
+    let runner = CapturingCommandRunner::new(output_with_status(0));
+
+    toolchain
+        .install_components_with(&runner, &[CRANELIFT_COMPONENT])
+        .expect("component installation should succeed");
+
+    let expected_args: Vec<String> = ["component", "add", "--toolchain", "nightly-2025-09-18"]
+        .into_iter()
+        .chain(REQUIRED_COMPONENTS.iter().copied())
+        .chain([CRANELIFT_COMPONENT])
+        .map(str::to_owned)
+        .collect();
+    assert_eq!(
+        runner.recorded_calls(),
+        vec![("rustup".to_owned(), expected_args)]
+    );
+}
+
+#[test]
+fn install_components_with_failure_reports_all_components() {
+    let toolchain = test_toolchain("nightly-2025-09-18");
+    let runner = CapturingCommandRunner::new(output_with_stderr(1, "component failed"));
+
+    let err = toolchain
+        .install_components_with(&runner, &[CRANELIFT_COMPONENT])
+        .expect_err("component installation should fail");
+
+    assert!(
+        matches!(
+            err,
+            InstallerError::ToolchainComponentInstallFailed {
+                ref toolchain,
+                ref components,
+                ref message,
+            } if toolchain == "nightly-2025-09-18"
+                && components == "rust-src, rustc-dev, llvm-tools-preview, rustc-codegen-cranelift"
+                && message.contains("component failed")
+        ),
+        "expected ToolchainComponentInstallFailed with all components, got {err:?}"
+    );
 }
 
 // Describes the type of installation failure being tested.

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -146,6 +146,80 @@ enum InstallFailure {
     ToolchainUnusableAfterInstall,
 }
 
+fn setup_toolchain_install_failure_mocks(
+    runner: &mut MockCommandRunner,
+    seq: &mut mockall::Sequence,
+    channel: &str,
+) {
+    expect_rustc_version(runner, seq, channel, 1);
+    expect_toolchain_install(
+        runner,
+        seq,
+        ToolchainInstallExpectation {
+            channel,
+            exit_code: 1,
+            stderr: Some("network down"),
+        },
+    );
+}
+
+fn setup_component_add_failure_mocks(
+    runner: &mut MockCommandRunner,
+    seq: &mut mockall::Sequence,
+    channel: &str,
+) {
+    expect_rustc_version(runner, seq, channel, 0);
+    runner
+        .expect_run()
+        .withf(|program, args| {
+            program == "rustup" && args.len() >= 4 && args[0] == "component" && args[1] == "add"
+        })
+        .times(1)
+        .in_sequence(seq)
+        .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
+}
+
+fn setup_cranelift_component_add_failure_mocks(
+    runner: &mut MockCommandRunner,
+    seq: &mut mockall::Sequence,
+    channel: &str,
+) {
+    let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
+    expect_rustc_version(runner, seq, channel, 0);
+    runner
+        .expect_run()
+        .withf(matches_multi_component_add(channel, &expected_components))
+        .times(1)
+        .in_sequence(seq)
+        .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
+}
+
+fn setup_toolchain_unusable_failure_mocks(
+    runner: &mut MockCommandRunner,
+    seq: &mut mockall::Sequence,
+    channel: &str,
+) {
+    expect_rustc_version(runner, seq, channel, 1);
+    expect_toolchain_install(
+        runner,
+        seq,
+        ToolchainInstallExpectation {
+            channel,
+            exit_code: 0,
+            stderr: None,
+        },
+    );
+    runner
+        .expect_run()
+        .withf(|program, args| {
+            program == "rustup" && args.len() >= 4 && args[0] == "component" && args[1] == "add"
+        })
+        .times(1)
+        .in_sequence(seq)
+        .returning(|_, _| Ok(output_with_status(0)));
+    expect_rustc_version(runner, seq, channel, 1);
+}
+
 fn setup_failure_mocks(
     runner: &mut MockCommandRunner,
     seq: &mut mockall::Sequence,
@@ -155,64 +229,16 @@ fn setup_failure_mocks(
     let channel = channel.as_str();
     match failure {
         InstallFailure::ToolchainInstall => {
-            expect_rustc_version(runner, seq, channel, 1);
-            expect_toolchain_install(
-                runner,
-                seq,
-                ToolchainInstallExpectation {
-                    channel,
-                    exit_code: 1,
-                    stderr: Some("network down"),
-                },
-            );
+            setup_toolchain_install_failure_mocks(runner, seq, channel);
         }
         InstallFailure::ComponentAdd => {
-            expect_rustc_version(runner, seq, channel, 0);
-            runner
-                .expect_run()
-                .withf(|program, args| {
-                    program == "rustup"
-                        && args.len() >= 4
-                        && args[0] == "component"
-                        && args[1] == "add"
-                })
-                .times(1)
-                .in_sequence(seq)
-                .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
+            setup_component_add_failure_mocks(runner, seq, channel);
         }
         InstallFailure::CraneliftComponentAdd => {
-            let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
-            expect_rustc_version(runner, seq, channel, 0);
-            runner
-                .expect_run()
-                .withf(matches_multi_component_add(channel, &expected_components))
-                .times(1)
-                .in_sequence(seq)
-                .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
+            setup_cranelift_component_add_failure_mocks(runner, seq, channel);
         }
         InstallFailure::ToolchainUnusableAfterInstall => {
-            expect_rustc_version(runner, seq, channel, 1);
-            expect_toolchain_install(
-                runner,
-                seq,
-                ToolchainInstallExpectation {
-                    channel,
-                    exit_code: 0,
-                    stderr: None,
-                },
-            );
-            runner
-                .expect_run()
-                .withf(|program, args| {
-                    program == "rustup"
-                        && args.len() >= 4
-                        && args[0] == "component"
-                        && args[1] == "add"
-                })
-                .times(1)
-                .in_sequence(seq)
-                .returning(|_, _| Ok(output_with_status(0)));
-            expect_rustc_version(runner, seq, channel, 1);
+            setup_toolchain_unusable_failure_mocks(runner, seq, channel);
         }
     }
 }

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -217,77 +217,68 @@ fn setup_failure_mocks(
     }
 }
 
-fn assert_toolchain_install_failed(err: InstallerError, channel: ToolchainChannel<'_>) {
-    let channel = channel.as_str();
-    assert!(
-        matches!(
-            err,
-            InstallerError::ToolchainInstallFailed { ref toolchain, ref message }
-                if toolchain == channel && message.contains("network down")
-        ),
-        "expected ToolchainInstallFailed error, got {err:?}"
-    );
+/// Asserts that `err` satisfies `predicate`, printing `description` on failure.
+fn assert_error_matches<F>(err: &InstallerError, description: &str, predicate: F)
+where
+    F: FnOnce(&InstallerError) -> bool,
+{
+    assert!(predicate(err), "expected {description}, got {err:?}");
 }
 
-fn assert_component_add_failed(err: InstallerError, channel: ToolchainChannel<'_>) {
-    let channel = channel.as_str();
-    assert!(
-        matches!(
-            err,
-            InstallerError::ToolchainComponentInstallFailed {
-                ref toolchain,
-                ref message,
-                ..
-            } if toolchain == channel && message.contains("component failed")
-        ),
-        "expected ToolchainComponentInstallFailed error, got {err:?}"
-    );
-}
-
-fn assert_cranelift_component_add_failed(err: InstallerError, channel: ToolchainChannel<'_>) {
-    let channel = channel.as_str();
-    assert!(
-        matches!(
-            err,
-            InstallerError::ToolchainComponentInstallFailed {
-                ref toolchain,
-                ref components,
-                ref message,
-            } if toolchain == channel
-                && components.contains(CRANELIFT_COMPONENT)
-                && message.contains("component failed")
-        ),
-        "expected ToolchainComponentInstallFailed with cranelift component, got {err:?}"
-    );
-}
-
-fn assert_toolchain_not_installed(err: InstallerError, channel: ToolchainChannel<'_>) {
-    let channel = channel.as_str();
-    assert!(
-        matches!(
-            err,
-            InstallerError::ToolchainNotInstalled { ref toolchain }
-                if toolchain == channel
-        ),
-        "expected ToolchainNotInstalled error, got {err:?}"
-    );
-}
-
-fn assert_failure_error(err: InstallerError, channel: ToolchainChannel<'_>, failure: InstallFailure) {
-    let channel = channel.as_str();
+fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFailure) {
     match failure {
-        InstallFailure::ToolchainInstall => {
-            assert_toolchain_install_failed(err, ToolchainChannel(channel))
-        }
-        InstallFailure::ComponentAdd => {
-            assert_component_add_failed(err, ToolchainChannel(channel))
-        }
-        InstallFailure::CraneliftComponentAdd => {
-            assert_cranelift_component_add_failed(err, ToolchainChannel(channel))
-        }
-        InstallFailure::ToolchainUnusableAfterInstall => {
-            assert_toolchain_not_installed(err, ToolchainChannel(channel))
-        }
+        InstallFailure::ToolchainInstall => assert_error_matches(
+            &err,
+            &format!("ToolchainInstallFailed for {channel}"),
+            |e| {
+                matches!(
+                    e,
+                    InstallerError::ToolchainInstallFailed { toolchain, message }
+                        if toolchain == channel && message.contains("network down")
+                )
+            },
+        ),
+        InstallFailure::ComponentAdd => assert_error_matches(
+            &err,
+            &format!("ToolchainComponentInstallFailed for {channel}"),
+            |e| {
+                matches!(
+                    e,
+                    InstallerError::ToolchainComponentInstallFailed {
+                        toolchain,
+                        message,
+                        ..
+                    } if toolchain == channel && message.contains("component failed")
+                )
+            },
+        ),
+        InstallFailure::CraneliftComponentAdd => assert_error_matches(
+            &err,
+            &format!("ToolchainComponentInstallFailed with cranelift for {channel}"),
+            |e| {
+                matches!(
+                    e,
+                    InstallerError::ToolchainComponentInstallFailed {
+                        toolchain,
+                        components,
+                        message,
+                    } if toolchain == channel
+                        && components.contains(CRANELIFT_COMPONENT)
+                        && message.contains("component failed")
+                )
+            },
+        ),
+        InstallFailure::ToolchainUnusableAfterInstall => assert_error_matches(
+            &err,
+            &format!("ToolchainNotInstalled for {channel}"),
+            |e| {
+                matches!(
+                    e,
+                    InstallerError::ToolchainNotInstalled { toolchain }
+                        if toolchain == channel
+                )
+            },
+        ),
     }
 }
 
@@ -308,7 +299,7 @@ fn ensure_installed_reports_failure(#[case] failure: InstallFailure) {
         toolchain,
         |runner, seq| setup_failure_mocks(runner, seq, channel, failure),
         |toolchain, runner| toolchain.ensure_installed_with(runner, additional_components),
-        |err| assert_failure_error(err, channel, failure),
+        |err| assert_failure_error(err, channel.as_str(), failure),
     );
 }
 

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -264,7 +264,9 @@ fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFail
         InstallFailure::CraneliftComponentAdd => {
             assert_cranelift_component_add_failed(err, channel)
         }
-        InstallFailure::ToolchainUnusableAfterInstall => assert_toolchain_not_installed(err, channel),
+        InstallFailure::ToolchainUnusableAfterInstall => {
+            assert_toolchain_not_installed(err, channel)
+        }
     }
 }
 

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -193,7 +193,7 @@ impl CapturingCommandRunner {
 }
 
 impl CommandRunner for CapturingCommandRunner {
-    fn run<'a>(&self, program: &str, args: &[&'a str]) -> std::io::Result<Output> {
+    fn run(&self, program: &str, args: &[&str]) -> std::io::Result<Output> {
         self.calls.borrow_mut().push((
             program.to_owned(),
             args.iter().map(|arg| (*arg).to_owned()).collect(),

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -4,7 +4,9 @@ mod failure_mocks;
 mod test_helpers;
 
 use super::*;
-use failure_mocks::{FailureSetup, InstallFailure, assert_failure_error, setup_failure_mocks};
+use failure_mocks::{
+    FailureSetup, InstallFailure, ToolchainChannel, assert_failure_error, setup_failure_mocks,
+};
 use rstest::rstest;
 use test_helpers::{
     CapturingCommandRunner, ToolchainInstallExpectation, expect_rustc_version,
@@ -207,8 +209,8 @@ fn ensure_installed_reports_failure(
     #[case] failure: InstallFailure,
     #[case] additional_components: &[&str],
 ) {
-    let channel = "nightly-2025-09-18";
-    let toolchain = test_toolchain(channel);
+    let channel = ToolchainChannel("nightly-2025-09-18");
+    let toolchain = test_toolchain(channel.as_str());
 
     test_helpers::assert_install_fails_with(
         toolchain,

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -10,6 +10,8 @@ use test_helpers::{
     test_toolchain,
 };
 
+const CRANELIFT_COMPONENT: &str = "rustc-codegen-cranelift";
+
 // Asserts that a parsing function rejects invalid contents with an
 // InvalidToolchainFile error containing the expected reason substring.
 fn assert_parse_fails_with_reason<F, T>(contents: &str, expected_reason: &str, parse_fn: F)
@@ -84,7 +86,7 @@ fn ensure_installed_installs_missing_toolchain() {
     expect_rustc_version(&mut runner, &mut seq, channel, 0);
 
     let status = toolchain
-        .ensure_installed_with(&runner)
+        .ensure_installed_with(&runner, &[])
         .expect("toolchain should install");
 
     assert!(status.installed_toolchain());
@@ -108,7 +110,52 @@ fn ensure_installed_adds_required_components_when_toolchain_present() {
         .returning(|_, _| Ok(output_with_status(0)));
 
     let status = toolchain
-        .ensure_installed_with(&runner)
+        .ensure_installed_with(&runner, &[])
+        .expect("toolchain should be ready");
+
+    assert!(!status.installed_toolchain());
+}
+
+#[test]
+fn ensure_installed_adds_cranelift_component_when_requested() {
+    let channel = "nightly-2025-09-18";
+    let toolchain = test_toolchain(channel);
+    let mut runner = MockCommandRunner::new();
+    let mut seq = mockall::Sequence::new();
+    let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
+
+    expect_rustc_version(&mut runner, &mut seq, channel, 0);
+    runner
+        .expect_run()
+        .withf(matches_multi_component_add(channel, &expected_components))
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|_, _| Ok(output_with_status(0)));
+
+    let status = toolchain
+        .ensure_installed_with(&runner, &[CRANELIFT_COMPONENT])
+        .expect("toolchain should be ready");
+
+    assert!(!status.installed_toolchain());
+}
+
+#[test]
+fn ensure_installed_adds_only_required_components_when_no_extras_requested() {
+    let channel = "nightly-2025-09-18";
+    let toolchain = test_toolchain(channel);
+    let mut runner = MockCommandRunner::new();
+    let mut seq = mockall::Sequence::new();
+
+    expect_rustc_version(&mut runner, &mut seq, channel, 0);
+    runner
+        .expect_run()
+        .withf(matches_multi_component_add(channel, REQUIRED_COMPONENTS))
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|_, _| Ok(output_with_status(0)));
+
+    let status = toolchain
+        .ensure_installed_with(&runner, &[])
         .expect("toolchain should be ready");
 
     assert!(!status.installed_toolchain());
@@ -119,6 +166,7 @@ fn ensure_installed_adds_required_components_when_toolchain_present() {
 enum InstallFailure {
     ToolchainInstall,
     ComponentAdd,
+    CraneliftComponentAdd,
     ToolchainUnusableAfterInstall,
 }
 
@@ -151,6 +199,16 @@ fn setup_failure_mocks(
                         && args[0] == "component"
                         && args[1] == "add"
                 })
+                .times(1)
+                .in_sequence(seq)
+                .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
+        }
+        InstallFailure::CraneliftComponentAdd => {
+            let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
+            expect_rustc_version(runner, seq, channel, 0);
+            runner
+                .expect_run()
+                .withf(matches_multi_component_add(channel, &expected_components))
                 .times(1)
                 .in_sequence(seq)
                 .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
@@ -198,8 +256,26 @@ fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFail
             assert!(
                 matches!(
                     err,
-                    InstallerError::ToolchainComponentInstallFailed { ref toolchain, ref message, .. }
-                        if toolchain == channel && message.contains("component failed")
+                    InstallerError::ToolchainComponentInstallFailed {
+                        ref toolchain,
+                        ref message,
+                        ..
+                    } if toolchain == channel && message.contains("component failed")
+                ),
+                "expected ToolchainComponentInstallFailed error, got {err:?}"
+            );
+        }
+        InstallFailure::CraneliftComponentAdd => {
+            assert!(
+                matches!(
+                    err,
+                    InstallerError::ToolchainComponentInstallFailed {
+                        ref toolchain,
+                        ref components,
+                        ref message,
+                    } if toolchain == channel
+                        && components.contains(CRANELIFT_COMPONENT)
+                        && message.contains("component failed")
                 ),
                 "expected ToolchainComponentInstallFailed error, got {err:?}"
             );
@@ -220,14 +296,20 @@ fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFail
 #[rstest]
 #[case::toolchain_install_fails(InstallFailure::ToolchainInstall)]
 #[case::component_add_fails(InstallFailure::ComponentAdd)]
+#[case::cranelift_component_add_fails(InstallFailure::CraneliftComponentAdd)]
 #[case::toolchain_unusable_after_install(InstallFailure::ToolchainUnusableAfterInstall)]
 fn ensure_installed_reports_failure(#[case] failure: InstallFailure) {
     let channel = "nightly-2025-09-18";
     let toolchain = test_toolchain(channel);
+    let additional_components = match failure {
+        InstallFailure::CraneliftComponentAdd => &[CRANELIFT_COMPONENT][..],
+        _ => &[],
+    };
 
     assert_install_fails_with(
         toolchain,
         |runner, seq| setup_failure_mocks(runner, seq, channel, failure),
+        |toolchain, runner| toolchain.ensure_installed_with(runner, additional_components),
         |err| assert_failure_error(err, channel, failure),
     );
 }

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -4,7 +4,7 @@ mod failure_mocks;
 mod test_helpers;
 
 use super::*;
-use failure_mocks::{InstallFailure, assert_failure_error, setup_failure_mocks};
+use failure_mocks::{FailureSetup, InstallFailure, assert_failure_error, setup_failure_mocks};
 use rstest::rstest;
 use test_helpers::{
     CapturingCommandRunner, ToolchainInstallExpectation, expect_rustc_version,
@@ -189,21 +189,40 @@ fn install_components_with_failure_reports_all_components() {
 }
 
 #[rstest]
-#[case::toolchain_install_fails(InstallFailure::ToolchainInstall)]
-#[case::component_add_fails(InstallFailure::ComponentAdd)]
-#[case::cranelift_component_add_fails(InstallFailure::CraneliftComponentAdd)]
-#[case::toolchain_unusable_after_install(InstallFailure::ToolchainUnusableAfterInstall)]
-fn ensure_installed_reports_failure(#[case] failure: InstallFailure) {
+#[case::toolchain_install_fails(InstallFailure::ToolchainInstall, &[])]
+#[case::component_add_fails(InstallFailure::ComponentAdd, &[])]
+#[case::cranelift_component_add_fails(
+    InstallFailure::CraneliftComponentAdd,
+    &[CRANELIFT_COMPONENT],
+)]
+#[case::toolchain_unusable_after_install(
+    InstallFailure::ToolchainUnusableAfterInstall,
+    &[],
+)]
+#[case::toolchain_unusable_after_install_with_cranelift(
+    InstallFailure::ToolchainUnusableAfterInstall,
+    &[CRANELIFT_COMPONENT],
+)]
+fn ensure_installed_reports_failure(
+    #[case] failure: InstallFailure,
+    #[case] additional_components: &[&str],
+) {
     let channel = "nightly-2025-09-18";
     let toolchain = test_toolchain(channel);
-    let additional_components = match failure {
-        InstallFailure::CraneliftComponentAdd => &[CRANELIFT_COMPONENT][..],
-        _ => &[],
-    };
 
     test_helpers::assert_install_fails_with(
         toolchain,
-        |runner, seq| setup_failure_mocks(runner, seq, channel, failure),
+        |runner, seq| {
+            setup_failure_mocks(
+                runner,
+                seq,
+                channel,
+                FailureSetup {
+                    failure,
+                    additional_components,
+                },
+            )
+        },
         |toolchain, runner| toolchain.ensure_installed_with(runner, additional_components),
         |err| assert_failure_error(err, channel, failure),
     );

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -205,56 +205,66 @@ fn setup_failure_mocks(
     }
 }
 
+fn assert_toolchain_install_failed(err: InstallerError, channel: &str) {
+    assert!(
+        matches!(
+            err,
+            InstallerError::ToolchainInstallFailed { ref toolchain, ref message }
+                if toolchain == channel && message.contains("network down")
+        ),
+        "expected ToolchainInstallFailed error, got {err:?}"
+    );
+}
+
+fn assert_component_add_failed(err: InstallerError, channel: &str) {
+    assert!(
+        matches!(
+            err,
+            InstallerError::ToolchainComponentInstallFailed {
+                ref toolchain,
+                ref message,
+                ..
+            } if toolchain == channel && message.contains("component failed")
+        ),
+        "expected ToolchainComponentInstallFailed error, got {err:?}"
+    );
+}
+
+fn assert_cranelift_component_add_failed(err: InstallerError, channel: &str) {
+    assert!(
+        matches!(
+            err,
+            InstallerError::ToolchainComponentInstallFailed {
+                ref toolchain,
+                ref components,
+                ref message,
+            } if toolchain == channel
+                && components.contains(CRANELIFT_COMPONENT)
+                && message.contains("component failed")
+        ),
+        "expected ToolchainComponentInstallFailed with cranelift component, got {err:?}"
+    );
+}
+
+fn assert_toolchain_not_installed(err: InstallerError, channel: &str) {
+    assert!(
+        matches!(
+            err,
+            InstallerError::ToolchainNotInstalled { ref toolchain }
+                if toolchain == channel
+        ),
+        "expected ToolchainNotInstalled error, got {err:?}"
+    );
+}
+
 fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFailure) {
     match failure {
-        InstallFailure::ToolchainInstall => {
-            assert!(
-                matches!(
-                    err,
-                    InstallerError::ToolchainInstallFailed { ref toolchain, ref message }
-                        if toolchain == channel && message.contains("network down")
-                ),
-                "expected ToolchainInstallFailed error, got {err:?}"
-            );
-        }
-        InstallFailure::ComponentAdd => {
-            assert!(
-                matches!(
-                    err,
-                    InstallerError::ToolchainComponentInstallFailed {
-                        ref toolchain,
-                        ref message,
-                        ..
-                    } if toolchain == channel && message.contains("component failed")
-                ),
-                "expected ToolchainComponentInstallFailed error, got {err:?}"
-            );
-        }
+        InstallFailure::ToolchainInstall => assert_toolchain_install_failed(err, channel),
+        InstallFailure::ComponentAdd => assert_component_add_failed(err, channel),
         InstallFailure::CraneliftComponentAdd => {
-            assert!(
-                matches!(
-                    err,
-                    InstallerError::ToolchainComponentInstallFailed {
-                        ref toolchain,
-                        ref components,
-                        ref message,
-                    } if toolchain == channel
-                        && components.contains(CRANELIFT_COMPONENT)
-                        && message.contains("component failed")
-                ),
-                "expected ToolchainComponentInstallFailed error, got {err:?}"
-            );
+            assert_cranelift_component_add_failed(err, channel)
         }
-        InstallFailure::ToolchainUnusableAfterInstall => {
-            assert!(
-                matches!(
-                    err,
-                    InstallerError::ToolchainNotInstalled { ref toolchain }
-                        if toolchain == channel
-                ),
-                "expected ToolchainNotInstalled error, got {err:?}"
-            );
-        }
+        InstallFailure::ToolchainUnusableAfterInstall => assert_toolchain_not_installed(err, channel),
     }
 }
 

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -225,6 +225,24 @@ where
     assert!(predicate(err), "expected {description}, got {err:?}");
 }
 
+fn is_cranelift_component_install_failed(err: &InstallerError, channel: &str) -> bool {
+    let InstallerError::ToolchainComponentInstallFailed {
+        toolchain,
+        components,
+        message,
+    } = err
+    else {
+        return false;
+    };
+    if toolchain != channel {
+        return false;
+    }
+    if !components.contains(CRANELIFT_COMPONENT) {
+        return false;
+    }
+    message.contains("component failed")
+}
+
 fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFailure) {
     match failure {
         InstallFailure::ToolchainInstall => assert_error_matches(
@@ -255,18 +273,7 @@ fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFail
         InstallFailure::CraneliftComponentAdd => assert_error_matches(
             &err,
             &format!("ToolchainComponentInstallFailed with cranelift for {channel}"),
-            |e| {
-                matches!(
-                    e,
-                    InstallerError::ToolchainComponentInstallFailed {
-                        toolchain,
-                        components,
-                        message,
-                    } if toolchain == channel
-                        && components.contains(CRANELIFT_COMPONENT)
-                        && message.contains("component failed")
-                )
-            },
+            |e| is_cranelift_component_install_failed(e, channel),
         ),
         InstallFailure::ToolchainUnusableAfterInstall => assert_error_matches(
             &err,

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -1,28 +1,18 @@
 //! Tests for toolchain detection and installation.
 
+mod failure_mocks;
 mod test_helpers;
 
 use super::*;
+use failure_mocks::{InstallFailure, assert_failure_error, setup_failure_mocks};
 use rstest::rstest;
-use std::cell::RefCell;
 use test_helpers::{
-    ToolchainInstallExpectation, assert_install_fails_with, expect_rustc_version,
+    CapturingCommandRunner, ToolchainInstallExpectation, expect_rustc_version,
     expect_toolchain_install, matches_multi_component_add, output_with_status, output_with_stderr,
     test_toolchain,
 };
 
 const CRANELIFT_COMPONENT: &str = "rustc-codegen-cranelift";
-
-/// A typed toolchain channel identifier for use in tests
-/// (e.g. `"nightly-2025-09-18"`).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct ToolchainChannel<'a>(&'a str);
-
-impl<'a> ToolchainChannel<'a> {
-    fn as_str(self) -> &'a str {
-        self.0
-    }
-}
 
 // Asserts that a parsing function rejects invalid contents with an
 // InvalidToolchainFile error containing the expected reason substring.
@@ -174,34 +164,6 @@ fn ensure_installed_adds_correct_components(
     run_component_installation_test(&extra, &expected);
 }
 
-struct CapturingCommandRunner {
-    calls: RefCell<Vec<(String, Vec<String>)>>,
-    output: Output,
-}
-
-impl CapturingCommandRunner {
-    fn new(output: Output) -> Self {
-        Self {
-            calls: RefCell::new(Vec::new()),
-            output,
-        }
-    }
-
-    fn recorded_calls(&self) -> Vec<(String, Vec<String>)> {
-        self.calls.borrow().clone()
-    }
-}
-
-impl CommandRunner for CapturingCommandRunner {
-    fn run(&self, program: &str, args: &[&str]) -> std::io::Result<Output> {
-        self.calls.borrow_mut().push((
-            program.to_owned(),
-            args.iter().map(|arg| (*arg).to_owned()).collect(),
-        ));
-        Ok(self.output.clone())
-    }
-}
-
 #[test]
 fn install_components_with_additional_components_assembles_rustup_args_in_order() {
     let toolchain = test_toolchain("nightly-2025-09-18");
@@ -227,6 +189,8 @@ fn install_components_with_additional_components_assembles_rustup_args_in_order(
 fn install_components_with_failure_reports_all_components() {
     let toolchain = test_toolchain("nightly-2025-09-18");
     let runner = CapturingCommandRunner::new(output_with_stderr(1, "component failed"));
+    let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
+    let expected_component_list = expected_components.join(", ");
 
     let err = toolchain
         .install_components_with(&runner, &[CRANELIFT_COMPONENT])
@@ -240,187 +204,11 @@ fn install_components_with_failure_reports_all_components() {
                 ref components,
                 ref message,
             } if toolchain == "nightly-2025-09-18"
-                && components == "rust-src, rustc-dev, llvm-tools-preview, rustc-codegen-cranelift"
+                && components == &expected_component_list
                 && message.contains("component failed")
         ),
         "expected ToolchainComponentInstallFailed with all components, got {err:?}"
     );
-}
-
-// Describes the type of installation failure being tested.
-#[derive(Debug, Clone, Copy)]
-enum InstallFailure {
-    ToolchainInstall,
-    ComponentAdd,
-    CraneliftComponentAdd,
-    ToolchainUnusableAfterInstall,
-}
-
-fn setup_toolchain_install_failure_mocks(
-    runner: &mut MockCommandRunner,
-    seq: &mut mockall::Sequence,
-    channel: &str,
-) {
-    expect_rustc_version(runner, seq, channel, 1);
-    expect_toolchain_install(
-        runner,
-        seq,
-        ToolchainInstallExpectation {
-            channel,
-            exit_code: 1,
-            stderr: Some("network down"),
-        },
-    );
-}
-
-fn setup_component_add_failure_mocks(
-    runner: &mut MockCommandRunner,
-    seq: &mut mockall::Sequence,
-    channel: &str,
-) {
-    expect_rustc_version(runner, seq, channel, 0);
-    runner
-        .expect_run()
-        .withf(|program, args| {
-            program == "rustup" && args.len() >= 4 && args[0] == "component" && args[1] == "add"
-        })
-        .times(1)
-        .in_sequence(seq)
-        .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
-}
-
-fn setup_cranelift_component_add_failure_mocks(
-    runner: &mut MockCommandRunner,
-    seq: &mut mockall::Sequence,
-    channel: &str,
-) {
-    let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
-    expect_rustc_version(runner, seq, channel, 0);
-    runner
-        .expect_run()
-        .withf(matches_multi_component_add(channel, &expected_components))
-        .times(1)
-        .in_sequence(seq)
-        .returning(|_, _| Ok(output_with_stderr(1, "component failed")));
-}
-
-fn setup_toolchain_unusable_failure_mocks(
-    runner: &mut MockCommandRunner,
-    seq: &mut mockall::Sequence,
-    channel: &str,
-) {
-    expect_rustc_version(runner, seq, channel, 1);
-    expect_toolchain_install(
-        runner,
-        seq,
-        ToolchainInstallExpectation {
-            channel,
-            exit_code: 0,
-            stderr: None,
-        },
-    );
-    runner
-        .expect_run()
-        .withf(|program, args| {
-            program == "rustup" && args.len() >= 4 && args[0] == "component" && args[1] == "add"
-        })
-        .times(1)
-        .in_sequence(seq)
-        .returning(|_, _| Ok(output_with_status(0)));
-    expect_rustc_version(runner, seq, channel, 1);
-}
-
-fn setup_failure_mocks(
-    runner: &mut MockCommandRunner,
-    seq: &mut mockall::Sequence,
-    channel: ToolchainChannel<'_>,
-    failure: InstallFailure,
-) {
-    let channel = channel.as_str();
-    match failure {
-        InstallFailure::ToolchainInstall => {
-            setup_toolchain_install_failure_mocks(runner, seq, channel);
-        }
-        InstallFailure::ComponentAdd => {
-            setup_component_add_failure_mocks(runner, seq, channel);
-        }
-        InstallFailure::CraneliftComponentAdd => {
-            setup_cranelift_component_add_failure_mocks(runner, seq, channel);
-        }
-        InstallFailure::ToolchainUnusableAfterInstall => {
-            setup_toolchain_unusable_failure_mocks(runner, seq, channel);
-        }
-    }
-}
-
-/// Asserts that `err` satisfies `predicate`, printing `description` on failure.
-fn assert_error_matches<F>(err: &InstallerError, description: &str, predicate: F)
-where
-    F: FnOnce(&InstallerError) -> bool,
-{
-    assert!(predicate(err), "expected {description}, got {err:?}");
-}
-
-fn is_cranelift_component_install_failed(err: &InstallerError, channel: &str) -> bool {
-    let InstallerError::ToolchainComponentInstallFailed {
-        toolchain,
-        components,
-        message,
-    } = err
-    else {
-        return false;
-    };
-    if toolchain != channel {
-        return false;
-    }
-    if !components.contains(CRANELIFT_COMPONENT) {
-        return false;
-    }
-    message.contains("component failed")
-}
-
-fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFailure) {
-    match failure {
-        InstallFailure::ToolchainInstall => assert_error_matches(
-            &err,
-            &format!("ToolchainInstallFailed for {channel}"),
-            |e| {
-                matches!(
-                    e,
-                    InstallerError::ToolchainInstallFailed { toolchain, message }
-                        if toolchain == channel && message.contains("network down")
-                )
-            },
-        ),
-        InstallFailure::ComponentAdd => assert_error_matches(
-            &err,
-            &format!("ToolchainComponentInstallFailed for {channel}"),
-            |e| {
-                matches!(
-                    e,
-                    InstallerError::ToolchainComponentInstallFailed {
-                        toolchain,
-                        message,
-                        ..
-                    } if toolchain == channel && message.contains("component failed")
-                )
-            },
-        ),
-        InstallFailure::CraneliftComponentAdd => assert_error_matches(
-            &err,
-            &format!("ToolchainComponentInstallFailed with cranelift for {channel}"),
-            |e| is_cranelift_component_install_failed(e, channel),
-        ),
-        InstallFailure::ToolchainUnusableAfterInstall => {
-            assert_error_matches(&err, &format!("ToolchainNotInstalled for {channel}"), |e| {
-                matches!(
-                    e,
-                    InstallerError::ToolchainNotInstalled { toolchain }
-                        if toolchain == channel
-                )
-            })
-        }
-    }
 }
 
 #[rstest]
@@ -429,18 +217,18 @@ fn assert_failure_error(err: InstallerError, channel: &str, failure: InstallFail
 #[case::cranelift_component_add_fails(InstallFailure::CraneliftComponentAdd)]
 #[case::toolchain_unusable_after_install(InstallFailure::ToolchainUnusableAfterInstall)]
 fn ensure_installed_reports_failure(#[case] failure: InstallFailure) {
-    let channel = ToolchainChannel("nightly-2025-09-18");
-    let toolchain = test_toolchain(channel.as_str());
+    let channel = "nightly-2025-09-18";
+    let toolchain = test_toolchain(channel);
     let additional_components = match failure {
         InstallFailure::CraneliftComponentAdd => &[CRANELIFT_COMPONENT][..],
         _ => &[],
     };
 
-    assert_install_fails_with(
+    test_helpers::assert_install_fails_with(
         toolchain,
         |runner, seq| setup_failure_mocks(runner, seq, channel, failure),
         |toolchain, runner| toolchain.ensure_installed_with(runner, additional_components),
-        |err| assert_failure_error(err, channel.as_str(), failure),
+        |err| assert_failure_error(err, channel, failure),
     );
 }
 

--- a/installer/src/toolchain/tests/test_helpers.rs
+++ b/installer/src/toolchain/tests/test_helpers.rs
@@ -123,9 +123,14 @@ pub fn expect_toolchain_install(
 }
 
 // Helper to test that ensure_installed fails with the expected error.
-pub fn assert_install_fails_with<F, E>(toolchain: Toolchain, setup_mocks: F, error_matcher: E)
-where
+pub fn assert_install_fails_with<F, I, E>(
+    toolchain: Toolchain,
+    setup_mocks: F,
+    install: I,
+    error_matcher: E,
+) where
     F: FnOnce(&mut MockCommandRunner, &mut mockall::Sequence),
+    I: FnOnce(&Toolchain, &MockCommandRunner) -> Result<ToolchainInstallStatus>,
     E: FnOnce(InstallerError),
 {
     let mut runner = MockCommandRunner::new();
@@ -133,9 +138,7 @@ where
 
     setup_mocks(&mut runner, &mut seq);
 
-    let err = toolchain
-        .ensure_installed_with(&runner)
-        .expect_err("expected installation failure");
+    let err = install(&toolchain, &runner).expect_err("expected installation failure");
 
     error_matcher(err);
 }
@@ -144,16 +147,22 @@ where
 pub fn matches_multi_component_add(
     channel: &str,
     components: &[&str],
-) -> impl Fn(&str, &[&str]) -> bool {
+) -> impl Fn(&str, &[&str]) -> bool + use<> {
     let channel = channel.to_owned();
     let components: Vec<String> = components.iter().map(|s| (*s).to_owned()).collect();
     move |program, args| {
+        let Some(actual_components) = args.get(4..) else {
+            return false;
+        };
         program == "rustup"
-            && args.len() == 4 + components.len()
             && args[0] == "component"
             && args[1] == "add"
             && args[2] == "--toolchain"
             && args[3] == channel
-            && args[4..].iter().zip(&components).all(|(a, b)| *a == b)
+            && actual_components.len() == components.len()
+            && actual_components
+                .iter()
+                .zip(&components)
+                .all(|(a, b)| *a == b)
     }
 }

--- a/installer/src/toolchain/tests/test_helpers.rs
+++ b/installer/src/toolchain/tests/test_helpers.rs
@@ -122,7 +122,7 @@ pub fn expect_toolchain_install(
     );
 }
 
-// Helper to test that ensure_installed fails with the expected error.
+/// Helper to test that ensure_installed fails with the expected error.
 pub fn assert_install_fails_with<F, I, E>(
     toolchain: Toolchain,
     setup_mocks: F,
@@ -143,7 +143,7 @@ pub fn assert_install_fails_with<F, I, E>(
     error_matcher(err);
 }
 
-// Returns a predicate that matches a rustup component add command with multiple components.
+/// Returns a predicate that matches a rustup component add command with multiple components.
 pub fn matches_multi_component_add(
     channel: &str,
     components: &[&str],

--- a/installer/src/toolchain/tests/test_helpers.rs
+++ b/installer/src/toolchain/tests/test_helpers.rs
@@ -1,6 +1,7 @@
 //! Test helpers for toolchain tests.
 
 use super::*;
+use std::cell::RefCell;
 use std::process::ExitStatus;
 
 #[cfg(unix)]
@@ -37,6 +38,34 @@ pub fn test_toolchain(channel: &str) -> Toolchain {
     Toolchain {
         channel: channel.to_owned(),
         workspace_root: Utf8PathBuf::from("."),
+    }
+}
+
+pub(crate) struct CapturingCommandRunner {
+    calls: RefCell<Vec<(String, Vec<String>)>>,
+    output: Output,
+}
+
+impl CapturingCommandRunner {
+    pub(crate) fn new(output: Output) -> Self {
+        Self {
+            calls: RefCell::new(Vec::new()),
+            output,
+        }
+    }
+
+    pub(crate) fn recorded_calls(&self) -> Vec<(String, Vec<String>)> {
+        self.calls.borrow().clone()
+    }
+}
+
+impl CommandRunner for CapturingCommandRunner {
+    fn run(&self, program: &str, args: &[&str]) -> std::io::Result<Output> {
+        self.calls.borrow_mut().push((
+            program.to_owned(),
+            args.iter().map(|arg| (*arg).to_owned()).collect(),
+        ));
+        Ok(self.output.clone())
     }
 }
 

--- a/installer/src/toolchain/tests/test_helpers.rs
+++ b/installer/src/toolchain/tests/test_helpers.rs
@@ -41,12 +41,14 @@ pub fn test_toolchain(channel: &str) -> Toolchain {
     }
 }
 
+/// Captures command invocations and returns a preconfigured `Output`.
 pub(crate) struct CapturingCommandRunner {
     calls: RefCell<Vec<(String, Vec<String>)>>,
     output: Output,
 }
 
 impl CapturingCommandRunner {
+    /// Creates a capture runner that clones `output` for every executed command.
     pub(crate) fn new(output: Output) -> Self {
         Self {
             calls: RefCell::new(Vec::new()),
@@ -54,6 +56,7 @@ impl CapturingCommandRunner {
         }
     }
 
+    /// Returns a cloned list of recorded `(program, args)` pairs without mutating state.
     pub(crate) fn recorded_calls(&self) -> Vec<(String, Vec<String>)> {
         self.calls.borrow().clone()
     }


### PR DESCRIPTION
## Summary
- add an explicit `--cranelift` installer flag and thread it through Whitaker toolchain setup
- let toolchain component installation append `rustc-codegen-cranelift` when requested and report the full requested component set on failure
- extend installer tests and docs for the new flow, and harden the dependency-binary behaviour test that was environment-sensitive during validation

## Validation
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`

Closes #207

## Summary by Sourcery

Add support for optionally installing extra rustup components, including rustc-codegen-cranelift, during Whitaker toolchain provisioning and streamline fast-path installation handling.

New Features:
- Introduce a --cranelift CLI flag to request installation of the rustc-codegen-cranelift rustup component.
- Allow the installer to pass additional requested components into toolchain provisioning so they are installed alongside required components.

Enhancements:
- Refine toolchain installation error reporting to include the full set of requested components when component installation fails.
- Factor out shared logic for fast-path installations (prebuilt download and staged-suite) into a reusable helper and context struct.
- Improve test helpers and matchers for component installation to support variable component sets and better error assertions.

Documentation:
- Document the new --cranelift option in the installer README, user guide, and developer guide.

Tests:
- Extend CLI, toolchain, and installer tests to cover the new cranelift flag, additional component handling, and more robust failure scenarios.