### PR TITLE
Roadmap audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           version: 'latest'
 
       - name: Install Nixie
-        run: uv tool install --from git+https://github.com/leynos/nixie nixie
+        run: uv tool install nixie-cli
 
       - name: Nixie
         run: make nixie

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           version: 'latest'
 
       - name: Install Nixie
-        run: uv tool install nixie-cli
+        run: uv tool install "nixie-cli==1.0.0"
 
       - name: Nixie
         run: make nixie

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/act
 __pycache__/
 *.py[cod]
 *.so
+*:Zone.Identifier

--- a/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
+++ b/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
@@ -219,7 +219,7 @@ Axinite’s migration audit found repeated cases where a trait had *no direct dy
 call sites* but still could not migrate because a dyn-backed trait inherited it
 as a supertrait. [^3]
 
-So we compute `dyn_required` as:
+`dyn_required` is computed as:
 
 ```text
 dyn_required = dyn_used ∪ supertraits_transitive(dyn_used)
@@ -251,7 +251,7 @@ while let Some(t) = worklist.pop():
 ADR 006 formalizes the naming rule: keep `Tool`/`Database`/… as the dyn-facing
 trait name, and use `NativeTool`/`NativeDatabase` as the sibling. [^1]
 
-We detect siblings by finding, for a given dyn-facing trait `T`:
+Sibling traits are detected by finding, for a given dyn-facing trait `T`:
 
 - expected native name = `format!("{prefix}{T}")` (default prefix `Native`)
 - sibling must live in the same parent module (same `tcx.parent(def_id)`),
@@ -265,7 +265,7 @@ repeated trait names.
 The ADR defines the adapter as a blanket impl bridging `Native*` into the dyn
 trait. [^1]
 
-We treat an impl as the family’s canonical adapter when all hold:
+An impl is treated as the family’s canonical adapter when all hold:
 
 - it implements the **dyn-facing** trait,
 - the self type is a type parameter (e.g. `T`) rather than a concrete type, and
@@ -281,7 +281,7 @@ condition, because HIR body matching across rustc versions is brittle.
 ADR 006 recommends a single boxed-future alias to keep signatures readable (and
 to avoid repeating long `Pin<Box<dyn Future…>>` types). [^1]
 
-We detect aliases by scanning `type` items and matching the syntactic shape:
+Aliases are detected by scanning `type` items and matching the syntactic shape:
 
 - outer: `Pin< … >` in `core::pin` or `std::pin`
 - inner: `Box< … >` in `alloc::boxed` or `std::boxed`

--- a/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
+++ b/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
@@ -1,10 +1,12 @@
 # Async-trait architecture hygiene dylint suite design for Whitaker
 
-Status: Proposed Scope: Single-crate async-trait architecture hygiene lint
-suite with no cross-crate analysis. Primary audience: Whitaker compiler and
-lint maintainers, and Rust contributors. Precedence documents: Axinite ADR 006,
-`docs/whitaker-dylint-suite-design.md`, and later ADRs or roadmap decisions
-that supersede this design.
+- Status: Proposed
+- Scope: Single-crate async-trait architecture hygiene lint suite with no
+  cross-crate analysis.
+- Primary audience: Whitaker compiler and lint maintainers, and Rust
+  contributors.
+- Precedence: Axinite ADR 006, `docs/whitaker-dylint-suite-design.md`, and
+  later ADRs or roadmap decisions that supersede this design.
 
 ## 1. Executive summary
 
@@ -158,6 +160,8 @@ for early rollout; others become “ratchets” once a family is migrated.
 | `native_async_future_must_be_send`                  | compatibility restriction | deny    | Native sibling method returns `impl Future` without `+ Send` when policy requires Send parity                                        | Inspect `Native*` trait method return bounds; require explicit `+ Send` unless family marked `allow_nonsend`                                                                        | Config toggle per family (for `#[async_trait(?Send)]`-equivalent designs)                                                                    | Add `+ Send` to return type                                                                            | `ui/native_missing_send_deny.rs`, `ui/native_nonsend_allowed.rs`     |
 | `native_async_multi_borrow_requires_named_lifetime` | maintainability           | warn    | Native sibling method uses `+ '_` but captures more than `&self` (multi-borrow), risking E0477-style failure and brittle signatures  | Detect `impl Future + … + '_` combined with ≥2 reference-bearing inputs; require an explicit named lifetime parameter applied consistently                                          | Only fire when a `'_` lifetime appears explicitly; allowlist specific methods                                                                | Introduce `'a` and apply to all borrows and return `+ 'a`                                              | `ui/native_multi_borrow_lifetime_warn.rs`                            |
 | `async_trait_signature_markers_present`             | restriction               | warn    | “High confidence” `async-trait` macro expansion markers still present (eg. `< 'async_trait>` lifetime + boxed dyn future return)     | Inspect trait/impl method generics for `'async_trait` and return types for boxed dyn futures with `'async_trait` bound                                                              | Allow on legacy modules; ignore `async_trait` name collisions by requiring both markers                                                      | Migrate to native/dual-trait pattern; eliminate macro-generated signature                              | `ui/async_trait_markers_warn.rs`                                     |
+
+Table: Async-trait architecture hygiene lint catalogue.
 
 The Axinite rollout explicitly called out two recurrent migration
 hazards—losing implicit `Send` guarantees and multi-borrow lifetime binding—so

--- a/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
+++ b/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
@@ -1,6 +1,12 @@
 # Async-trait architecture hygiene dylint suite design for Whitaker
 
-## Executive summary
+Status: Proposed Scope: Single-crate async-trait architecture hygiene lint
+suite with no cross-crate analysis. Primary audience: Whitaker compiler and
+lint maintainers, and Rust contributors. Precedence documents: Axinite ADR 006,
+`docs/whitaker-dylint-suite-design.md`, and later ADRs or roadmap decisions
+that supersede this design.
+
+## 1. Executive summary
 
 The goal of this design is to add an opinionated, architecture-hygiene lint
 suite to the Whitaker Dylint workspace that makes “async + dyn dispatch”
@@ -22,9 +28,9 @@ The suite is intentionally scoped to single-crate analysis (no cross-crate
 inventories, no workspace-wide graphing), mirroring existing Whitaker design
 choices and keeping performance predictable. [^2]
 
-## Repository reconnaissance
+## 2. Repository reconnaissance
 
-### Whitaker locations inspected
+### 2.1 Whitaker locations inspected
 
 The existing Whitaker workspace is structured around per-lint `cdylib` crates
 under `crates/*`, a shared `common` helper crate, and an aggregated suite crate
@@ -40,7 +46,7 @@ Code-level “HIR helper” precedent exists in `src/hir.rs` (module spans,
 attribute conversion, test-attribute detection), which is an obvious
 integration point for a new trait-family index. [^2]
 
-### Axinite materials inspected
+### 2.2 Axinite materials inspected
 
 Axinite’s migration plan and ADR provide the design target and concrete failure
 modes the lints should encode:
@@ -53,7 +59,7 @@ modes the lints should encode:
 - ExecPlan: “Roll out ADR 006…” (wave-based rollout discipline, explicit `Send`
   policy, and evidence collection expectations). [^3]
 
-### External primary sources consulted
+### 2.3 External primary sources consulted
 
 This design relies on primary/official sources for language constraints and
 library mechanics:
@@ -74,9 +80,9 @@ library mechanics:
   `cfg_attr(dylint_lib=...)`, but pre-expansion lints require
   `#[allow(unknown_lints)]` to avoid “unknown lint” warnings. [^8]
 
-## Goals, scope, non-goals, and taxonomy
+## 3. Goals, scope, non-goals, and taxonomy
 
-### Goals
+### 3.1 Goals
 
 The suite should:
 
@@ -95,7 +101,7 @@ The suite should:
    `Send`-bound parity and multi-borrow lifetime binding—into lintable
    structural rules. [^1][^3]
 
-### Scope
+### 3.2 Scope
 
 These lints operate at the Rust compiler HIR/type-check level and are
 crate-local, consistent with Whitaker’s existing approach to local analysis and
@@ -106,7 +112,7 @@ families, dispatch modes, and boundary representations; it is allowed to be
 opinionated, but it must ship with strong false-positive controls and clear
 “escape hatch” guidance.
 
-### Non-goals
+### 3.3 Non-goals
 
 - Cross-crate / whole-workspace enforcement (for example, proving that *no
   downstream crate* uses a trait as `dyn`). This is not a tractable contract
@@ -119,7 +125,7 @@ opinionated, but it must ship with strong false-positive controls and clear
   evidence as a separate artefact captured by CI commands like
   `cargo check --timings`, not something enforced via static analysis. [^3]
 
-### Categorization taxonomy for Whitaker lints
+### 3.4 Categorization taxonomy for Whitaker lints
 
 Whitaker already uses a “kind” vocabulary such as `style`, `restriction`,
 `pedantic`, and `maintainability`. [^2] To avoid “random bugbear” accretion,
@@ -135,12 +141,12 @@ this suite should commit to a narrow taxonomy mapping:
   behaviour during or after migration (eg. requiring `+ Send` where
   `async-trait` previously implied it by default). [^5][^3]
 
-## Lint catalogue
+## 4. Lint catalogue
 
 The suite is intended as a *cohesive set*: some lints are “inventory”/advisory
 for early rollout; others become “ratchets” once a family is migrated.
 
-### Proposed lint table
+### 4.1 Proposed lint table
 
 | Lint name                                           | Kind                      | Default | Trigger summary                                                                                                                      | HIR queries and patterns                                                                                                                                                            | False-positive controls                                                                                                                      | Suggested fix                                                                                          | Canonical UI tests                                                   |
 | --------------------------------------------------- | ------------------------- | ------: | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
@@ -158,16 +164,16 @@ hazards—losing implicit `Send` guarantees and multi-borrow lifetime binding—
 those are treated as first-class lint rules rather than “docs-only” advice.
 [^1][^3]
 
-### Implementation notes on lint granularity
+### 4.2 Implementation notes on lint granularity
 
 The lints are deliberately fine-grained rather than one monolithic “ADR 006
 compliance” lint. This enables migration waves that start with inventory-only
 warnings and end with a small number of `deny` ratchets once a family is
 migrated, matching Axinite’s incremental approach. [^3]
 
-## Shared analysis design
+## 5. Shared analysis design
 
-### AsyncTraitFamilyIndex fields
+### 5.1 AsyncTraitFamilyIndex fields
 
 The `AsyncTraitFamilyIndex` is a crate-local, derived-data index computed once
 per compilation session (per crate being linted). It is analogous in spirit to
@@ -192,9 +198,9 @@ the index. [^2]
 Determinism note: choose `BTreeMap/BTreeSet` for stable iteration and stable
 diagnostics ordering, consistent with other Whitaker architecture designs. [^2]
 
-### Algorithms
+### 5.2 Algorithms
 
-#### Candidate trait discovery
+#### 5.2.1 Candidate trait discovery
 
 A “candidate async interface trait” is a local trait that contains at least one
 method whose return type is either:
@@ -206,7 +212,7 @@ This intentionally classifies both hand-written boxed-future dyn traits and
 `async-trait` macro output, because for architecture hygiene they are the same
 artefact: an object-safe async boundary expressed via erased futures. [^5]
 
-#### Dyn-use closure and supertrait closure
+#### 5.2.2 Dyn-use closure and supertrait closure
 
 Two language facts shape the closure computation:
 
@@ -246,7 +252,7 @@ while let Some(t) = worklist.pop():
     if dyn_required.insert(s): worklist.push(s)
 ```
 
-#### Native sibling detection
+#### 5.2.3 Native sibling detection
 
 ADR 006 formalizes the naming rule: keep `Tool`/`Database`/… as the dyn-facing
 trait name, and use `NativeTool`/`NativeDatabase` as the sibling. [^1]
@@ -260,7 +266,7 @@ Sibling traits are detected by finding, for a given dyn-facing trait `T`:
 This “same parent” rule keeps the match unambiguous in large codebases with
 repeated trait names.
 
-#### Blanket adapter detection
+#### 5.2.4 Blanket adapter detection
 
 The ADR defines the adapter as a blanket impl bridging `Native*` into the dyn
 trait. [^1]
@@ -276,7 +282,7 @@ Method-body inspection (e.g. checking for `Box::pin(NativeTrait::method(..))`)
 is optional and should be a second-stage “confidence upgrade”, not a required
 condition, because HIR body matching across rustc versions is brittle.
 
-#### Boxed-future alias detection
+#### 5.2.5 Boxed-future alias detection
 
 ADR 006 recommends a single boxed-future alias to keep signatures readable (and
 to avoid repeating long `Pin<Box<dyn Future…>>` types). [^1]
@@ -289,7 +295,7 @@ Aliases are detected by scanning `type` items and matching the syntactic shape:
 
 This detection is deliberately syntactic/structural rather than string-based.
 
-### Family graph diagram
+### 5.3 Family graph diagram
 
 This diagram shows how dyn-facing and native sibling traits connect through the
 blanket adapter and concrete implementation choices.
@@ -310,9 +316,9 @@ flowchart TD
 Caption: Family graph showing dyn-facing traits, native siblings, and the
 blanket adapter.
 
-## Integration plan and rollout strategy
+## 6. Integration plan and rollout strategy
 
-### Shared helper placement in Whitaker
+### 6.1 Shared helper placement in Whitaker
 
 Whitaker distinguishes between:
 
@@ -334,7 +340,7 @@ Proposed module layout:
 - `whitaker/src/async_trait_hygiene/config.rs` (shared config structs and
   parsing helpers)
 
-### New lint crates
+### 6.2 New lint crates
 
 Whitaker’s documented convention is one lint per `cdylib` crate with
 feature-gated rustc dependencies. [^2]
@@ -346,7 +352,7 @@ on:
   `AsyncTraitFamilyIndex`)
 - `common` (diagnostic helpers, i18n, etc)
 
-### Suite plumbing
+### 6.3 Suite plumbing
 
 There are two viable integration modes:
 
@@ -359,7 +365,7 @@ There are two viable integration modes:
 Either way, the suite wiring pattern is clear: add lint declarations to the
 suite list and register pass types in the combined pass. [^2]
 
-### Configuration model
+### 6.4 Configuration model
 
 A practical config model for migration waves:
 
@@ -378,7 +384,7 @@ Directory/crate overrides should be implemented via explicit allowlists and
 path-prefix matching against `SourceMap` filenames, not by attempting to infer
 Cargo workspace structure from inside rustc.
 
-### Migration waves and default levels
+### 6.5 Migration waves and default levels
 
 Align the rollout with Axinite’s “prove in waves” discipline (inventory →
 migrate family-by-family → ratchet). [^3]
@@ -399,7 +405,7 @@ Suggested wave policy:
     in production modules
   - warn on direct dyn impls where native+adapter exist
 
-#### Rollout timeline diagram
+#### 6.5.1 Rollout timeline diagram
 
 This diagram summarizes the staged rollout from inventory to migration and then
 to the regression-prevention ratchet.
@@ -422,9 +428,9 @@ timeline
 
 Caption: Rollout timeline showing the inventory, migration, and ratchet waves.
 
-## Performance, CI boundaries, and open decisions
+## 7. Performance, CI boundaries, and open decisions
 
-### Performance and compile-time cost considerations
+### 7.1 Performance and compile-time cost considerations
 
 The motivation for eliminating `async-trait` in dyn-heavy codebases is not
 “micro-optimizing futures”; it is reducing proc-macro expansion and boilerplate
@@ -447,7 +453,7 @@ For the lint suite itself, the expensive step is building
 This is consistent with Whitaker’s documented preference for local, linear
 analyses rather than global program graphs. [^2]
 
-### CI and xtask responsibilities versus lints
+### 7.2 CI and xtask responsibilities versus lints
 
 Two responsibilities should explicitly remain outside lints:
 
@@ -461,7 +467,7 @@ Two responsibilities should explicitly remain outside lints:
   limitation is structurally unavoidable for per-crate linting and should be
   documented prominently.
 
-### Pending architectural decisions and trade-offs
+### 7.3 Pending architectural decisions and trade-offs
 
 **Alias locality versus shared alias module.** ADR 006 defaults to a shared
 boxed-future alias (“one helper module”) to reduce signature verbosity.
@@ -499,7 +505,7 @@ encourage teams to pair it with a separate, workspace-level audit step when
 planning migrations, matching Axinite’s discipline of explicit inventories and
 approvals. [^1][^3]
 
-## References
+## 8. References
 
 [^1]: Axinite ADR 006, `Dual-trait pattern for dyn-backed async interfaces`.
       <https://raw.githubusercontent.com/leynos/axinite/refs/heads/main/docs/adr-006-dual-trait-pattern-for-dyn-backed-async-interfaces.md>

--- a/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
+++ b/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
@@ -1,4 +1,4 @@
-# Async-trait Architecture Hygiene Dylint Suite Design for Whitaker
+# Async-trait architecture hygiene dylint suite design for Whitaker
 
 ## Executive summary
 

--- a/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
+++ b/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
@@ -291,6 +291,9 @@ This detection is deliberately syntactic/structural rather than string-based.
 
 ### Family graph diagram
 
+This diagram shows how dyn-facing and native sibling traits connect through the
+blanket adapter and concrete implementation choices.
+
 ```mermaid
 flowchart TD
   DynUse["dyn call sites\n(Box/Arc/&dyn)"] --> DynTrait["Dyn-facing trait\nFoo: object-safe\nreturns BoxFuture"]
@@ -303,6 +306,9 @@ flowchart TD
   ImplTypes["Concrete types"] -->|prefer| NativeTrait
   ImplTypes -->|escape hatch| DynTrait
 ```
+
+Caption: Family graph showing dyn-facing traits, native siblings, and the
+blanket adapter.
 
 ## Integration plan and rollout strategy
 
@@ -395,6 +401,9 @@ Suggested wave policy:
 
 #### Rollout timeline diagram
 
+This diagram summarizes the staged rollout from inventory to migration and then
+to the regression-prevention ratchet.
+
 ```mermaid
 timeline
   title Async-trait hygiene lint rollout
@@ -410,6 +419,8 @@ timeline
     Deny macro-signature regressions : C
     Tighten adapter requirements : C
 ```
+
+Caption: Rollout timeline showing the inventory, migration, and ratchet waves.
 
 ## Performance, CI boundaries, and open decisions
 

--- a/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
+++ b/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
@@ -28,15 +28,13 @@ choices and keeping performance predictable. [^2]
 
 The existing Whitaker workspace is structured around per-lint `cdylib` crates
 under `crates/*`, a shared `common` helper crate, and an aggregated suite crate
-that registers multiple lints in one Dylint library.
-[^2] The suite wiring uses a combined late lint pass
-and a registry list of included lints. [^2]
+that registers multiple lints in one Dylint library. [^2] The suite wiring uses
+a combined late lint pass and a registry list of included lints. [^2]
 
 For lint-crate ergonomics and build hygiene, Whitaker uses feature-gating
 (`dylint-driver`) to keep `rustc_private` dependencies out of unit-test builds,
-and enables `constituent` for suite aggregation. [^2]
-The root `whitaker` crate already hosts `rustc_private`-bound helpers behind
-the same feature gate. [^2]
+and enables `constituent` for suite aggregation. [^2] The root `whitaker` crate
+already hosts `rustc_private`-bound helpers behind the same feature gate. [^2]
 
 Code-level “HIR helper” precedent exists in `src/hir.rs` (module spans,
 attribute conversion, test-attribute detection), which is an obvious
@@ -65,8 +63,7 @@ library mechanics:
   not dyn-compatible. [^4]
 - `async-trait` docs: the crate exists specifically to support async-in-traits
   with dyn traits by erasing the future to `Pin<Box<dyn Future + …>>`; it
-  defaults to `Send` futures unless `#[async_trait(?Send)]` is used.
-  [^5]
+  defaults to `Send` futures unless `#[async_trait(?Send)]` is used. [^5]
 - Rust Blog announcement for `async fn`/RPITIT in traits: dynamic dispatch
   remains unsupported; `trait-variant` is positioned as a utility, with dyn
   support described as future work. [^6]
@@ -75,8 +72,7 @@ library mechanics:
   explicit `+ Send` when that matters. [^7]
 - Dylint docs: conditional compilation works for most lints via
   `cfg_attr(dylint_lib=...)`, but pre-expansion lints require
-  `#[allow(unknown_lints)]` to avoid “unknown lint” warnings.
-  [^8]
+  `#[allow(unknown_lints)]` to avoid “unknown lint” warnings. [^8]
 
 ## Goals, scope, non-goals, and taxonomy
 
@@ -89,8 +85,7 @@ The suite should:
    relationships that implicitly tie traits to dyn usage.
 2. Enforce the ADR 006 dual-trait pattern **where dynamic dispatch is actually
    in play**: dyn-facing trait returning boxed futures, sibling `Native*` trait
-   returning `impl Future + Send`, and blanket adapter bridging them.
-   [^1]
+   returning `impl Future + Send`, and blanket adapter bridging them. [^1]
 3. Prevent unnecessary use of `async-trait`-style boxing when the trait is not
    dyn-required (directly or as a supertrait of a dyn trait), reflecting
    Axinite’s real-world discovery that “concrete-only” candidates were rarer
@@ -122,15 +117,13 @@ opinionated, but it must ship with strong false-positive controls and clear
   whole-program rewrites.
 - Measuring compile times inside lints. Axinite’s rollout plan treats timing
   evidence as a separate artefact captured by CI commands like
-  `cargo check --timings`, not something enforced via static analysis.
-  [^3]
+  `cargo check --timings`, not something enforced via static analysis. [^3]
 
 ### Categorization taxonomy for Whitaker lints
 
 Whitaker already uses a “kind” vocabulary such as `style`, `restriction`,
-`pedantic`, and `maintainability`. [^2] To avoid
-“random bugbear” accretion, this suite should commit to a narrow taxonomy
-mapping:
+`pedantic`, and `maintainability`. [^2] To avoid “random bugbear” accretion,
+this suite should commit to a narrow taxonomy mapping:
 
 - **restriction**: rules that prevent semantically risky or
   architecture-breaking patterns (eg. reintroducing `async-trait` boxing on a
@@ -140,8 +133,7 @@ mapping:
 - **compatibility** (documented sublabel, but mapped to
   restriction/maintainability in crate docs): rules whose purpose is preserving
   behaviour during or after migration (eg. requiring `+ Send` where
-  `async-trait` previously implied it by default).
-  [^5][^3]
+  `async-trait` previously implied it by default). [^5][^3]
 
 ## Lint catalogue
 
@@ -198,8 +190,7 @@ the index. [^2]
 | `diagnostic_paths`     | small strings                                 | `tcx.def_path_str(def_id)` snapshots for messages                                                  | stable reporting                               |
 
 Determinism note: choose `BTreeMap/BTreeSet` for stable iteration and stable
-diagnostics ordering, consistent with other Whitaker architecture designs.
-[^2]
+diagnostics ordering, consistent with other Whitaker architecture designs. [^2]
 
 ### Algorithms
 
@@ -213,16 +204,14 @@ method whose return type is either:
 
 This intentionally classifies both hand-written boxed-future dyn traits and
 `async-trait` macro output, because for architecture hygiene they are the same
-artefact: an object-safe async boundary expressed via erased futures.
-[^5]
+artefact: an object-safe async boundary expressed via erased futures. [^5]
 
 #### Dyn-use closure and supertrait closure
 
 Two language facts shape the closure computation:
 
 - Trait objects require a dyn-compatible base trait, and trait objects
-  implement the base trait **and its supertraits**.
-  [^4]
+  implement the base trait **and its supertraits**. [^4]
 - `async fn` and return-position `impl Trait` prevent dyn compatibility.
   [^4][^5]
 
@@ -260,8 +249,7 @@ while let Some(t) = worklist.pop():
 #### Native sibling detection
 
 ADR 006 formalizes the naming rule: keep `Tool`/`Database`/… as the dyn-facing
-trait name, and use `NativeTool`/`NativeDatabase` as the sibling.
-[^1]
+trait name, and use `NativeTool`/`NativeDatabase` as the sibling. [^1]
 
 We detect siblings by finding, for a given dyn-facing trait `T`:
 
@@ -327,11 +315,10 @@ Whitaker distinguishes between:
   `dylint-driver` feature. [^2]
 
 `AsyncTraitFamilyIndex` should live in the `whitaker` crate (not `common`)
-under `#[cfg(feature = "dylint-driver")]`, alongside existing HIR helpers.
-[^2] This keeps the index available to lint crates
-without forcing compiler dependencies into `common`, consistent with other
-Whitaker designs that keep pure logic separate from extraction.
-[^2]
+under `#[cfg(feature = "dylint-driver")]`, alongside existing HIR helpers. [^2]
+This keeps the index available to lint crates without forcing compiler
+dependencies into `common`, consistent with other Whitaker designs that keep
+pure logic separate from extraction. [^2]
 
 Proposed module layout:
 
@@ -364,8 +351,7 @@ There are two viable integration modes:
   Cargo feature on the suite crate so teams opt in explicitly.
 
 Either way, the suite wiring pattern is clear: add lint declarations to the
-suite list and register pass types in the combined pass.
-[^2]
+suite list and register pass types in the combined pass. [^2]
 
 ### Configuration model
 
@@ -433,10 +419,10 @@ The motivation for eliminating `async-trait` in dyn-heavy codebases is not
 “micro-optimizing futures”; it is reducing proc-macro expansion and boilerplate
 generation. Axinite measured 158 `async-trait` uses across 74 files early in
 the migration and described each use as generating boxing/dynamic dispatch
-boilerplate at compile time. [^3] The `async-trait` crate
-documentation confirms the core mechanical transformation into boxed futures
-and the default `Send` behaviour, which are exactly the costs and semantics
-teams must make explicit when migrating. [^5]
+boilerplate at compile time. [^3] The `async-trait` crate documentation
+confirms the core mechanical transformation into boxed futures and the default
+`Send` behaviour, which are exactly the costs and semantics teams must make
+explicit when migrating. [^5]
 
 For the lint suite itself, the expensive step is building
 `AsyncTraitFamilyIndex`. The design keeps that cost bounded:
@@ -468,25 +454,25 @@ Two responsibilities should explicitly remain outside lints:
 
 **Alias locality versus shared alias module.** ADR 006 defaults to a shared
 boxed-future alias (“one helper module”) to reduce signature verbosity.
-[^1][^3] Whitaker lints should support both “one canonical
-alias” and “family-local alias” modes, because some codebases prefer keeping
-interface types private to the module. The trade-off is between global
-consistency (better for large migrations) and local encapsulation.
+[^1][^3] Whitaker lints should support both “one canonical alias” and
+“family-local alias” modes, because some codebases prefer keeping interface
+types private to the module. The trade-off is between global consistency
+(better for large migrations) and local encapsulation.
 
 **Native trait surface form.** Using `fn -> impl Future + Send` in `Native*`
 traits avoids both dyn-compatibility issues and the rustc `async_fn_in_trait`
-warning about unspecified auto-trait bounds on futures.
-[^7][^6] This suite should treat
-`async fn` *in native sibling traits* as a lintable smell (at least for
-exported traits), even if it sometimes compiles fine, because it undermines the
-main point of the native sibling: making `Send`/lifetime bounds explicit.
+warning about unspecified auto-trait bounds on futures. [^7][^6] This suite
+should treat `async fn` *in native sibling traits* as a lintable smell (at
+least for exported traits), even if it sometimes compiles fine, because it
+undermines the main point of the native sibling: making `Send`/lifetime bounds
+explicit.
 
 **Detecting `#[async_trait]` usage.** A pre-expansion lint would be the most
 direct way to catch the attribute, but Dylint’s own documentation notes that
-pre-expansion lints have special “unknown lint” suppression requirements.
-[^8] The proposed `async_trait_signature_markers_present` lint
-avoids that complexity by detecting high-confidence expansion markers in HIR
-instead. The trade-off is that it is a heuristic (though a strong one).
+pre-expansion lints have special “unknown lint” suppression requirements. [^8]
+The proposed `async_trait_signature_markers_present` lint avoids that
+complexity by detecting high-confidence expansion markers in HIR instead. The
+trade-off is that it is a heuristic (though a strong one).
 
 **How hard to enforce “generic bounds prefer Native*”.** This can quickly
 become a high false-positive rule because a generic bound may exist for future
@@ -495,13 +481,12 @@ The design therefore keeps this as an optional “advisory” lint (not in the
 initial core) unless a downstream team explicitly wants to ratchet on it.
 
 **Cross-crate truth versus crate-local truth.** Because trait objects include
-supertraits, crate-local closure computation is necessary and useful.
-[^4] But it still cannot capture downstream dyn
-usage. The suite should expose this limitation directly in help text for
-`async_trait_concrete_only`, and strongly encourage teams to pair it with a
-separate, workspace-level audit step when planning migrations, matching
-Axinite’s discipline of explicit inventories and approvals.
-[^1][^3]
+supertraits, crate-local closure computation is necessary and useful. [^4] But
+it still cannot capture downstream dyn usage. The suite should expose this
+limitation directly in help text for `async_trait_concrete_only`, and strongly
+encourage teams to pair it with a separate, workspace-level audit step when
+planning migrations, matching Axinite’s discipline of explicit inventories and
+approvals. [^1][^3]
 
 ## References
 

--- a/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
+++ b/docs/async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md
@@ -1,0 +1,535 @@
+# Async-trait Architecture Hygiene Dylint Suite Design for Whitaker
+
+## Executive summary
+
+The goal of this design is to add an opinionated, architecture-hygiene lint
+suite to the Whitaker Dylint workspace that makes “async + dyn dispatch”
+interfaces explicit, consistent, and enforceable, while also preventing teams
+from reaching for `async-trait` when they do not actually need dynamic
+dispatch. The suite operationalizes the dual-trait pattern described in Axinite
+ADR 006: keep an object-safe dyn-facing trait that returns boxed futures, add a
+`Native*` sibling trait that returns `impl Future + Send`, and bridge them with
+a blanket adapter. [^1]
+
+The technical centrepiece is a shared crate-local analysis,
+`AsyncTraitFamilyIndex`, built once per compilation session and reused by
+multiple lints. It identifies dyn-backed “async interface families”, computes
+the dyn-required closure (direct dyn uses plus supertrait closure), detects
+`Native*` siblings, blanket adapters, and boxed-future aliases, and exposes
+enough derived structure to make individual lints cheap and deterministic.
+
+The suite is intentionally scoped to single-crate analysis (no cross-crate
+inventories, no workspace-wide graphing), mirroring existing Whitaker design
+choices and keeping performance predictable. [^2]
+
+## Repository reconnaissance
+
+### Whitaker locations inspected
+
+The existing Whitaker workspace is structured around per-lint `cdylib` crates
+under `crates/*`, a shared `common` helper crate, and an aggregated suite crate
+that registers multiple lints in one Dylint library.
+[^2] The suite wiring uses a combined late lint pass
+and a registry list of included lints. [^2]
+
+For lint-crate ergonomics and build hygiene, Whitaker uses feature-gating
+(`dylint-driver`) to keep `rustc_private` dependencies out of unit-test builds,
+and enables `constituent` for suite aggregation. [^2]
+The root `whitaker` crate already hosts `rustc_private`-bound helpers behind
+the same feature gate. [^2]
+
+Code-level “HIR helper” precedent exists in `src/hir.rs` (module spans,
+attribute conversion, test-attribute detection), which is an obvious
+integration point for a new trait-family index. [^2]
+
+### Axinite materials inspected
+
+Axinite’s migration plan and ADR provide the design target and concrete failure
+modes the lints should encode:
+
+- ExecPlan: “Migrate from async-trait to native async traits” (inventory,
+  dyn-blocking reality, and incremental batching). [^3]
+- ADR 006: “Dual-trait pattern for dyn-backed async interfaces” (accepted
+  shape, BoxFuture alias convention, blanket adapter, and migration gotchas).
+  [^1]
+- ExecPlan: “Roll out ADR 006…” (wave-based rollout discipline, explicit `Send`
+  policy, and evidence collection expectations). [^3]
+
+### External primary sources consulted
+
+This design relies on primary/official sources for language constraints and
+library mechanics:
+
+- Rust Reference: trait objects require a dyn-compatible base trait; dyn traits
+  include supertraits; `async fn` and return-position `impl Trait` make a trait
+  not dyn-compatible. [^4]
+- `async-trait` docs: the crate exists specifically to support async-in-traits
+  with dyn traits by erasing the future to `Pin<Box<dyn Future + …>>`; it
+  defaults to `Send` futures unless `#[async_trait(?Send)]` is used.
+  [^5]
+- Rust Blog announcement for `async fn`/RPITIT in traits: dynamic dispatch
+  remains unsupported; `trait-variant` is positioned as a utility, with dyn
+  support described as future work. [^6]
+- rustc’s `async_fn_in_trait` lint rationale: public async trait methods do not
+  promise auto-trait bounds like `Send` on the returned future, motivating
+  explicit `+ Send` when that matters. [^7]
+- Dylint docs: conditional compilation works for most lints via
+  `cfg_attr(dylint_lib=...)`, but pre-expansion lints require
+  `#[allow(unknown_lints)]` to avoid “unknown lint” warnings.
+  [^8]
+
+## Goals, scope, non-goals, and taxonomy
+
+### Goals
+
+The suite should:
+
+1. Detect and classify dyn-backed async interface families (trait +
+   implementations + call sites) in a single crate, including supertrait
+   relationships that implicitly tie traits to dyn usage.
+2. Enforce the ADR 006 dual-trait pattern **where dynamic dispatch is actually
+   in play**: dyn-facing trait returning boxed futures, sibling `Native*` trait
+   returning `impl Future + Send`, and blanket adapter bridging them.
+   [^1]
+3. Prevent unnecessary use of `async-trait`-style boxing when the trait is not
+   dyn-required (directly or as a supertrait of a dyn trait), reflecting
+   Axinite’s real-world discovery that “concrete-only” candidates were rarer
+   than expected once dyn usage and supertrait inheritance were accounted for.
+   [^3]
+4. Encode the migration “sharp edges” observed during rollout—especially
+   `Send`-bound parity and multi-borrow lifetime binding—into lintable
+   structural rules. [^1][^3]
+
+### Scope
+
+These lints operate at the Rust compiler HIR/type-check level and are
+crate-local, consistent with Whitaker’s existing approach to local analysis and
+avoidance of whole-program graphing. [^2]
+
+The suite targets **architecture hygiene**, not style: it reasons about trait
+families, dispatch modes, and boundary representations; it is allowed to be
+opinionated, but it must ship with strong false-positive controls and clear
+“escape hatch” guidance.
+
+### Non-goals
+
+- Cross-crate / whole-workspace enforcement (for example, proving that *no
+  downstream crate* uses a trait as `dyn`). This is not a tractable contract
+  for a Dylint pass running per crate and is explicitly avoided by other
+  Whitaker “architecture-ish” designs. [^2]
+- Automated refactors. The suite should suggest shapes (and occasionally
+  machine-applicable edits for local syntax), but it should not attempt
+  whole-program rewrites.
+- Measuring compile times inside lints. Axinite’s rollout plan treats timing
+  evidence as a separate artefact captured by CI commands like
+  `cargo check --timings`, not something enforced via static analysis.
+  [^3]
+
+### Categorization taxonomy for Whitaker lints
+
+Whitaker already uses a “kind” vocabulary such as `style`, `restriction`,
+`pedantic`, and `maintainability`. [^2] To avoid
+“random bugbear” accretion, this suite should commit to a narrow taxonomy
+mapping:
+
+- **restriction**: rules that prevent semantically risky or
+  architecture-breaking patterns (eg. reintroducing `async-trait` boxing on a
+  dyn-backed family that has an established native sibling).
+- **maintainability**: rules that preserve consistency and readability of
+  boundary signatures (eg. boxed-future alias uniformity).
+- **compatibility** (documented sublabel, but mapped to
+  restriction/maintainability in crate docs): rules whose purpose is preserving
+  behaviour during or after migration (eg. requiring `+ Send` where
+  `async-trait` previously implied it by default).
+  [^5][^3]
+
+## Lint catalogue
+
+The suite is intended as a *cohesive set*: some lints are “inventory”/advisory
+for early rollout; others become “ratchets” once a family is migrated.
+
+### Proposed lint table
+
+| Lint name                                           | Kind                      | Default | Trigger summary                                                                                                                      | HIR queries and patterns                                                                                                                                                            | False-positive controls                                                                                                                      | Suggested fix                                                                                          | Canonical UI tests                                                   |
+| --------------------------------------------------- | ------------------------- | ------: | ------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `async_trait_concrete_only`                         | maintainability           | warn    | Trait uses boxed-future async pattern but is **not dyn-required** in this crate                                                      | Build `dyn_required` set from `dyn Trait` uses plus supertrait closure; identify boxed-future async traits by return types matching boxed-future alias or `Pin<Box<dyn Future…>>`   | Ignore traits in allowlist; ignore macro-expanded items by default; optionally require “high confidence” `async-trait` signature markers     | Convert trait to native `fn -> impl Future + …` or `async fn` in impls; remove boxing                  | `ui/concrete_only_trait_warn.rs`, `ui/supertrait_blocked_no_warn.rs` |
+| `async_dyn_family_requires_native_sibling`          | restriction               | warn    | Dyn-required boxed-future trait lacks `Native*` sibling                                                                              | Detect dyn-facing traits (dyn-required + boxed-future methods); sibling lookup by same parent module + name convention                                                              | Allowlist of traits or modules; ignore test-only modules; configurable naming prefix/suffix                                                  | Add `NativeX` trait with `fn -> impl Future + Send` and delegate defaults                              | `ui/dyn_trait_missing_native.rs`                                     |
+| `async_dyn_family_requires_blanket_adapter`         | restriction               | warn    | Dyn-facing + native sibling exist but no blanket adapter bridging them                                                               | Scan `impl Trait for T` items; identify adapter as impl of dyn trait for a type param with a where-bound on `Native*`                                                               | Allow explicit “manual impl allowed” setting per family; ignore provided trait impls in macro expansions                                     | Add `impl<X: NativeX + …> X for X` pattern and delegate methods via `Box::pin(NativeX::m(self,…))`     | `ui/missing_blanket_impl.rs`                                         |
+| `async_dyn_direct_impl_prefers_native`              | maintainability           | warn    | A concrete type implements dyn-facing trait directly even though a native sibling + blanket adapter exist                            | For each impl of dyn trait, if self-type is concrete (not a type param) and family has adapter, flag                                                                                | Allow in tests; allow via `#[allow]`; allowlist for tiny fakes                                                                               | Implement `Native*` instead; rely on blanket impl for dyn trait                                        | `ui/direct_dyn_impl_warn.rs`                                         |
+| `async_dyn_boxed_future_alias_required`             | maintainability           | warn    | Dyn-facing trait method return types spell out `Pin<Box<dyn Future…>>` (or vary inconsistently) instead of using a family alias      | Inspect dyn-facing trait methods; classify return ty; require it be a path to an approved alias def_id                                                                              | Allow futures’ `BoxFuture` by config; ignore single-method traits by config                                                                  | Introduce/standardize `type XFuture<'a, T> = …` and use it                                             | `ui/raw_pin_box_return_warn.rs`                                      |
+| `native_async_future_must_be_send`                  | compatibility restriction | deny    | Native sibling method returns `impl Future` without `+ Send` when policy requires Send parity                                        | Inspect `Native*` trait method return bounds; require explicit `+ Send` unless family marked `allow_nonsend`                                                                        | Config toggle per family (for `#[async_trait(?Send)]`-equivalent designs)                                                                    | Add `+ Send` to return type                                                                            | `ui/native_missing_send_deny.rs`, `ui/native_nonsend_allowed.rs`     |
+| `native_async_multi_borrow_requires_named_lifetime` | maintainability           | warn    | Native sibling method uses `+ '_` but captures more than `&self` (multi-borrow), risking E0477-style failure and brittle signatures  | Detect `impl Future + … + '_` combined with ≥2 reference-bearing inputs; require an explicit named lifetime parameter applied consistently                                          | Only fire when a `'_` lifetime appears explicitly; allowlist specific methods                                                                | Introduce `'a` and apply to all borrows and return `+ 'a`                                              | `ui/native_multi_borrow_lifetime_warn.rs`                            |
+| `async_trait_signature_markers_present`             | restriction               | warn    | “High confidence” `async-trait` macro expansion markers still present (eg. `< 'async_trait>` lifetime + boxed dyn future return)     | Inspect trait/impl method generics for `'async_trait` and return types for boxed dyn futures with `'async_trait` bound                                                              | Allow on legacy modules; ignore `async_trait` name collisions by requiring both markers                                                      | Migrate to native/dual-trait pattern; eliminate macro-generated signature                              | `ui/async_trait_markers_warn.rs`                                     |
+
+The Axinite rollout explicitly called out two recurrent migration
+hazards—losing implicit `Send` guarantees and multi-borrow lifetime binding—so
+those are treated as first-class lint rules rather than “docs-only” advice.
+[^1][^3]
+
+### Implementation notes on lint granularity
+
+The lints are deliberately fine-grained rather than one monolithic “ADR 006
+compliance” lint. This enables migration waves that start with inventory-only
+warnings and end with a small number of `deny` ratchets once a family is
+migrated, matching Axinite’s incremental approach. [^3]
+
+## Shared analysis design
+
+### AsyncTraitFamilyIndex fields
+
+The `AsyncTraitFamilyIndex` is a crate-local, derived-data index computed once
+per compilation session (per crate being linted). It is analogous in spirit to
+“metric builder” helpers elsewhere in Whitaker: do the expensive work once,
+keep results deterministic, and let individual lints become simple queries over
+the index. [^2]
+
+| Field                  | Type                                          | Computation source                                                                                 | Used by                                        |
+| ---------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `traits`               | `BTreeMap<DefId, TraitInfo>`                  | HIR item traversal of local traits                                                                 | all lints                                      |
+| `dyn_uses`             | `BTreeMap<DefId, Vec<Span>>`                  | Visitor over `hir::TyKind::TraitObject` occurrences                                                | `async_trait_concrete_only`, dyn-family rules  |
+| `supertraits`          | `BTreeMap<DefId, Vec<DefId>>`                 | From each trait’s declared bounds                                                                  | dyn-closure computation                        |
+| `dyn_required`         | `BTreeSet<DefId>`                             | `dyn_uses` plus transitive supertrait closure                                                      | “concrete-only” and dyn-family classifiers     |
+| `boxed_future_aliases` | `BTreeMap<DefId, BoxedFutureAliasInfo>`       | Scan `type` aliases; match `Pin<Box<dyn Future…>>` shape                                           | alias lints, family classification             |
+| `trait_method_shapes`  | `BTreeMap<(DefId, Symbol), AsyncMethodShape>` | For each trait method, inspect return type and bounds                                              | family method matching, Send/lifetime rules    |
+| `impls`                | `Vec<ImplInfo>`                               | Scan `impl` items; record `trait_def_id`, `self_ty_kind`, where-bounds                             | adapter detection, impl counts                 |
+| `adapter_impls`        | `BTreeMap<DefId, AdapterInfo>`                | Filter `impls` to “blanket impl implementing dyn trait for type param bounded by native trait”     | adapter-required lint, direct-impl lint        |
+| `native_siblings`      | `BTreeMap<DefId, NativeSiblingInfo>`          | Name convention + same-parent module lookup                                                        | family completeness lints                      |
+| `impl_counts`          | `BTreeMap<DefId, ImplCounts>`                 | Aggregate `impls` by trait                                                                         | severity heuristics and messaging              |
+| `diagnostic_paths`     | small strings                                 | `tcx.def_path_str(def_id)` snapshots for messages                                                  | stable reporting                               |
+
+Determinism note: choose `BTreeMap/BTreeSet` for stable iteration and stable
+diagnostics ordering, consistent with other Whitaker architecture designs.
+[^2]
+
+### Algorithms
+
+#### Candidate trait discovery
+
+A “candidate async interface trait” is a local trait that contains at least one
+method whose return type is either:
+
+- A known boxed-future alias (as discovered by `boxed_future_aliases`), or
+- A syntactic shape matching `Pin<Box<dyn Future<Output=…> + … + 'a>>`.
+
+This intentionally classifies both hand-written boxed-future dyn traits and
+`async-trait` macro output, because for architecture hygiene they are the same
+artefact: an object-safe async boundary expressed via erased futures.
+[^5]
+
+#### Dyn-use closure and supertrait closure
+
+Two language facts shape the closure computation:
+
+- Trait objects require a dyn-compatible base trait, and trait objects
+  implement the base trait **and its supertraits**.
+  [^4]
+- `async fn` and return-position `impl Trait` prevent dyn compatibility.
+  [^4][^5]
+
+Axinite’s migration audit found repeated cases where a trait had *no direct dyn
+call sites* but still could not migrate because a dyn-backed trait inherited it
+as a supertrait. [^3]
+
+So we compute `dyn_required` as:
+
+```text
+dyn_required = dyn_used ∪ supertraits_transitive(dyn_used)
+```
+
+HIR-oriented pseudocode:
+
+```rust
+// Step 1: direct dyn uses
+visit all hir::Ty:
+  if TyKind::TraitObject(bounds, ..):
+    for trait_bound in bounds:
+      dyn_used[trait_def_id(trait_bound)].push(ty.span)
+
+// Step 2: supertrait edges for local traits
+for each local trait ItemKind::Trait(.., bounds, ..):
+  supertraits[trait_def_id] = bounds.filter_map(bound_trait_def_id)
+
+// Step 3: closure
+dyn_required = dyn_used.keys()
+worklist = dyn_used.keys()
+while let Some(t) = worklist.pop():
+  for s in supertraits[t]:
+    if dyn_required.insert(s): worklist.push(s)
+```
+
+#### Native sibling detection
+
+ADR 006 formalizes the naming rule: keep `Tool`/`Database`/… as the dyn-facing
+trait name, and use `NativeTool`/`NativeDatabase` as the sibling.
+[^1]
+
+We detect siblings by finding, for a given dyn-facing trait `T`:
+
+- expected native name = `format!("{prefix}{T}")` (default prefix `Native`)
+- sibling must live in the same parent module (same `tcx.parent(def_id)`),
+  unless `allow_cross_module_siblings = true` in config.
+
+This “same parent” rule keeps the match unambiguous in large codebases with
+repeated trait names.
+
+#### Blanket adapter detection
+
+The ADR defines the adapter as a blanket impl bridging `Native*` into the dyn
+trait. [^1]
+
+We treat an impl as the family’s canonical adapter when all hold:
+
+- it implements the **dyn-facing** trait,
+- the self type is a type parameter (e.g. `T`) rather than a concrete type, and
+- the where-clause includes `T: NativeTrait` (plus any required auto
+  traits/bounds).
+
+Method-body inspection (e.g. checking for `Box::pin(NativeTrait::method(..))`)
+is optional and should be a second-stage “confidence upgrade”, not a required
+condition, because HIR body matching across rustc versions is brittle.
+
+#### Boxed-future alias detection
+
+ADR 006 recommends a single boxed-future alias to keep signatures readable (and
+to avoid repeating long `Pin<Box<dyn Future…>>` types). [^1]
+
+We detect aliases by scanning `type` items and matching the syntactic shape:
+
+- outer: `Pin< … >` in `core::pin` or `std::pin`
+- inner: `Box< … >` in `alloc::boxed` or `std::boxed`
+- boxed element: `dyn Future<Output = X> + … + 'a` (with optional `Send`)
+
+This detection is deliberately syntactic/structural rather than string-based.
+
+### Family graph diagram
+
+```mermaid
+flowchart TD
+  DynUse["dyn call sites\n(Box/Arc/&dyn)"] --> DynTrait["Dyn-facing trait\nFoo: object-safe\nreturns BoxFuture"]
+  DynTrait -->|supertraits| Super["Supertraits\nFoo: Bar + Baz"]
+
+  NativeTrait["Native sibling trait\nNativeFoo\nreturns impl Future + Send"]
+  --> Adapter["Blanket adapter\nimpl<T: NativeFoo> Foo for T"]
+  Adapter --> DynTrait
+
+  ImplTypes["Concrete types"] -->|prefer| NativeTrait
+  ImplTypes -->|escape hatch| DynTrait
+```
+
+## Integration plan and rollout strategy
+
+### Shared helper placement in Whitaker
+
+Whitaker distinguishes between:
+
+- a compiler-independent `common` crate, and
+- `rustc_private`-bound helpers in the root `whitaker` crate behind the
+  `dylint-driver` feature. [^2]
+
+`AsyncTraitFamilyIndex` should live in the `whitaker` crate (not `common`)
+under `#[cfg(feature = "dylint-driver")]`, alongside existing HIR helpers.
+[^2] This keeps the index available to lint crates
+without forcing compiler dependencies into `common`, consistent with other
+Whitaker designs that keep pure logic separate from extraction.
+[^2]
+
+Proposed module layout:
+
+- `whitaker/src/async_trait_hygiene/mod.rs`
+- `whitaker/src/async_trait_hygiene/index.rs`
+- `whitaker/src/async_trait_hygiene/shape.rs` (type-shape classifiers)
+- `whitaker/src/async_trait_hygiene/config.rs` (shared config structs and
+  parsing helpers)
+
+### New lint crates
+
+Whitaker’s documented convention is one lint per `cdylib` crate with
+feature-gated rustc dependencies. [^2]
+
+Add eight crates under `crates/` corresponding to the lint table. Each depends
+on:
+
+- `whitaker` with `features = ["dylint-driver"]` (to access
+  `AsyncTraitFamilyIndex`)
+- `common` (diagnostic helpers, i18n, etc)
+
+### Suite plumbing
+
+There are two viable integration modes:
+
+- **Specialized suite (recommended)**: create an `async-trait`-focused
+  aggregated suite crate, e.g. `async_trait_suite/`, to keep the default
+  `whitaker_suite` from expanding into a highly domain-specific policy set.
+- **Feature-gated inclusion in `whitaker_suite`**: include these lints behind a
+  Cargo feature on the suite crate so teams opt in explicitly.
+
+Either way, the suite wiring pattern is clear: add lint declarations to the
+suite list and register pass types in the combined pass.
+[^2]
+
+### Configuration model
+
+A practical config model for migration waves:
+
+- a shared table `[async_trait_hygiene]` for suite-wide defaults:
+  - naming convention (`native_prefix`, default `Native`)
+  - Send policy (`require_send = true`)
+  - alias policy (`allowed_box_future_aliases`, `prefer_local_alias = true`)
+  - allowlists (`allow_traits`, `allow_modules`, `allow_paths`)
+- per-lint tables to override:
+  - `[async_dyn_family_requires_native_sibling]` etc.
+
+This mirrors Whitaker’s existing “load with defaults, allow small overrides”
+philosophy. [^2]
+
+Directory/crate overrides should be implemented via explicit allowlists and
+path-prefix matching against `SourceMap` filenames, not by attempting to infer
+Cargo workspace structure from inside rustc.
+
+### Migration waves and default levels
+
+Align the rollout with Axinite’s “prove in waves” discipline (inventory →
+migrate family-by-family → ratchet). [^3]
+
+Suggested wave policy:
+
+- **Wave A: inventory-only**
+  - enable: `async_trait_concrete_only`,
+    `async_trait_signature_markers_present` as `warn`
+  - keep all pattern-enforcement lints as `allow` (or set to `warn` but
+    allowlist all known families)
+- **Wave B: enforce for migrated families**
+  - for migrated families, remove allowlist entries and enforce:
+    - `native_async_future_must_be_send` as `deny`
+    - `async_dyn_family_requires_blanket_adapter` as `warn` → `deny` once stable
+- **Wave C: regression prevention**
+  - deny “reintroduced macro-shape” (`async_trait_signature_markers_present`)
+    in production modules
+  - warn on direct dyn impls where native+adapter exist
+
+#### Rollout timeline diagram
+
+```mermaid
+timeline
+  title Async-trait hygiene lint rollout
+  section Inventory
+    Enable inventory lints : A
+    Establish allowlists : A
+  section Migration
+    Migrate one family : B
+    Remove allowlist for that family : B
+    Capture timing evidence in CI : B
+  section Ratchet
+    Deny missing Send on Native* : C
+    Deny macro-signature regressions : C
+    Tighten adapter requirements : C
+```
+
+## Performance, CI boundaries, and open decisions
+
+### Performance and compile-time cost considerations
+
+The motivation for eliminating `async-trait` in dyn-heavy codebases is not
+“micro-optimizing futures”; it is reducing proc-macro expansion and boilerplate
+generation. Axinite measured 158 `async-trait` uses across 74 files early in
+the migration and described each use as generating boxing/dynamic dispatch
+boilerplate at compile time. [^3] The `async-trait` crate
+documentation confirms the core mechanical transformation into boxed futures
+and the default `Send` behaviour, which are exactly the costs and semantics
+teams must make explicit when migrating. [^5]
+
+For the lint suite itself, the expensive step is building
+`AsyncTraitFamilyIndex`. The design keeps that cost bounded:
+
+- single HIR traversal for dyn uses and trait/impl discovery
+- closure computation over trait graph edges
+- purely structural matching for boxed-future aliases and adapter impls
+- deterministic collections to avoid reordering noise (useful for UI snapshot
+  stability)
+
+This is consistent with Whitaker’s documented preference for local, linear
+analyses rather than global program graphs. [^2]
+
+### CI and xtask responsibilities versus lints
+
+Two responsibilities should explicitly remain outside lints:
+
+- **Timing evidence**: Axinite’s rollout treats `cargo check --timings` and
+  similar measurements as required artefacts captured per wave. That belongs in
+  CI scripts/xtasks, not static analysis, because it is inherently
+  environment-dependent. [^3]
+- **Workspace-level inventory**: lints cannot reliably answer “is this trait
+  ever used as dyn anywhere in the workspace?”; they can answer “in this crate,
+  it is dyn-required due to direct dyn use or supertrait closure.” That
+  limitation is structurally unavoidable for per-crate linting and should be
+  documented prominently.
+
+### Pending architectural decisions and trade-offs
+
+**Alias locality versus shared alias module.** ADR 006 defaults to a shared
+boxed-future alias (“one helper module”) to reduce signature verbosity.
+[^1][^3] Whitaker lints should support both “one canonical
+alias” and “family-local alias” modes, because some codebases prefer keeping
+interface types private to the module. The trade-off is between global
+consistency (better for large migrations) and local encapsulation.
+
+**Native trait surface form.** Using `fn -> impl Future + Send` in `Native*`
+traits avoids both dyn-compatibility issues and the rustc `async_fn_in_trait`
+warning about unspecified auto-trait bounds on futures.
+[^7][^6] This suite should treat
+`async fn` *in native sibling traits* as a lintable smell (at least for
+exported traits), even if it sometimes compiles fine, because it undermines the
+main point of the native sibling: making `Send`/lifetime bounds explicit.
+
+**Detecting `#[async_trait]` usage.** A pre-expansion lint would be the most
+direct way to catch the attribute, but Dylint’s own documentation notes that
+pre-expansion lints have special “unknown lint” suppression requirements.
+[^8] The proposed `async_trait_signature_markers_present` lint
+avoids that complexity by detecting high-confidence expansion markers in HIR
+instead. The trade-off is that it is a heuristic (though a strong one).
+
+**How hard to enforce “generic bounds prefer Native*”.** This can quickly
+become a high false-positive rule because a generic bound may exist for future
+dyn adaptation or because the same function might return a trait object later.
+The design therefore keeps this as an optional “advisory” lint (not in the
+initial core) unless a downstream team explicitly wants to ratchet on it.
+
+**Cross-crate truth versus crate-local truth.** Because trait objects include
+supertraits, crate-local closure computation is necessary and useful.
+[^4] But it still cannot capture downstream dyn
+usage. The suite should expose this limitation directly in help text for
+`async_trait_concrete_only`, and strongly encourage teams to pair it with a
+separate, workspace-level audit step when planning migrations, matching
+Axinite’s discipline of explicit inventories and approvals.
+[^1][^3]
+
+## References
+
+[^1]: Axinite ADR 006, `Dual-trait pattern for dyn-backed async interfaces`.
+      <https://raw.githubusercontent.com/leynos/axinite/refs/heads/main/docs/adr-006-dual-trait-pattern-for-dyn-backed-async-interfaces.md>
+[^2]: Whitaker design and implementation references: brain-trust lints design,
+      Dylint suite design, suite driver wiring, suite lint registry,
+      `dylint-driver` feature configuration, root `lib.rs`, and `src/hir.rs`.
+      <https://github.com/leynos/whitaker/blob/a39e9a21431133855a0da7fb4d521d425f9477b6/docs/brain-trust-lints-design.md>
+      <https://github.com/leynos/whitaker/blob/a39e9a21431133855a0da7fb4d521d425f9477b6/docs/whitaker-dylint-suite-design.md>
+      <https://github.com/leynos/whitaker/blob/a39e9a21431133855a0da7fb4d521d425f9477b6/suite/src/driver.rs>
+      <https://github.com/leynos/whitaker/blob/a39e9a21431133855a0da7fb4d521d425f9477b6/suite/src/lints.rs>
+      <https://github.com/leynos/whitaker/blob/a39e9a21431133855a0da7fb4d521d425f9477b6/crates/no_std_fs_operations/Cargo.toml>
+      <https://github.com/leynos/whitaker/blob/a39e9a21431133855a0da7fb4d521d425f9477b6/src/lib.rs>
+      <https://github.com/leynos/whitaker/blob/a39e9a21431133855a0da7fb4d521d425f9477b6/src/hir.rs>
+[^3]: Axinite migration planning artefacts: `migrate-async-trait.md` and
+      `adr-006-broad-rollout.md`.
+      <https://raw.githubusercontent.com/leynos/axinite/refs/heads/main/docs/execplans/migrate-async-trait.md>
+      <https://raw.githubusercontent.com/leynos/axinite/refs/heads/main/docs/execplans/adr-006-broad-rollout.md>
+[^4]: Rust Reference material on trait objects and dyn-compatibility.
+      <https://doc.rust-lang.org/stable/reference/types/trait-object.html?highlight=dyn>
+      <https://doc.rust-lang.org/stable/reference/items/traits.html?highlight=extension+trait>
+[^5]: `async-trait` crate documentation.
+      <https://docs.rs/async-trait/latest/async_trait/>
+[^6]: Rust Blog announcement for `async fn` and RPITIT in traits.
+      <https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits/>
+[^7]: rustc documentation for the `async_fn_in_trait` lint.
+      <https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/async_fn_in_trait/static.ASYNC_FN_IN_TRAIT.html>
+[^8]: Dylint documentation, including conditional compilation and
+      pre-expansion-lint guidance.
+      <https://trailofbits.github.io/dylint/>

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -24,8 +24,8 @@
 - [Whitaker Dylint suite design](whitaker-dylint-suite-design.md) explains the
   architecture and rationale behind the core lint suite.
 - [Whitaker command-line interface (CLI) design](whitaker-cli-design.md)
-  describes the command-line surface and design choices for installer and
-  operator workflows.
+  defines the unified `whitaker` binary, its configuration model, and the
+  installation and diagnostic workflows behind it.
 - [Whitaker clone detector design](whitaker-clone-detector-design.md)
   documents the clone detector architecture, data flow, and supporting
   reasoning.
@@ -57,17 +57,19 @@
 
 ## Decision records
 
-- Architectural decision record (ADR) 001: prebuilt Dylint libraries
-  <adr-001-prebuilt-dylint-libraries.md> records the decision to ship prebuilt
-  Dylint libraries and the constraints that follow from that release model.
-- Architectural decision record (ADR) 002: Dylint `expect` attribute macro
-  <adr-002-dylint-expect-attribute-macro.md> records the decision and migration
-  guidance for the `#[expect(...)]` attribute-macro approach.
-- Architectural decision record (ADR) 003: formal proof strategy for clone
-  detector pipeline
-  <adr-003-formal-proof-strategy-for-clone-detector-pipeline.md> records the
-  formal verification direction for the clone detector pipeline and its proof
-  boundaries.
+- [Architectural decision record (ADR) 001: prebuilt Dylint
+  libraries](adr-001-prebuilt-dylint-libraries.md) records the decision to ship
+  prebuilt Dylint libraries and the constraints that follow from that release
+  model.
+- [Architectural decision record (ADR) 002: Dylint `expect` attribute
+  macro](adr-002-dylint-expect-attribute-macro.md) records the support-macro
+  decision, migration phases, and known limitations for conditional
+  `#[expect(...)]` usage.
+- [Architectural decision record (ADR) 003: formal proof strategy for clone
+  detector
+  pipeline](adr-003-formal-proof-strategy-for-clone-detector-pipeline.md)
+  records the formal verification direction for the clone detector pipeline and
+  its proof boundaries.
 
 ## Planning material
 

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -23,6 +23,19 @@
 
 - [Whitaker Dylint suite design](whitaker-dylint-suite-design.md) explains the
   architecture and rationale behind the core lint suite.
+- [Ownership shape lints design](ownership-shape-lints-design.md) describes
+  the clone-pressure and local shared-ownership lints planned for the
+  ownership-shape phase.
+- [Async-trait architecture hygiene Dylint suite design for Whitaker](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+  defines the trait-family analysis, lint catalogue, and rollout model for
+  async dyn-dispatch hygiene checks.
+- [Technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+  explains the split between lightweight Dylint detectors and the richer
+  workspace analysis needed to inventory dead or over-suppressed test support
+  code.
+- [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+  defines the architecture-boundary lints and the Cargo graph checker for
+  compile-time hygiene policy.
 - [Whitaker command-line interface (CLI) design](whitaker-cli-design.md)
   defines the unified `whitaker` binary, its configuration model, and the
   installation and diagnostic workflows behind it.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -322,7 +322,7 @@ providing a clean testing interface.
 
 See
 [`docs/execplans/6-4-5-use-kani-to-verify-build-adjacency-preserves-similarity-edges.md`](./execplans/6-4-5-use-kani-to-verify-build-adjacency-preserves-similarity-edges.md)
-for the complete design rationale and implementation decisions.
+ for the complete design rationale and implementation decisions.
 
 ## Installer release helper binaries
 

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -73,7 +73,6 @@ material, the user's guide explains how to use the project, the developer's
 guide explains how to work on the project, the design document explains why the
 system is shaped the way it is, and the repository layout document explains
 where important things live. For discoverability, use canonical filenames
-<<<<<<< /tmp/.tmpDIJy9w/ours
 unless a stronger repository-specific constraint applies. A minimal canonical
 set looks like
 `docs/{contents,users-guide,developers-guide,repository-layout}.md` plus a
@@ -185,116 +184,6 @@ Use a dedicated design document, conventionally named
 rationale, and intended evolution of a system or subsystem. This document is
 the correct location for design intent; that material must not be buried in the
 user's guide or developer's guide.
-||||||| /tmp/.tmpDIJy9w/base
-## Example snippet
-=======
-unless a stronger repository-specific constraint applies: `docs/contents.md`,
-`docs/users-guide.md`, `docs/developers-guide.md`, `docs/repository-layout.md`,
-and a primary design document with an explicit product or topic name such as
-`docs/theoremc-design.md` or `docs/query-planner-design.md`.
-
-### Contents file
-
-Use a dedicated contents file, typically `docs/contents.md`, as the index for
-the documentation set.
-
-- Make the document title explicit, for example `# Documentation contents`.
-- Begin with the contents file linking to itself so readers can confirm they
-  are at the index.
-- List each document exactly once with an inline link and a short descriptive
-  phrase explaining why someone would open it.
-- Group related material together, such as decision records, reference
-  documents, guides, and plan directories.
-- Keep the descriptions audience-focused. Explain the purpose of the document,
-  not merely its filename.
-- Prefer stable ordering so repeated readers can scan predictably. Grouping by
-  topic is usually better than strict alphabetic ordering.
-- When listing a directory, add one nested level only where it materially
-  improves navigation, for example to enumerate execution plans beneath an
-  `execplans/` entry.
-- Update the contents file whenever a document is added, renamed, or removed.
-
-### User's guide
-
-Use the user's guide, canonically `docs/users-guide.md`, for readers who need
-to apply the project rather than modify its internals. In a library, this means
-consumers of the application programming interface (API). In an application,
-this means operators, end users, or integrators.
-
-- Open with one short paragraph that states the audience and scope.
-- Organize the guide around user-facing tasks, concepts, and guarantees rather
-  than internal module boundaries.
-- Introduce the primary workflow early, with a minimal working example that a
-  reader can adapt immediately.
-- Put public-facing reference material here when users need it to succeed, for
-  example CLI usage, configuration keys, file-format rules, or API surface
-  summaries.
-- Present rules, constraints, defaults, and error behaviour near the feature
-  they affect, rather than scattering them across the document.
-- Use tables where they clarify field sets, command options, or compatibility
-  matrices.
-- Include concrete examples in code or data form when describing formats,
-  schemas, or command usage.
-- Higher-level user workflows belong here, for example "load a document",
-  "configure the service", or "interpret diagnostics".
-- Link to design documents or maintainer references when deeper rationale would
-  otherwise overload the guide.
-- Exclude maintainer-only concerns such as internal layering debates, future
-  refactor plans, or enforcement tooling unless they directly affect users.
-
-### Developer's guide
-
-Use the developer's guide, canonically `docs/developers-guide.md`, for
-maintainers and contributors. Treat this as the operating manual for working on
-the existing system, not as the place for the project's primary design document.
-
-- Open with one short paragraph that states the audience and the operational
-  scope of the guide.
-- Link early to the design document, accepted decision records, and other
-  normative references that explain architecture or rationale in depth.
-- Put maintainer-facing implementation guidance here, for example build, test,
-  lint, release, debugging, extension, and contribution workflows.
-- Use numbered sections for long-form technical documents to improve
-  cross-referencing in reviews and follow-up discussions.
-- Separate normative rules from informative explanation. Mark source-of-truth
-  sections clearly.
-- Include compact interface maps or workflow diagrams where they materially
-  improve implementation guidance.
-- Keep subsystem descriptions focused on current responsibilities,
-  integration points, and operational expectations. Put design rationale, major
-  trade-offs, and proposed architecture in design documents instead.
-- Keep the document synchronized with decision records, roadmap items, and the
-  codebase. A stale developer's guide is worse than a shorter one.
-
-### Design document, ADR, and RFC
-
-Use these document types for different jobs. Do not collapse them into one
-catch-all "design note".
-
-- A **design document** explains the shape of a system or subsystem: its
-  architecture, constraints, data flow, rationale, and intended evolution. It
-  is usually a living document and may describe the current implementation, the
-  target implementation, or both.
-- An **Architecture Decision Record (ADR)** captures one accepted decision. It
-  should be narrow, stable, and explicit about context, decision, consequences,
-  and status. Use an ADR when the important thing to preserve is the outcome,
-  not the full exploratory discussion that led to it.
-- A **Request for Comments (RFC)** proposes a change before acceptance. It is
-  the right format for changes that need reviewing, alternatives analysis,
-  migration planning, or cross-team discussion. An RFC may later be accepted,
-  rejected, superseded, or distilled into one or more ADRs.
-
-In short: use a design document to explain the system, an ADR to record a
-decision, and an RFC to propose a change.
-
-### Design document
-
-Use a dedicated design document, conventionally named
-`docs/<product-or-topic>-design.md`, to explain the architecture,
-constraints, rationale, and intended evolution of a system or subsystem. This
-document is the correct location for design intent; that material must not be
-buried in the user's guide or developer's guide.
->>>>>>> /tmp/.tmpDIJy9w/theirs
 
 - Start with a concise front matter section that states status, scope, primary
   audience, and the decision records or other documents that take precedence.

--- a/docs/ownership-shape-lints-design.md
+++ b/docs/ownership-shape-lints-design.md
@@ -21,6 +21,22 @@ checker". It reports observable, mechanically defensible phenomena:
 This phase concerns **value clones**, not Whitaker's separate **code clone
 detector** pipeline.
 
+## At a glance
+
+For readers skimming the design, the three proposed lints differ mainly in what
+signal they treat as strongest evidence:
+
+- `clone_only_used_by_borrow`: starts from a concrete clone expression and
+  asks whether every observed use is read-only borrowing or copy-like access.
+- `owned_param_causes_clone`: starts from repeated call-site clone pressure and
+  asks whether a same-crate by-value parameter is only read by the callee.
+- `local_shared_ownership`: starts from a locally created shared-ownership or
+  interior-mutability wrapper and asks whether it ever escapes or serves a real
+  API-imposed boundary.
+
+In short, the first lint is clone-centric, the second is signature-centric, and
+the third is wrapper-centric.
+
 ## Why this phase belongs in Whitaker
 
 Whitaker's original core suite established its house style around readable
@@ -29,8 +45,7 @@ avoidance. The project already ships shared Dylint infrastructure, per-lint
 `cdylib` crates, localized diagnostics, and UI-test harness helpers, and its
 roadmap has expanded into deeper maintainability analyses such as Bumpy Road,
 brain-type and brain-trait lints, the code-clone detector pipeline, and
-upcoming `rstest` hygiene
-work.[^whitaker-readme][^whitaker-design][^whitaker-roadmap]
+upcoming `rstest` hygiene work.[^1][^2][^3]
 
 That leaves a conspicuous Rust-specific gap: **ownership shape**. In Rust,
 otherwise straightforward code often acquires unnecessary clones, `Rc` or
@@ -53,7 +68,7 @@ Whitaker should not duplicate existing Clippy coverage. Clippy already detects
 several local ownership smells, including `redundant_clone`,
 `unnecessary_to_owned`, `needless_pass_by_value`, `clone_on_ref_ptr`,
 `rc_buffer`, `redundant_allocation`, and
-`arc_with_non_send_sync`.[^clippy-redundant-clone][^clippy-unnecessary-to-owned][^clippy-needless-pass-by-value][^clippy-clone-on-ref-ptr][^clippy-rc-buffer][^clippy-redundant-allocation][^clippy-arc-non-send-sync]
+`arc_with_non_send_sync`.[^4][^5][^6][^7][^8][^9][^10]
 
 Whitaker's contribution should therefore be narrower and more structural:
 
@@ -105,7 +120,7 @@ diagnostics accordingly.
 The suite should follow Whitaker's existing design patterns: one lint per
 crate, shared diagnostics and localization helpers in `common`, deterministic
 data structures, UI coverage, and configurable rollout from experimental to
-standard.[^whitaker-design][^brain-trust-design][^whitaker-roadmap-rstest]
+standard.[^2][^11][^12]
 
 ### 5. Start with local, crate-contained analysis
 
@@ -117,7 +132,7 @@ external API boundaries provide enough signal for a valuable first phase.
 
 This work should land in the roadmap as **Phase 9. Ownership shape lints**. The
 current roadmap already extends through Phase 8, so Phase 9 fits the sequence
-cleanly.[^whitaker-roadmap]
+cleanly.[^3]
 
 ## Lint suite overview
 
@@ -178,7 +193,7 @@ imply a new compiler lint group on day one.
 The Servo `servo-shot` example is a useful calibration case because, at a
 glance, it contains exactly the kinds of patterns an overzealous ownership lint
 would attack: `Rc` handles, `.clone()` on `Rc`, `Cell` fields, and an
-`Rc<Cell<bool>>` captured by a callback.[^servo-shot-main]
+`Rc<Cell<bool>>` captured by a callback.[^13]
 
 A closer look shows that most of this shape is **API-induced rather than
 incidental**:
@@ -191,8 +206,7 @@ incidental**:
 - `WebView` itself is a handle backed by `Rc<RefCell<_>>`.
 
 Those are precisely the kinds of external constraints that the lint suite must
-classify as suppressing
-evidence.[^servo-webview-builder][^servo-webview][^servo-webview-delegate][^servo-webview-api]
+classify as suppressing evidence.[^14][^15][^16][^17]
 
 Concretely, the following shapes should not trigger:
 
@@ -214,14 +228,14 @@ Whitaker already establishes the right implementation pattern:
 - shared diagnostics and localization live in `common`;
 - human-facing strings go through Fluent bundles with stable message slugs; and
 - lint logic can rely on late passes with type information, while more
-  specialised flow-sensitive checks may use MIR where
-  necessary.[^whitaker-design-lints][^whitaker-i18n][^rustc-lints]
+  specialized flow-sensitive checks may use the Rust compiler's Mid-level
+  Intermediate Representation (MIR) where necessary.[^18][^19][^20]
 
 This phase should follow the same split used by the brain-trust work:
 
 - **pure, compiler-independent models and evaluation logic** in `common`; and
-- **HIR and MIR walkers and rustc-private integration** in the lint
-  crates.[^brain-trust-design]
+- **High-level Intermediate Representation (HIR) and MIR walkers plus
+  rustc-private integration** in the lint crates.[^11]
 
 ### Proposed crate and module layout
 
@@ -286,7 +300,7 @@ pub enum FixConfidence {
 The shared module should also define small, deterministic summaries such as
 `CloneUseSummary`, `OwnedParamPressure`, and `SharedOwnershipSummary`. As with
 Whitaker's brain-trust helpers, prefer `BTreeMap` and `BTreeSet` for
-deterministic iteration and snapshot stability.[^brain-trust-design]
+deterministic iteration and snapshot stability.[^11]
 
 For screen readers: The following class diagram shows the shared ownership
 shape enums, summary records, and evaluation entry points. It highlights how
@@ -396,8 +410,7 @@ The lints should resolve functions, methods, and wrapper constructors by
 **resolved `DefId` paths**, not by source text snippets. Whitaker already uses
 `tcx.def_path_str(def_id)` plus a simple path parser in `no_std_fs_operations`;
 the ownership suite should adopt the same technique for `Clone`, `ToOwned`,
-`Rc`, `Arc`, `Cell`, `RefCell`, `Mutex`, and `RwLock`
-classifiers.[^whitaker-def-path]
+`Rc`, `Arc`, `Cell`, `RefCell`, `Mutex`, and `RwLock` classifiers.[^21]
 
 ### HIR prefilter, MIR confirmation
 
@@ -406,22 +419,22 @@ The suite should use a two-stage approach:
 1. **HIR prefilter** to cheaply find candidate clone expressions, candidate
    wrapper constructors, local call-site clone pressure, and syntactic origins
    such as "simple place expression" versus "arbitrary temporary".
-2. **MIR confirmation** to classify uses and escapes conservatively enough that
-   diagnostics remain credible.
+2. **MIR confirmation** to classify uses and escapes conservatively enough
+   that diagnostics remain credible.
 
 This matches the problem domain. Late lints run after analysis with full type
 information, and Rust's lint infrastructure explicitly supports both late
 passes and MIR-based checks for cases where flow-sensitive facts
-matter.[^rustc-lints][^rustc-mir]
+matter.[^20][^22]
 
 ## Lint 1: `clone_only_used_by_borrow`
 
-### `owned_param_causes_clone` intent
+### `clone_only_used_by_borrow` intent
 
 Detect clones whose resulting value is only observed through immutable borrows
 or `&self` method calls before being dropped.
 
-### `owned_param_causes_clone` detection model
+### `clone_only_used_by_borrow` detection model
 
 A candidate arises from one of the following operations:
 
@@ -490,7 +503,7 @@ consume(tmp);
 s.push('!');
 ```
 
-### `owned_param_causes_clone` diagnostics
+### `clone_only_used_by_borrow` diagnostics
 
 Primary message:
 
@@ -513,7 +526,7 @@ Machine-applicable suggestions should be limited to:
 
 More complex cases should remain diagnostic-only.
 
-### `owned_param_causes_clone` false-positive controls
+### `clone_only_used_by_borrow` false-positive controls
 
 Suppress when:
 
@@ -526,7 +539,7 @@ Suppress when:
 
 ## Lint 2: `owned_param_causes_clone`
 
-### `local_shared_ownership` intent
+### `owned_param_causes_clone` intent
 
 Detect local, same-crate functions or methods whose by-value parameter shapes
 are creating clone pressure in real call sites even though the callee only
@@ -536,7 +549,7 @@ This lint is the suite's main product differentiator. It turns "this parameter
 could be a reference" into "this parameter is *currently causing callers to
 allocate or clone*".
 
-### `local_shared_ownership` detection model
+### `owned_param_causes_clone` detection model
 
 The lint runs in two passes.
 
@@ -557,7 +570,7 @@ Each candidate stores:
 - source place kind; and
 - whether the call occurs in a macro expansion.
 
-#### Pass B: summarise callee parameter usage
+#### Pass B: summarize callee parameter usage
 
 For each candidate callee parameter, classify the parameter as one of:
 
@@ -584,7 +597,7 @@ Suppress by default when the callee is:
 
 The exported-API suppression mirrors Clippy's existing
 `avoid-breaking-exported-api` pattern for several ownership-related
-lints.[^clippy-needless-pass-by-value][^clippy-redundant-allocation]
+lints.[^6][^9]
 
 ### Exact borrow mappings
 
@@ -603,7 +616,7 @@ signature rewrite.
 For screen readers: The following flow diagram shows the two-pass
 `owned_param_causes_clone` analysis. The lint first scans call expressions to
 record clone pressure for local callees, then groups those candidates by
-parameter, summarises each parameter's observed use, applies exemptions, and
+parameter, summarizes each parameter's observed use, applies exemptions, and
 emits a diagnostic only when the evaluation still indicates read-only clone
 pressure.
 
@@ -647,7 +660,7 @@ graph TD
 <!-- markdownlint-enable MD013 -->
 
 *Figure: `owned_param_causes_clone` flow from call-site clone-pressure
-collection through parameter summarisation, exemption handling, evaluation, and
+collection through parameter summarization, exemption handling, evaluation, and
 diagnostic emission.*
 
 ### Diagnostics
@@ -716,7 +729,7 @@ body via:
 - `Mutex::new(...)`
 - `RwLock::new(...)`
 
-Nested forms such as `Rc<RefCell<T>>` and `Arc<Mutex<T>>` should be recognised
+Nested forms such as `Rc<RefCell<T>>` and `Arc<Mutex<T>>` should be recognized
 explicitly.
 
 ### Detection model
@@ -756,7 +769,7 @@ The lint should distinguish three families:
 This lint should remain **diagnostic-only** in the first release.
 
 A machine-applicable rewrite from `Rc<RefCell<T>>` to `let mut x = T` is too
-risky. The lint should instead point to the constructor span, summarise the
+risky. The lint should instead point to the constructor span, summarize the
 evidence, and suggest a manual review.
 
 ### Servo-style exemptions
@@ -770,8 +783,7 @@ Suppress when the wrapper exists because:
   legitimate local state carrier.
 
 That suppresses the Servo `Rc<Cell<bool>>` callback bridge and `Cell`-backed
-delegate state described
-above.[^servo-shot-main][^servo-webview-builder][^servo-webview-delegate][^servo-webview-api]
+delegate state described above.[^13][^14][^16][^17]
 
 ### `local_shared_ownership` false-positive controls
 
@@ -815,13 +827,13 @@ Pure decision functions that accept summaries and return:
 - the diagnostic argument map needed for Fluent.
 
 This mirrors Whitaker's existing preference for pure evaluation helpers in
-`common` and thin lint-driver crates.[^brain-trust-design]
+`common` and thin lint-driver crates.[^11]
 
 ## Diagnostics and localization
 
 Whitaker already localizes diagnostics through Fluent bundles, uses stable
 slugs, and routes messages, notes, labels, and help text through shared
-helpers. The ownership suite should do the same.[^whitaker-i18n]
+helpers. The ownership suite should do the same.[^19]
 
 Suggested lint slugs:
 
@@ -846,13 +858,13 @@ Diagnostic arguments should include concrete facts such as:
 - `{ exact_borrow_type }`
 
 As elsewhere in Whitaker, missing translations should degrade to deterministic
-English rather than panic.[^whitaker-i18n]
+English rather than panic.[^19]
 
 ## Configuration
 
-Whitaker's longer-term roadmap is moving toward a unified CLI and
-`whitaker.toml` configuration surface while retaining compatibility with
-`dylint.toml` during migration.[^whitaker-roadmap-config] This phase should
+Whitaker's longer-term roadmap is moving toward a unified command-line
+interface (CLI) and `whitaker.toml` configuration surface while retaining
+compatibility with `dylint.toml` during migration.[^23] This phase should
 follow that direction:
 
 - define the canonical schema in `whitaker.toml` form; and
@@ -901,7 +913,7 @@ Use Whitaker's existing `rstest-bdd` pattern for:
 - localization fallback;
 - public-API suppression;
 - callback-boundary suppression; and
-- representative machine-suggestion cases.[^whitaker-design][^whitaker-i18n]
+- representative machine-suggestion cases.[^2][^19]
 
 ### UI tests
 
@@ -984,7 +996,7 @@ Keep `local_shared_ownership` experimental until:
 - the lint demonstrates clear signal on non-framework, non-async code.
 
 This mirrors the roadmap precedent for feature-gated experimental sets and
-explicit promotion criteria.[^whitaker-roadmap-rstest]
+explicit promotion criteria.[^12]
 
 ## Open questions
 
@@ -1013,62 +1025,62 @@ evidence rather than anomalies.
 
 ## References
 
-[^whitaker-readme]: Whitaker README, current lint inventory and project
+[^1]: Whitaker README, current lint inventory and project
     framing. <https://github.com/leynos/whitaker>
-[^whitaker-design]: Whitaker suite design, shared helpers, localization, UI
+[^2]: Whitaker suite design, shared helpers, localization, UI
     harness, and existing core-lint architecture.
     <https://raw.githubusercontent.com/leynos/whitaker/main/docs/whitaker-dylint-suite-design.md>
-[^whitaker-design-lints]: Whitaker suite design, per-lint crate scaffolding and
+[^3]: Whitaker roadmap, current phase sequence through Phase 8
+    and related delivered work.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/roadmap.md>
+[^4]: Clippy `redundant_clone`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone>
+[^5]: Clippy `unnecessary_to_owned`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned>
+[^6]: Clippy `needless_pass_by_value`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value>
+[^7]: Clippy `clone_on_ref_ptr`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_ref_ptr>
+[^8]: Clippy `rc_buffer`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#rc_buffer>
+[^9]: Clippy `redundant_allocation`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation>
+[^10]: Clippy `arc_with_non_send_sync`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync>
+[^11]: Whitaker brain-trust lints design, pure-helper pattern
+    and deterministic data structures in `common`.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/brain-trust-lints-design.md>
+[^12]: Whitaker roadmap, experimental-set and
+    promotion-criteria precedent in Phase 8.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/roadmap.md>
+[^13]: `servo-shot` example source.
+    <https://raw.githubusercontent.com/simonw/research/main/servo-crate-exploration/servo-shot/src/main.rs>
+[^14]: Servo `WebViewBuilder` docs,
+    `Rc<dyn RenderingContext>` and `Rc<dyn WebViewDelegate>` API shape.
+    <https://doc.servo.org/servo/webview/struct.WebViewBuilder.html>
+[^15]: Servo `WebView` docs, handle backed by
+    `Rc<RefCell<WebViewInner>>`.
+    <https://doc.servo.org/servo/struct.WebView.html>
+[^16]: Servo `WebViewDelegate` docs, callback surface uses
+    `&self`.
+    <https://doc.servo.org/servo/webview_delegate/trait.WebViewDelegate.html>
+[^17]: Servo `WebView` docs, `'static` callback requirements for
+    `evaluate_javascript` and `take_screenshot`.
+    <https://doc.servo.org/servo/struct.WebView.html>
+[^18]: Whitaker suite design, per-lint crate scaffolding and
     suite wiring.
     <https://raw.githubusercontent.com/leynos/whitaker/main/docs/whitaker-dylint-suite-design.md>
-[^whitaker-i18n]: Whitaker suite design, localization and diagnostic structure.
+[^19]: Whitaker suite design, localization and diagnostic structure.
     <https://raw.githubusercontent.com/leynos/whitaker/main/docs/whitaker-dylint-suite-design.md>
-[^whitaker-def-path]: Whitaker suite design,
+[^20]: Rust compiler development guide, lint timing and late or MIR
+    lint infrastructure.
+    <https://rustc-dev-guide.rust-lang.org/diagnostics.html>
+[^21]: Whitaker suite design,
     `no_std_fs_operations` implementation using `tcx.def_path_str(def_id)` and
     parsed path segments.
     <https://raw.githubusercontent.com/leynos/whitaker/main/docs/whitaker-dylint-suite-design.md>
-[^whitaker-roadmap]: Whitaker roadmap, current phase sequence through Phase 8
-    and related delivered work.
-    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/roadmap.md>
-[^whitaker-roadmap-config]: Whitaker roadmap, unified CLI / `whitaker.toml`
+[^22]: Rust compiler development guide, MIR overview and passes.
+    <https://rustc-dev-guide.rust-lang.org/mir/index.html>
+[^23]: Whitaker roadmap, unified CLI / `whitaker.toml`
     direction with compatibility period.
     <https://raw.githubusercontent.com/leynos/whitaker/main/docs/roadmap.md>
-[^whitaker-roadmap-rstest]: Whitaker roadmap, experimental-set and
-    promotion-criteria precedent in Phase 8.
-    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/roadmap.md>
-[^brain-trust-design]: Whitaker brain-trust lints design, pure-helper pattern
-    and deterministic data structures in `common`.
-    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/brain-trust-lints-design.md>
-[^clippy-redundant-clone]: Clippy `redundant_clone`.
-    <https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone>
-[^clippy-unnecessary-to-owned]: Clippy `unnecessary_to_owned`.
-    <https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned>
-[^clippy-needless-pass-by-value]: Clippy `needless_pass_by_value`.
-    <https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value>
-[^clippy-clone-on-ref-ptr]: Clippy `clone_on_ref_ptr`.
-    <https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_ref_ptr>
-[^clippy-rc-buffer]: Clippy `rc_buffer`.
-    <https://rust-lang.github.io/rust-clippy/master/index.html#rc_buffer>
-[^clippy-redundant-allocation]: Clippy `redundant_allocation`.
-    <https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation>
-[^clippy-arc-non-send-sync]: Clippy `arc_with_non_send_sync`.
-    <https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync>
-[^rustc-lints]: Rust compiler development guide, lint timing and late or MIR
-    lint infrastructure.
-    <https://rustc-dev-guide.rust-lang.org/diagnostics.html>
-[^rustc-mir]: Rust compiler development guide, MIR overview and passes.
-    <https://rustc-dev-guide.rust-lang.org/mir/index.html>
-[^servo-shot-main]: `servo-shot` example source.
-    <https://raw.githubusercontent.com/simonw/research/main/servo-crate-exploration/servo-shot/src/main.rs>
-[^servo-webview-builder]: Servo `WebViewBuilder` docs,
-    `Rc<dyn RenderingContext>` and `Rc<dyn WebViewDelegate>` API shape.
-    <https://doc.servo.org/servo/webview/struct.WebViewBuilder.html>
-[^servo-webview]: Servo `WebView` docs, handle backed by
-    `Rc<RefCell<WebViewInner>>`.
-    <https://doc.servo.org/servo/struct.WebView.html>
-[^servo-webview-delegate]: Servo `WebViewDelegate` docs, callback surface uses
-    `&self`.
-    <https://doc.servo.org/servo/webview_delegate/trait.WebViewDelegate.html>
-[^servo-webview-api]: Servo `WebView` docs, `'static` callback requirements for
-    `evaluate_javascript` and `take_screenshot`.
-    <https://doc.servo.org/servo/struct.WebView.html>

--- a/docs/ownership-shape-lints-design.md
+++ b/docs/ownership-shape-lints-design.md
@@ -288,6 +288,108 @@ The shared module should also define small, deterministic summaries such as
 Whitaker's brain-trust helpers, prefer `BTreeMap` and `BTreeSet` for
 deterministic iteration and snapshot stability.[^brain-trust-design]
 
+For screen readers: The following class diagram shows the shared ownership
+shape enums, summary records, and evaluation entry points. It highlights how
+use and escape classifications feed summary objects, which are then consumed by
+the central evaluation logic to produce an `EvaluationResult`.
+
+<!-- markdownlint-disable MD013 -->
+```mermaid
+classDiagram
+
+class UseClass {
+  <<enum>>
+  SharedBorrow
+  MethodBySharedRef
+  CopyRead
+  MutableBorrow
+  MethodByMutableRef
+  Move
+  Return
+  Store
+  UnknownCall
+}
+
+class EscapeKind {
+  <<enum>>
+  No
+  Return
+  Store
+  ClosureCapture
+  StaticCallback
+  ThreadBoundary
+  ExternalApiBoundary
+  Unknown
+}
+
+class ApiConstraint {
+  <<enum>>
+  None
+  SharedHandleRequired
+  TraitSignatureRequired
+  StaticCallbackRequired
+  ThreadSafeSharedRequired
+}
+
+class FixConfidence {
+  <<enum>>
+  MachineApplicable
+  MaybeIncorrect
+  DiagnosticOnly
+}
+
+class CloneUseSummary {
+  +use_classes : Map
+  +escape_kind : EscapeKind
+}
+
+class OwnedParamPressure {
+  +callee_id : DefId
+  +param_index : usize
+  +callsite_count : usize
+  +source_type : TypeId
+}
+
+class SharedOwnershipSummary {
+  +wrapper_type : TypeId
+  +escape_kind : EscapeKind
+  +api_constraint : ApiConstraint
+}
+
+class ExactBorrowMapping {
+  +owned_type : TypeId
+  +borrow_type : TypeId
+}
+
+class EvaluationResult {
+  +emit : bool
+  +level : LintLevel
+  +fix_confidence : FixConfidence
+  +diagnostic_args : Map
+}
+
+class OwnershipShapeEvaluation {
+  +evaluate_clone_only_used_by_borrow(summary : CloneUseSummary) EvaluationResult
+  +evaluate_owned_param_causes_clone(pressure : OwnedParamPressure, summary : CloneUseSummary, mapping : ExactBorrowMapping) EvaluationResult
+  +evaluate_local_shared_ownership(summary : SharedOwnershipSummary) EvaluationResult
+}
+
+UseClass --> CloneUseSummary : used_by
+EscapeKind --> CloneUseSummary : classifies
+EscapeKind --> SharedOwnershipSummary : classifies
+ApiConstraint --> SharedOwnershipSummary : constrained_by
+FixConfidence --> EvaluationResult : sets
+CloneUseSummary --> OwnershipShapeEvaluation : input
+OwnedParamPressure --> OwnershipShapeEvaluation : input
+SharedOwnershipSummary --> OwnershipShapeEvaluation : input
+ExactBorrowMapping --> OwnershipShapeEvaluation : consulted_by
+EvaluationResult --> OwnershipShapeEvaluation : output
+```
+<!-- markdownlint-enable MD013 -->
+
+*Figure: Shared ownership-shape model showing the core enums, summaries, and
+evaluation entry points used across the proposed lint suite.*
+
 ### Resolution strategy
 
 The lints should resolve functions, methods, and wrapper constructors by
@@ -497,6 +599,56 @@ common owned-to-borrow mappings:
 For other concrete types, emit a generic "consider borrowing this parameter
 instead of taking ownership" help message without a machine-applicable
 signature rewrite.
+
+For screen readers: The following flow diagram shows the two-pass
+`owned_param_causes_clone` analysis. The lint first scans call expressions to
+record clone pressure for local callees, then groups those candidates by
+parameter, summarises each parameter's observed use, applies exemptions, and
+emits a diagnostic only when the evaluation still indicates read-only clone
+pressure.
+
+<!-- markdownlint-disable MD013 -->
+```mermaid
+graph TD
+  A["Start lint pass for owned_param_causes_clone"] --> B["Iterate over all functions and methods in crate"]
+  B --> C["Pass A: inspect each call expression"]
+
+  C --> C1["Is argument a clone_like operation on a retained value?"]
+  C1 -- "No" --> C_NEXT["Skip argument"]
+  C1 -- "Yes" --> C2["Resolve callee DefId and argument index"]
+
+  C2 --> C3["Is callee defined in this crate?"]
+  C3 -- "No" --> C_NEXT
+  C3 -- "Yes" --> C4["Record OwnedParamPressure entry with callsite span and source type"]
+
+  C4 --> C_NEXT
+  C_NEXT --> C_DONE["All calls processed"]
+  C_DONE --> D["Group pressure entries by callee and parameter index"]
+
+  D --> E["Pass B: for each candidate parameter"]
+  E --> E1["Summarise parameter usage using HIR and MIR"]
+  E1 --> E2["Classify parameter as ReadOnlyBorrowed, Consumed, MutablyBorrowed, or Opaque"]
+
+  E2 --> E3["Apply exemption rules (exported API, trait method, extern, async)"]
+  E3 -- "Exempt" --> NEXT_PARAM["Skip emission for this parameter"]
+  E3 -- "Not exempt" --> E4["Combine parameter summary with OwnedParamPressure and ExactBorrowMapping"]
+
+  E4 --> E5["Call ownership_shape evaluation to decide emission and FixConfidence"]
+  E5 -- "Do not emit" --> NEXT_PARAM
+  E5 -- "Emit diagnostic" --> F["Build diagnostic args and choose message slugs"]
+
+  F --> G["Emit lint diagnostic at parameter span with optional callsite note"]
+  G --> NEXT_PARAM
+
+  NEXT_PARAM --> H["More candidate parameters?"]
+  H -- "Yes" --> E
+  H -- "No" --> I["End lint pass"]
+```
+<!-- markdownlint-enable MD013 -->
+
+*Figure: `owned_param_causes_clone` flow from call-site clone-pressure
+collection through parameter summarisation, exemption handling, evaluation, and
+diagnostic emission.*
 
 ### Diagnostics
 

--- a/docs/ownership-shape-lints-design.md
+++ b/docs/ownership-shape-lints-design.md
@@ -1,0 +1,922 @@
+# Ownership shape lints design for value clones and local shared ownership
+
+## Purpose and scope
+
+This document proposes the next core-lint phase for Whitaker: an
+ownership-shape suite aimed at value clones and local shared-ownership patterns
+that arise when surrounding code does not appear to require ownership transfer
+or shared indirection.
+
+The phase is intentionally descriptive rather than moralizing. It does **not**
+attempt to infer developer intent or accuse code of "skirting the borrow
+checker". It reports observable, mechanically defensible phenomena:
+
+- a cloned value that is only ever immutably borrowed before it is dropped;
+- a by-value parameter in a local function or method whose shape induces clones
+  at call sites even though the callee only reads the value; and
+- a locally created shared-ownership or interior-mutability wrapper that does
+  not escape and whose access pattern looks expressible with an ordinary local
+  and borrows.
+
+This phase concerns **value clones**, not Whitaker's separate **code clone
+detector** pipeline.
+
+## Why this phase belongs in Whitaker
+
+Whitaker's original core suite established its house style around readable
+structure, explicit documentation, bounded control-flow complexity, and panic
+avoidance. The project already ships shared Dylint infrastructure, per-lint
+`cdylib` crates, localized diagnostics, and UI-test harness helpers, and its
+roadmap has expanded into deeper maintainability analyses such as Bumpy Road,
+brain-type and brain-trait lints, the code-clone detector pipeline, and
+upcoming `rstest` hygiene
+work.[^whitaker-readme][^whitaker-design][^whitaker-roadmap]
+
+That leaves a conspicuous Rust-specific gap: **ownership shape**. In Rust,
+otherwise straightforward code often acquires unnecessary clones, `Rc` or
+`Arc`, or interior-mutable wrappers because a signature, local control-flow
+shape, or callback boundary makes borrowing awkward. Left unexamined, these
+patterns can:
+
+- obscure the semantic distinction between "borrowing for observation" and
+  "taking ownership";
+- add allocation or reference-count churn; and
+- harden APIs around ownership when a borrow-based shape would remain more
+  flexible.
+
+Whitaker should address that gap, but it should do so with a false-positive
+budget that matches the rest of the suite.
+
+## Product motivation and positioning
+
+Whitaker should not duplicate existing Clippy coverage. Clippy already detects
+several local ownership smells, including `redundant_clone`,
+`unnecessary_to_owned`, `needless_pass_by_value`, `clone_on_ref_ptr`,
+`rc_buffer`, `redundant_allocation`, and
+`arc_with_non_send_sync`.[^clippy-redundant-clone][^clippy-unnecessary-to-owned][^clippy-needless-pass-by-value][^clippy-clone-on-ref-ptr][^clippy-rc-buffer][^clippy-redundant-allocation][^clippy-arc-non-send-sync]
+
+Whitaker's contribution should therefore be narrower and more structural:
+
+1. connect a clone at the call site to the signature that caused it;
+2. distinguish local ownership inflation from external API obligations; and
+3. surface diagnostics that explain *why* the current ownership shape is
+   heavier than the observed behaviour requires.
+
+This is especially important for Rust code that is exploratory,
+machine-generated, newly ported from other languages, or authored by
+contributors who have not yet internalized borrow-oriented API design.
+
+## Non-goals
+
+This phase will not:
+
+- infer motive or report that a developer is "working around" or "skirting" the
+  borrow checker;
+- forbid `Rc`, `Arc`, `Cell`, `RefCell`, `Mutex`, or `RwLock` in general;
+- attempt whole-program alias analysis or cross-crate ownership proofs;
+- require breaking changes to exported APIs by default;
+- warn on ownership shapes that are imposed by external trait signatures,
+  callback contracts, thread or task boundaries, or framework APIs;
+- supersede Clippy's purely local syntactic lints; or
+- auto-rewrite non-trivial smart-pointer refactors.
+
+## Design principles
+
+### 1. Report shape, not intent
+
+Lint names, messages, and documentation should describe the ownership
+phenomenon rather than speculate about why the code was written that way.
+
+### 2. Prefer high-confidence facts over broad coverage
+
+A smaller suite with reliable findings is more valuable than an accusatory lint
+that fires on every `Rc<RefCell<_>>` in a GUI, browser, async, or
+callback-heavy codebase.
+
+### 3. Treat API boundaries as first-class evidence
+
+Rust code often uses clones or wrappers because an API *requires* a particular
+ownership or lifetime shape. That is not noise around the design. It is the
+design. The lints must detect these boundaries and suppress or downgrade
+diagnostics accordingly.
+
+### 4. Reuse Whitaker's existing infrastructure
+
+The suite should follow Whitaker's existing design patterns: one lint per
+crate, shared diagnostics and localization helpers in `common`, deterministic
+data structures, UI coverage, and configurable rollout from experimental to
+standard.[^whitaker-design][^brain-trust-design][^whitaker-roadmap-rstest]
+
+### 5. Start with local, crate-contained analysis
+
+The first release should stay within one crate and avoid speculative
+cross-crate reasoning. Local or private functions, local bodies, and resolved
+external API boundaries provide enough signal for a valuable first phase.
+
+## Phase title and roadmap placement
+
+This work should land in the roadmap as **Phase 9. Ownership shape lints**. The
+current roadmap already extends through Phase 8, so Phase 9 fits the sequence
+cleanly.[^whitaker-roadmap]
+
+## Lint suite overview
+
+The phase should ship three lints:
+
+### Metadata for `clone_only_used_by_borrow`
+
+Warn when a cloned value is only ever immutably borrowed before drop, and the
+original value appears borrowable across the same region.
+
+This is the highest-confidence lint in the phase and the likeliest candidate
+for stable, warn-by-default status after validation.
+
+### Metadata for `owned_param_causes_clone`
+
+Warn on local, same-crate functions or methods whose by-value parameter shape
+induces actual clones at call sites even though the callee only reads the
+argument.
+
+This lint complements rather than replaces Clippy's `needless_pass_by_value`:
+it requires *observed clone pressure* at local call sites, which makes the
+diagnosis more concrete and more actionably Whitaker-like.
+
+### Metadata for `local_shared_ownership`
+
+Flag locally created `Rc`, `Arc`, or interior-mutability wrappers that do not
+escape and whose observed use-pattern does not appear to require shared
+ownership or runtime borrow mediation.
+
+This lint should start as experimental and feature-gated.
+
+## Suggested lint metadata
+
+### `clone_only_used_by_borrow`
+
+- Kind: `ownership`
+- Default level: `warn`
+- Rollout target: standard suite after false-positive validation
+
+### `owned_param_causes_clone`
+
+- Kind: `ownership`
+- Default level: `warn`
+- Rollout target: experimental first, standard once public-API and generic
+  suppression rules settle
+
+### `local_shared_ownership`
+
+- Kind: `ownership`
+- Default level: `allow` or experimental `warn`
+- Rollout target: experimental only in the first phase
+
+The `ownership` label is a documentation and selection category. It need not
+imply a new compiler lint group on day one.
+
+## Worked exception model: Servo-style code must stay quiet
+
+The Servo `servo-shot` example is a useful calibration case because, at a
+glance, it contains exactly the kinds of patterns an overzealous ownership lint
+would attack: `Rc` handles, `.clone()` on `Rc`, `Cell` fields, and an
+`Rc<Cell<bool>>` captured by a callback.[^servo-shot-main]
+
+A closer look shows that most of this shape is **API-induced rather than
+incidental**:
+
+- `WebViewBuilder::new` takes `Rc<dyn RenderingContext>`.
+- `.delegate(...)` takes `Rc<dyn WebViewDelegate>`.
+- `evaluate_javascript` and `take_screenshot` take `FnOnce(...) + 'static`
+  callbacks.
+- `WebViewDelegate` notification methods use `&self`.
+- `WebView` itself is a handle backed by `Rc<RefCell<_>>`.
+
+Those are precisely the kinds of external constraints that the lint suite must
+classify as suppressing
+evidence.[^servo-webview-builder][^servo-webview][^servo-webview-delegate][^servo-webview-api]
+
+Concretely, the following shapes should not trigger:
+
+- `rendering_context.clone()` and `delegate.clone()` passed into Servo builder
+  APIs that require `Rc<...>`;
+- `Rc<Cell<bool>>` used only to bridge a `'static` callback contract; and
+- `Cell<bool>` or `Cell<usize>` stored in a delegate whose trait methods only
+  expose `&self`.
+
+This case should ship as a regression fixture in the UI suite.
+
+## Shared implementation approach
+
+### Architectural fit
+
+Whitaker already establishes the right implementation pattern:
+
+- lint crates are separate `cdylib`s;
+- shared diagnostics and localization live in `common`;
+- human-facing strings go through Fluent bundles with stable message slugs; and
+- lint logic can rely on late passes with type information, while more
+  specialised flow-sensitive checks may use MIR where
+  necessary.[^whitaker-design-lints][^whitaker-i18n][^rustc-lints]
+
+This phase should follow the same split used by the brain-trust work:
+
+- **pure, compiler-independent models and evaluation logic** in `common`; and
+- **HIR and MIR walkers and rustc-private integration** in the lint
+  crates.[^brain-trust-design]
+
+### Proposed crate and module layout
+
+```text
+common/
+└── src/
+    └── ownership_shape/
+        ├── mod.rs
+        ├── model.rs
+        ├── diagnostics.rs
+        ├── evaluation.rs
+        ├── path_kinds.rs
+        └── exact_borrow_mappings.rs
+
+crates/
+├── clone_only_used_by_borrow/
+├── owned_param_causes_clone/
+└── local_shared_ownership/
+```
+
+### Proposed shared domain model
+
+```rust
+pub enum UseClass {
+    SharedBorrow,
+    MethodBySharedRef,
+    CopyRead,
+    MutableBorrow,
+    MethodByMutableRef,
+    Move,
+    Return,
+    Store,
+    UnknownCall,
+}
+
+pub enum EscapeKind {
+    No,
+    Return,
+    Store,
+    ClosureCapture,
+    StaticCallback,
+    ThreadBoundary,
+    ExternalApiBoundary,
+    Unknown,
+}
+
+pub enum ApiConstraint {
+    None,
+    SharedHandleRequired,
+    TraitSignatureRequired,
+    StaticCallbackRequired,
+    ThreadSafeSharedRequired,
+}
+
+pub enum FixConfidence {
+    MachineApplicable,
+    MaybeIncorrect,
+    DiagnosticOnly,
+}
+```
+
+The shared module should also define small, deterministic summaries such as
+`CloneUseSummary`, `OwnedParamPressure`, and `SharedOwnershipSummary`. As with
+Whitaker's brain-trust helpers, prefer `BTreeMap` and `BTreeSet` for
+deterministic iteration and snapshot stability.[^brain-trust-design]
+
+### Resolution strategy
+
+The lints should resolve functions, methods, and wrapper constructors by
+**resolved `DefId` paths**, not by source text snippets. Whitaker already uses
+`tcx.def_path_str(def_id)` plus a simple path parser in `no_std_fs_operations`;
+the ownership suite should adopt the same technique for `Clone`, `ToOwned`,
+`Rc`, `Arc`, `Cell`, `RefCell`, `Mutex`, and `RwLock`
+classifiers.[^whitaker-def-path]
+
+### HIR prefilter, MIR confirmation
+
+The suite should use a two-stage approach:
+
+1. **HIR prefilter** to cheaply find candidate clone expressions, candidate
+   wrapper constructors, local call-site clone pressure, and syntactic origins
+   such as "simple place expression" versus "arbitrary temporary".
+2. **MIR confirmation** to classify uses and escapes conservatively enough that
+   diagnostics remain credible.
+
+This matches the problem domain. Late lints run after analysis with full type
+information, and Rust's lint infrastructure explicitly supports both late
+passes and MIR-based checks for cases where flow-sensitive facts
+matter.[^rustc-lints][^rustc-mir]
+
+## Lint 1: `clone_only_used_by_borrow`
+
+### `owned_param_causes_clone` intent
+
+Detect clones whose resulting value is only observed through immutable borrows
+or `&self` method calls before being dropped.
+
+### `owned_param_causes_clone` detection model
+
+A candidate arises from one of the following operations:
+
+- `.clone()` on an owned or shared handle;
+- `Clone::clone(&x)`;
+- `.to_owned()`;
+- `ToOwned::to_owned(&x)`.
+
+The lint then asks four questions:
+
+1. What local or temporary receives the cloned value?
+2. How is that local used?
+3. Does the cloned value escape via move, return, storage, or unknown call?
+4. Can the original value plausibly be borrowed across the same region without
+   conflicting mutable uses?
+
+The lint fires only when:
+
+- every observed use is `SharedBorrow`, `MethodBySharedRef`, or `CopyRead`;
+- no use is `Move`, `MutableBorrow`, `MethodByMutableRef`, `Return`, `Store`,
+  or `UnknownCall`; and
+- the original receiver is a simple place whose borrow would not overlap a move
+  or mutable borrow before the clone's last use.
+
+### Examples
+
+Positive:
+
+```rust
+let tmp = path.clone();
+render(&tmp);
+log::debug!("{}", tmp.display());
+```
+
+Suggested shape:
+
+```rust
+render(&path);
+log::debug!("{}", path.display());
+```
+
+Positive, direct call-site form:
+
+```rust
+foo(&name.clone());
+```
+
+Suggested shape:
+
+```rust
+foo(&name);
+```
+
+Negative:
+
+```rust
+let tmp = name.clone();
+cache.insert(tmp);
+```
+
+Negative:
+
+```rust
+let tmp = s.clone();
+consume(tmp);
+s.push('!');
+```
+
+### `owned_param_causes_clone` diagnostics
+
+Primary message:
+
+> value cloned here but only immutably borrowed before drop
+
+Notes:
+
+- identify the receiver type where helpful;
+- explain that no ownership-taking use was observed; and
+- suppress the message entirely if the replacement borrow would overlap a
+  mutable use of the original.
+
+### Suggestion policy
+
+Machine-applicable suggestions should be limited to:
+
+- same-expression cases such as `foo(&x.clone())`; and
+- simple `let tmp = x.clone(); ...` bindings where every use of `tmp` rewrites
+  directly to `x`.
+
+More complex cases should remain diagnostic-only.
+
+### `owned_param_causes_clone` false-positive controls
+
+Suppress when:
+
+- the receiver is not a simple local or field place;
+- the clone result feeds an unknown function by value;
+- the original is moved or mutably borrowed before the last clone use;
+- the candidate is from a macro expansion; or
+- the clone exists to satisfy an explicit API shape that will be handled by
+  `owned_param_causes_clone` instead.
+
+## Lint 2: `owned_param_causes_clone`
+
+### `local_shared_ownership` intent
+
+Detect local, same-crate functions or methods whose by-value parameter shapes
+are creating clone pressure in real call sites even though the callee only
+needs read access.
+
+This lint is the suite's main product differentiator. It turns "this parameter
+could be a reference" into "this parameter is *currently causing callers to
+allocate or clone*".
+
+### `local_shared_ownership` detection model
+
+The lint runs in two passes.
+
+#### Pass A: collect clone-pressure evidence at call sites
+
+Record a candidate when all of the following hold:
+
+- a call argument is a clone-like operation (`clone`, `to_owned`);
+- the source value remains live and is later used by the caller; and
+- the callee resolves to a function or method defined in the current crate.
+
+Each candidate stores:
+
+- callee `DefId`;
+- argument index;
+- clone expression span;
+- source type;
+- source place kind; and
+- whether the call occurs in a macro expansion.
+
+#### Pass B: summarise callee parameter usage
+
+For each candidate callee parameter, classify the parameter as one of:
+
+- `ReadOnlyBorrowed`: only shared borrows, `&self` methods, or copy reads;
+- `Consumed`: moved, returned, stored, or passed by value to another call;
+- `MutablyBorrowed`: any `&mut` use or `&mut self` method;
+- `Opaque`: analysis inconclusive.
+
+The lint fires when:
+
+- a by-value parameter has at least one clone-pressure call site;
+- the parameter is `ReadOnlyBorrowed`; and
+- the callee is not exempt.
+
+### Exemptions
+
+Suppress by default when the callee is:
+
+- publicly exported;
+- a trait method declaration;
+- a trait-impl method whose signature is fixed by the trait;
+- `extern` or FFI-facing; or
+- `async` in the initial release.
+
+The exported-API suppression mirrors Clippy's existing
+`avoid-breaking-exported-api` pattern for several ownership-related
+lints.[^clippy-needless-pass-by-value][^clippy-redundant-allocation]
+
+### Exact borrow mappings
+
+For the first release, support machine-guided rewrite hints only for exact,
+common owned-to-borrow mappings:
+
+- `String -> &str`
+- `Vec<T> -> &[T]`
+- `PathBuf -> &Path`
+- `OsString -> &OsStr`
+
+For other concrete types, emit a generic "consider borrowing this parameter
+instead of taking ownership" help message without a machine-applicable
+signature rewrite.
+
+### Diagnostics
+
+Primary span: parameter binding or function signature.
+
+Primary message:
+
+> parameter `{name}` takes ownership, and local callers clone to satisfy it
+
+Notes:
+
+- include the number of local clone-pressure call sites;
+- identify the observed use-class as read-only; and
+- where possible, suggest the exact borrow mapping.
+
+A secondary call-site note may be emitted at one representative clone span.
+
+### Example
+
+```rust
+fn normalise(name: String) -> usize {
+    name.trim().len()
+}
+
+let a = normalise(user.name.clone());
+let b = normalise(admin.name.clone());
+```
+
+Suggested direction:
+
+```rust
+fn normalise(name: &str) -> usize {
+    name.trim().len()
+}
+```
+
+### False-positive controls
+
+Suppress when:
+
+- the parameter is moved, returned, stored, or mutably borrowed;
+- the callee is exported or trait-constrained, unless configuration opts in;
+- call-site evidence arises only in macro expansions;
+- generic or async transformations would require non-trivial lifetime
+  introduction; or
+- the clone source is itself a temporary, so the evidence does not actually
+  show retained ownership pressure.
+
+## Lint 3: `local_shared_ownership`
+
+### Intent
+
+Detect non-escaping shared-ownership or runtime-borrow wrappers whose observed
+use-pattern looks local and sequential.
+
+### Scope
+
+The first release should restrict itself to wrappers created in the current
+body via:
+
+- `Rc::new(...)`
+- `Arc::new(...)`
+- `Cell::new(...)`
+- `RefCell::new(...)`
+- `Mutex::new(...)`
+- `RwLock::new(...)`
+
+Nested forms such as `Rc<RefCell<T>>` and `Arc<Mutex<T>>` should be recognised
+explicitly.
+
+### Detection model
+
+A candidate wrapper is linted only when all of the following are true:
+
+- the wrapper originates from a local constructor call in the current body;
+- it does not return, store, or otherwise escape the body;
+- it is not captured by a `'static` callback, async task, thread spawn, or
+  other long-lived boundary;
+- it is not passed to an external API that requires the wrapper shape; and
+- the observed operations are limited to local, sequential `get`, `set`,
+  `borrow`, `borrow_mut`, `lock`, `read`, or `write` patterns.
+
+### Diagnostic classes
+
+The lint should distinguish three families:
+
+1. **Local interior mutability only**
+
+   - example: `Cell<bool>`, `RefCell<Vec<T>>`
+   - likely advice: "plain local plus `&mut` may be simpler"
+
+2. **Local shared handle only**
+
+   - example: `Rc<T>`, `Arc<T>` with no meaningful sharing
+   - likely advice: "ordinary local ownership appears sufficient"
+
+3. **Local shared mutable wrapper**
+
+   - example: `Rc<RefCell<T>>`, `Arc<Mutex<T>>`
+   - likely advice: "non-escaping shared mutable wrapper appears heavier than
+     the local usage requires"
+
+### `local_shared_ownership` suggestion policy
+
+This lint should remain **diagnostic-only** in the first release.
+
+A machine-applicable rewrite from `Rc<RefCell<T>>` to `let mut x = T` is too
+risky. The lint should instead point to the constructor span, summarise the
+evidence, and suggest a manual review.
+
+### Servo-style exemptions
+
+Suppress when the wrapper exists because:
+
+- a callback requires `FnOnce + 'static` or equivalent;
+- an external builder or framework requires `Rc` or `Arc` or trait-object
+  handles; or
+- a trait callback surface uses `&self`, making `Cell` or `RefCell` a
+  legitimate local state carrier.
+
+That suppresses the Servo `Rc<Cell<bool>>` callback bridge and `Cell`-backed
+delegate state described
+above.[^servo-shot-main][^servo-webview-builder][^servo-webview-delegate][^servo-webview-api]
+
+### `local_shared_ownership` false-positive controls
+
+Suppress when:
+
+- a clone of `Rc` or `Arc` actually crosses a closure, async, thread, or
+  external boundary;
+- `Weak` handles are involved;
+- multiple strong-handle aliases are observed in ways the analysis cannot
+  confidently classify;
+- the wrapper constructor is from a macro expansion; or
+- the inner type is itself a framework handle type and the wrapper appears to
+  be part of that framework's ownership contract.
+
+## Common helper requirements
+
+### `common::ownership_shape::path_kinds`
+
+Resolved-path classifiers for:
+
+- clone-like operations (`Clone::clone`, `ToOwned::to_owned`);
+- shared-ownership constructors (`Rc::new`, `Arc::new`);
+- interior-mutability constructors (`Cell::new`, `RefCell::new`, `Mutex::new`,
+  `RwLock::new`);
+- wrapper operation methods (`borrow`, `borrow_mut`, `get`, `set`, `lock`,
+  `read`, `write`); and
+- callback, async, and task APIs that impose `'static` or thread-safe shared
+  state.
+
+### `common::ownership_shape::exact_borrow_mappings`
+
+A pure mapping table used by `owned_param_causes_clone`.
+
+### `common::ownership_shape::evaluation`
+
+Pure decision functions that accept summaries and return:
+
+- whether to emit;
+- emission level;
+- fix confidence; and
+- the diagnostic argument map needed for Fluent.
+
+This mirrors Whitaker's existing preference for pure evaluation helpers in
+`common` and thin lint-driver crates.[^brain-trust-design]
+
+## Diagnostics and localization
+
+Whitaker already localizes diagnostics through Fluent bundles, uses stable
+slugs, and routes messages, notes, labels, and help text through shared
+helpers. The ownership suite should do the same.[^whitaker-i18n]
+
+Suggested lint slugs:
+
+- `clone_only_used_by_borrow.primary`
+- `clone_only_used_by_borrow.note`
+- `clone_only_used_by_borrow.help`
+- `owned_param_causes_clone.primary`
+- `owned_param_causes_clone.note`
+- `owned_param_causes_clone.help`
+- `local_shared_ownership.primary`
+- `local_shared_ownership.note`
+- `local_shared_ownership.help`
+
+Diagnostic arguments should include concrete facts such as:
+
+- `{ variable }`
+- `{ callee }`
+- `{ parameter }`
+- `{ wrapper }`
+- `{ callsite_count }`
+- `{ use_summary }`
+- `{ exact_borrow_type }`
+
+As elsewhere in Whitaker, missing translations should degrade to deterministic
+English rather than panic.[^whitaker-i18n]
+
+## Configuration
+
+Whitaker's longer-term roadmap is moving toward a unified CLI and
+`whitaker.toml` configuration surface while retaining compatibility with
+`dylint.toml` during migration.[^whitaker-roadmap-config] This phase should
+follow that direction:
+
+- define the canonical schema in `whitaker.toml` form; and
+- provide a compatibility loader from current Dylint configuration until the
+  unified config work lands.
+
+Suggested configuration surface:
+
+```toml
+[clone_only_used_by_borrow]
+enabled = true
+include_to_owned = true
+emit_machine_suggestions = true
+
+[owned_param_causes_clone]
+enabled = true
+min_local_callsites = 1
+avoid_breaking_exported_api = true
+ignore_async_fns = true
+representative_callsite_note = true
+
+[local_shared_ownership]
+enabled = false
+ignore_static_callback_captures = true
+ignore_trait_signature_constraints = true
+ignore_external_api_boundaries = true
+```
+
+## Testing strategy
+
+### Unit tests
+
+Pure tests in `common` should cover:
+
+- path classification;
+- exact borrow mappings;
+- summary evaluation logic;
+- escape-kind reduction; and
+- diagnostic argument shaping.
+
+### Behaviour tests
+
+Use Whitaker's existing `rstest-bdd` pattern for:
+
+- configuration precedence;
+- localization fallback;
+- public-API suppression;
+- callback-boundary suppression; and
+- representative machine-suggestion cases.[^whitaker-design][^whitaker-i18n]
+
+### UI tests
+
+Each lint crate should ship pass or fail fixtures.
+
+#### UI tests for `clone_only_used_by_borrow`
+
+Positive fixtures:
+
+- direct `&x.clone()` call;
+- local binding only borrowed;
+- `to_owned()` borrowed-only case.
+
+Negative fixtures:
+
+- moved clone;
+- mutable original conflict;
+- unknown by-value call;
+- macro expansion.
+
+#### UI tests for `owned_param_causes_clone`
+
+Positive fixtures:
+
+- private function taking `String` but only reading it;
+- private method taking `Vec<T>` but only reading it.
+
+Negative fixtures:
+
+- parameter consumed or returned;
+- exported function;
+- trait method;
+- async function;
+- source temporary rather than retained local.
+
+#### UI tests for `local_shared_ownership`
+
+Positive fixtures:
+
+- local `Cell<bool>` that never crosses a boundary;
+- local `Rc<RefCell<Vec<_>>>` with purely sequential access.
+
+Negative fixtures:
+
+- `Rc<Cell<bool>>` captured by `'static` callback;
+- `Arc<Mutex<T>>` sent to a thread;
+- `Rc<dyn Trait>` required by external API;
+- Servo-style legitimate builder and callback usage.
+
+## Rollout plan
+
+### Release 1
+
+- ship `clone_only_used_by_borrow` as experimental `warn`;
+- ship `owned_param_causes_clone` as experimental `warn` with exported-API
+  suppression enabled; and
+- ship `local_shared_ownership` as experimental and feature-gated, off by
+  default.
+
+### Promotion criteria
+
+Promote `clone_only_used_by_borrow` when:
+
+- machine-applicable suggestions compile in UI fixtures;
+- false positives remain low across representative internal repositories; and
+- no known framework regression fixtures fail.
+
+Promote `owned_param_causes_clone` when:
+
+- exported-API and trait-signature suppression rules are stable;
+- the lint demonstrates more value than noise relative to Clippy's
+  `needless_pass_by_value`; and
+- at least one representative large codebase shows actionable findings without
+  suppression churn.
+
+Keep `local_shared_ownership` experimental until:
+
+- callback-boundary suppression is robust;
+- Servo-style and GUI-style fixtures remain quiet; and
+- the lint demonstrates clear signal on non-framework, non-async code.
+
+This mirrors the roadmap precedent for feature-gated experimental sets and
+explicit promotion criteria.[^whitaker-roadmap-rstest]
+
+## Open questions
+
+1. Which MIR query offers the best compromise between source-span fidelity and
+   post-borrow-check accuracy for external Dylint lints in Whitaker's pinned
+   toolchain?
+2. Should `owned_param_causes_clone` remain fully crate-local, or should a
+   future version emit softer notes for exported APIs when clone pressure is
+   visible in the same crate?
+3. Should the exact borrow-mapping table remain intentionally small, or grow to
+   cover additional buffer, path, or smart-handle types?
+4. Does `local_shared_ownership` warrant a separate "callback bridge"
+   exemption classifier shared with future async or UI lints?
+5. Should Whitaker eventually expose an `ownership` rule selection group in the
+   planned unified CLI?
+
+## Decision summary
+
+Whitaker should add a neutral, ownership-shape phase rather than a moralizing
+"borrow-checker workaround" lint. The suite should begin with one
+high-confidence clone-use lint, one call-site-to-callee ownership-pressure
+lint, and one experimental local-wrapper lint. The design should reuse
+Whitaker's current Dylint, localization, diagnostics, and pure-helper
+architecture, while treating framework and callback boundaries as suppressing
+evidence rather than anomalies.
+
+## References
+
+[^whitaker-readme]: Whitaker README, current lint inventory and project
+    framing. <https://github.com/leynos/whitaker>
+[^whitaker-design]: Whitaker suite design, shared helpers, localization, UI
+    harness, and existing core-lint architecture.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/whitaker-dylint-suite-design.md>
+[^whitaker-design-lints]: Whitaker suite design, per-lint crate scaffolding and
+    suite wiring.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/whitaker-dylint-suite-design.md>
+[^whitaker-i18n]: Whitaker suite design, localization and diagnostic structure.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/whitaker-dylint-suite-design.md>
+[^whitaker-def-path]: Whitaker suite design,
+    `no_std_fs_operations` implementation using `tcx.def_path_str(def_id)` and
+    parsed path segments.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/whitaker-dylint-suite-design.md>
+[^whitaker-roadmap]: Whitaker roadmap, current phase sequence through Phase 8
+    and related delivered work.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/roadmap.md>
+[^whitaker-roadmap-config]: Whitaker roadmap, unified CLI / `whitaker.toml`
+    direction with compatibility period.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/roadmap.md>
+[^whitaker-roadmap-rstest]: Whitaker roadmap, experimental-set and
+    promotion-criteria precedent in Phase 8.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/roadmap.md>
+[^brain-trust-design]: Whitaker brain-trust lints design, pure-helper pattern
+    and deterministic data structures in `common`.
+    <https://raw.githubusercontent.com/leynos/whitaker/main/docs/brain-trust-lints-design.md>
+[^clippy-redundant-clone]: Clippy `redundant_clone`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone>
+[^clippy-unnecessary-to-owned]: Clippy `unnecessary_to_owned`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned>
+[^clippy-needless-pass-by-value]: Clippy `needless_pass_by_value`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_value>
+[^clippy-clone-on-ref-ptr]: Clippy `clone_on_ref_ptr`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_ref_ptr>
+[^clippy-rc-buffer]: Clippy `rc_buffer`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#rc_buffer>
+[^clippy-redundant-allocation]: Clippy `redundant_allocation`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#redundant_allocation>
+[^clippy-arc-non-send-sync]: Clippy `arc_with_non_send_sync`.
+    <https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync>
+[^rustc-lints]: Rust compiler development guide, lint timing and late or MIR
+    lint infrastructure.
+    <https://rustc-dev-guide.rust-lang.org/diagnostics.html>
+[^rustc-mir]: Rust compiler development guide, MIR overview and passes.
+    <https://rustc-dev-guide.rust-lang.org/mir/index.html>
+[^servo-shot-main]: `servo-shot` example source.
+    <https://raw.githubusercontent.com/simonw/research/main/servo-crate-exploration/servo-shot/src/main.rs>
+[^servo-webview-builder]: Servo `WebViewBuilder` docs,
+    `Rc<dyn RenderingContext>` and `Rc<dyn WebViewDelegate>` API shape.
+    <https://doc.servo.org/servo/webview/struct.WebViewBuilder.html>
+[^servo-webview]: Servo `WebView` docs, handle backed by
+    `Rc<RefCell<WebViewInner>>`.
+    <https://doc.servo.org/servo/struct.WebView.html>
+[^servo-webview-delegate]: Servo `WebViewDelegate` docs, callback surface uses
+    `&self`.
+    <https://doc.servo.org/servo/webview_delegate/trait.WebViewDelegate.html>
+[^servo-webview-api]: Servo `WebView` docs, `'static` callback requirements for
+    `evaluate_javascript` and `take_screenshot`.
+    <https://doc.servo.org/servo/struct.WebView.html>

--- a/docs/ownership-shape-lints-design.md
+++ b/docs/ownership-shape-lints-design.md
@@ -1,6 +1,16 @@
+---
+Status: Proposed design for a future Whitaker lint phase.
+Scope: Crate-local ownership-shape lints for clone pressure and local shared ownership patterns.
+Primary audience: Whitaker maintainers implementing lint crates, shared helpers, and roadmap tasks.
+Precedent documents:
+  - docs/whitaker-dylint-suite-design.md
+  - docs/brain-trust-lints-design.md
+  - docs/roadmap.md
+---
+
 # Ownership shape lints design for value clones and local shared ownership
 
-## Purpose and scope
+## 1. Purpose and scope
 
 This document proposes the next core-lint phase for Whitaker: an
 ownership-shape suite aimed at value clones and local shared-ownership patterns
@@ -21,7 +31,7 @@ checker". It reports observable, mechanically defensible phenomena:
 This phase concerns **value clones**, not Whitaker's separate **code clone
 detector** pipeline.
 
-## At a glance
+## 2. At a glance
 
 For readers skimming the design, the three proposed lints differ mainly in what
 signal they treat as strongest evidence:
@@ -37,7 +47,7 @@ signal they treat as strongest evidence:
 In short, the first lint is clone-centric, the second is signature-centric, and
 the third is wrapper-centric.
 
-## Why this phase belongs in Whitaker
+## 3. Why this phase belongs in Whitaker
 
 Whitaker's original core suite established its house style around readable
 structure, explicit documentation, bounded control-flow complexity, and panic
@@ -62,7 +72,7 @@ patterns can:
 Whitaker should address that gap, but it should do so with a false-positive
 budget that matches the rest of the suite.
 
-## Product motivation and positioning
+## 4. Product motivation and positioning
 
 Whitaker should not duplicate existing Clippy coverage. Clippy already detects
 several local ownership smells, including `redundant_clone`,
@@ -81,7 +91,7 @@ This is especially important for Rust code that is exploratory,
 machine-generated, newly ported from other languages, or authored by
 contributors who have not yet internalized borrow-oriented API design.
 
-## Non-goals
+## 5. Non-goals
 
 This phase will not:
 
@@ -95,50 +105,50 @@ This phase will not:
 - supersede Clippy's purely local syntactic lints; or
 - auto-rewrite non-trivial smart-pointer refactors.
 
-## Design principles
+## 6. Design principles
 
-### 1. Report shape, not intent
+### 6.1. Report shape, not intent
 
 Lint names, messages, and documentation should describe the ownership
 phenomenon rather than speculate about why the code was written that way.
 
-### 2. Prefer high-confidence facts over broad coverage
+### 6.2. Prefer high-confidence facts over broad coverage
 
 A smaller suite with reliable findings is more valuable than an accusatory lint
 that fires on every `Rc<RefCell<_>>` in a GUI, browser, async, or
 callback-heavy codebase.
 
-### 3. Treat API boundaries as first-class evidence
+### 6.3. Treat API boundaries as first-class evidence
 
 Rust code often uses clones or wrappers because an API *requires* a particular
 ownership or lifetime shape. That is not noise around the design. It is the
 design. The lints must detect these boundaries and suppress or downgrade
 diagnostics accordingly.
 
-### 4. Reuse Whitaker's existing infrastructure
+### 6.4. Reuse Whitaker's existing infrastructure
 
 The suite should follow Whitaker's existing design patterns: one lint per
 crate, shared diagnostics and localization helpers in `common`, deterministic
 data structures, UI coverage, and configurable rollout from experimental to
 standard.[^2][^11][^12]
 
-### 5. Start with local, crate-contained analysis
+### 6.5. Start with local, crate-contained analysis
 
 The first release should stay within one crate and avoid speculative
 cross-crate reasoning. Local or private functions, local bodies, and resolved
 external API boundaries provide enough signal for a valuable first phase.
 
-## Phase title and roadmap placement
+## 7. Phase title and roadmap placement
 
 This work should land in the roadmap as **Phase 9. Ownership shape lints**. The
 current roadmap already extends through Phase 8, so Phase 9 fits the sequence
 cleanly.[^3]
 
-## Lint suite overview
+## 8. Lint suite overview
 
 The phase should ship three lints:
 
-### Metadata for `clone_only_used_by_borrow`
+### 8.1. Metadata for `clone_only_used_by_borrow`
 
 Warn when a cloned value is only ever immutably borrowed before drop, and the
 original value appears borrowable across the same region.
@@ -146,7 +156,7 @@ original value appears borrowable across the same region.
 This is the highest-confidence lint in the phase and the likeliest candidate
 for stable, warn-by-default status after validation.
 
-### Metadata for `owned_param_causes_clone`
+### 8.2. Metadata for `owned_param_causes_clone`
 
 Warn on local, same-crate functions or methods whose by-value parameter shape
 induces actual clones at call sites even though the callee only reads the
@@ -156,7 +166,7 @@ This lint complements rather than replaces Clippy's `needless_pass_by_value`:
 it requires *observed clone pressure* at local call sites, which makes the
 diagnosis more concrete and more actionably Whitaker-like.
 
-### Metadata for `local_shared_ownership`
+### 8.3. Metadata for `local_shared_ownership`
 
 Flag locally created `Rc`, `Arc`, or interior-mutability wrappers that do not
 escape and whose observed use-pattern does not appear to require shared
@@ -164,22 +174,22 @@ ownership or runtime borrow mediation.
 
 This lint should start as experimental and feature-gated.
 
-## Suggested lint metadata
+## 9. Suggested lint metadata
 
-### `clone_only_used_by_borrow`
+### 9.1. `clone_only_used_by_borrow`
 
 - Kind: `ownership`
 - Default level: `warn`
 - Rollout target: standard suite after false-positive validation
 
-### `owned_param_causes_clone`
+### 9.2. `owned_param_causes_clone`
 
 - Kind: `ownership`
 - Default level: `warn`
 - Rollout target: experimental first, standard once public-API and generic
   suppression rules settle
 
-### `local_shared_ownership`
+### 9.3. `local_shared_ownership`
 
 - Kind: `ownership`
 - Default level: `allow` or experimental `warn`
@@ -188,7 +198,7 @@ This lint should start as experimental and feature-gated.
 The `ownership` label is a documentation and selection category. It need not
 imply a new compiler lint group on day one.
 
-## Worked exception model: Servo-style code must stay quiet
+## 10. Worked exception model: Servo-style code must stay quiet
 
 The Servo `servo-shot` example is a useful calibration case because, at a
 glance, it contains exactly the kinds of patterns an overzealous ownership lint
@@ -218,9 +228,9 @@ Concretely, the following shapes should not trigger:
 
 This case should ship as a regression fixture in the UI suite.
 
-## Shared implementation approach
+## 11. Shared implementation approach
 
-### Architectural fit
+### 11.1. Architectural fit
 
 Whitaker already establishes the right implementation pattern:
 
@@ -237,7 +247,7 @@ This phase should follow the same split used by the brain-trust work:
 - **High-level Intermediate Representation (HIR) and MIR walkers plus
   rustc-private integration** in the lint crates.[^11]
 
-### Proposed crate and module layout
+### 11.2. Proposed crate and module layout
 
 ```text
 common/
@@ -256,7 +266,7 @@ crates/
 └── local_shared_ownership/
 ```
 
-### Proposed shared domain model
+### 11.3. Proposed shared domain model
 
 ```rust
 pub enum UseClass {
@@ -404,7 +414,7 @@ EvaluationResult --> OwnershipShapeEvaluation : output
 *Figure: Shared ownership-shape model showing the core enums, summaries, and
 evaluation entry points used across the proposed lint suite.*
 
-### Resolution strategy
+### 11.4. Resolution strategy
 
 The lints should resolve functions, methods, and wrapper constructors by
 **resolved `DefId` paths**, not by source text snippets. Whitaker already uses
@@ -412,7 +422,7 @@ The lints should resolve functions, methods, and wrapper constructors by
 the ownership suite should adopt the same technique for `Clone`, `ToOwned`,
 `Rc`, `Arc`, `Cell`, `RefCell`, `Mutex`, and `RwLock` classifiers.[^21]
 
-### HIR prefilter, MIR confirmation
+### 11.5. High-level Intermediate Representation (HIR) prefilter, Mid-level Intermediate Representation (MIR) confirmation
 
 The suite should use a two-stage approach:
 
@@ -427,14 +437,14 @@ information, and Rust's lint infrastructure explicitly supports both late
 passes and MIR-based checks for cases where flow-sensitive facts
 matter.[^20][^22]
 
-## Lint 1: `clone_only_used_by_borrow`
+## 12. Lint 1: `clone_only_used_by_borrow`
 
-### `clone_only_used_by_borrow` intent
+### 12.1. `clone_only_used_by_borrow` intent
 
 Detect clones whose resulting value is only observed through immutable borrows
 or `&self` method calls before being dropped.
 
-### `clone_only_used_by_borrow` detection model
+### 12.2. `clone_only_used_by_borrow` detection model
 
 A candidate arises from one of the following operations:
 
@@ -459,7 +469,7 @@ The lint fires only when:
 - the original receiver is a simple place whose borrow would not overlap a move
   or mutable borrow before the clone's last use.
 
-### Examples
+### 12.3. Examples
 
 Positive:
 
@@ -503,7 +513,7 @@ consume(tmp);
 s.push('!');
 ```
 
-### `clone_only_used_by_borrow` diagnostics
+### 12.4. `clone_only_used_by_borrow` diagnostics
 
 Primary message:
 
@@ -516,7 +526,7 @@ Notes:
 - suppress the message entirely if the replacement borrow would overlap a
   mutable use of the original.
 
-### Suggestion policy
+### 12.5. Suggestion policy
 
 Machine-applicable suggestions should be limited to:
 
@@ -526,7 +536,7 @@ Machine-applicable suggestions should be limited to:
 
 More complex cases should remain diagnostic-only.
 
-### `clone_only_used_by_borrow` false-positive controls
+### 12.6. `clone_only_used_by_borrow` false-positive controls
 
 Suppress when:
 
@@ -537,9 +547,9 @@ Suppress when:
 - the clone exists to satisfy an explicit API shape that will be handled by
   `owned_param_causes_clone` instead.
 
-## Lint 2: `owned_param_causes_clone`
+## 13. Lint 2: `owned_param_causes_clone`
 
-### `owned_param_causes_clone` intent
+### 13.1. `owned_param_causes_clone` intent
 
 Detect local, same-crate functions or methods whose by-value parameter shapes
 are creating clone pressure in real call sites even though the callee only
@@ -549,11 +559,11 @@ This lint is the suite's main product differentiator. It turns "this parameter
 could be a reference" into "this parameter is *currently causing callers to
 allocate or clone*".
 
-### `owned_param_causes_clone` detection model
+### 13.2. `owned_param_causes_clone` detection model
 
 The lint runs in two passes.
 
-#### Pass A: collect clone-pressure evidence at call sites
+#### 13.2.1. Pass A: collect clone-pressure evidence at call sites
 
 Record a candidate when all of the following hold:
 
@@ -570,7 +580,7 @@ Each candidate stores:
 - source place kind; and
 - whether the call occurs in a macro expansion.
 
-#### Pass B: summarize callee parameter usage
+#### 13.2.2. Pass B: summarize callee parameter usage
 
 For each candidate callee parameter, classify the parameter as one of:
 
@@ -585,7 +595,7 @@ The lint fires when:
 - the parameter is `ReadOnlyBorrowed`; and
 - the callee is not exempt.
 
-### Exemptions
+### 13.3. Exemptions
 
 Suppress by default when the callee is:
 
@@ -599,7 +609,7 @@ The exported-API suppression mirrors Clippy's existing
 `avoid-breaking-exported-api` pattern for several ownership-related
 lints.[^6][^9]
 
-### Exact borrow mappings
+### 13.4. Exact borrow mappings
 
 For the first release, support machine-guided rewrite hints only for exact,
 common owned-to-borrow mappings:
@@ -663,7 +673,7 @@ graph TD
 collection through parameter summarization, exemption handling, evaluation, and
 diagnostic emission.*
 
-### Diagnostics
+### 13.5. Diagnostics
 
 Primary span: parameter binding or function signature.
 
@@ -679,7 +689,7 @@ Notes:
 
 A secondary call-site note may be emitted at one representative clone span.
 
-### Example
+### 13.6. Example
 
 ```rust
 fn normalise(name: String) -> usize {
@@ -698,7 +708,7 @@ fn normalise(name: &str) -> usize {
 }
 ```
 
-### False-positive controls
+### 13.7. False-positive controls
 
 Suppress when:
 
@@ -710,14 +720,14 @@ Suppress when:
 - the clone source is itself a temporary, so the evidence does not actually
   show retained ownership pressure.
 
-## Lint 3: `local_shared_ownership`
+## 14. Lint 3: `local_shared_ownership`
 
-### Intent
+### 14.1. Intent
 
 Detect non-escaping shared-ownership or runtime-borrow wrappers whose observed
 use-pattern looks local and sequential.
 
-### Scope
+### 14.2. Scope
 
 The first release should restrict itself to wrappers created in the current
 body via:
@@ -732,7 +742,7 @@ body via:
 Nested forms such as `Rc<RefCell<T>>` and `Arc<Mutex<T>>` should be recognized
 explicitly.
 
-### Detection model
+### 14.3. Detection model
 
 A candidate wrapper is linted only when all of the following are true:
 
@@ -744,7 +754,7 @@ A candidate wrapper is linted only when all of the following are true:
 - the observed operations are limited to local, sequential `get`, `set`,
   `borrow`, `borrow_mut`, `lock`, `read`, or `write` patterns.
 
-### Diagnostic classes
+### 14.4. Diagnostic classes
 
 The lint should distinguish three families:
 
@@ -764,7 +774,7 @@ The lint should distinguish three families:
    - likely advice: "non-escaping shared mutable wrapper appears heavier than
      the local usage requires"
 
-### `local_shared_ownership` suggestion policy
+### 14.5. `local_shared_ownership` suggestion policy
 
 This lint should remain **diagnostic-only** in the first release.
 
@@ -772,7 +782,7 @@ A machine-applicable rewrite from `Rc<RefCell<T>>` to `let mut x = T` is too
 risky. The lint should instead point to the constructor span, summarize the
 evidence, and suggest a manual review.
 
-### Servo-style exemptions
+### 14.6. Servo-style exemptions
 
 Suppress when the wrapper exists because:
 
@@ -785,7 +795,7 @@ Suppress when the wrapper exists because:
 That suppresses the Servo `Rc<Cell<bool>>` callback bridge and `Cell`-backed
 delegate state described above.[^13][^14][^16][^17]
 
-### `local_shared_ownership` false-positive controls
+### 14.7. `local_shared_ownership` false-positive controls
 
 Suppress when:
 
@@ -798,9 +808,9 @@ Suppress when:
 - the inner type is itself a framework handle type and the wrapper appears to
   be part of that framework's ownership contract.
 
-## Common helper requirements
+## 15. Common helper requirements
 
-### `common::ownership_shape::path_kinds`
+### 15.1. `common::ownership_shape::path_kinds`
 
 Resolved-path classifiers for:
 
@@ -813,11 +823,11 @@ Resolved-path classifiers for:
 - callback, async, and task APIs that impose `'static` or thread-safe shared
   state.
 
-### `common::ownership_shape::exact_borrow_mappings`
+### 15.2. `common::ownership_shape::exact_borrow_mappings`
 
 A pure mapping table used by `owned_param_causes_clone`.
 
-### `common::ownership_shape::evaluation`
+### 15.3. `common::ownership_shape::evaluation`
 
 Pure decision functions that accept summaries and return:
 
@@ -829,7 +839,7 @@ Pure decision functions that accept summaries and return:
 This mirrors Whitaker's existing preference for pure evaluation helpers in
 `common` and thin lint-driver crates.[^11]
 
-## Diagnostics and localization
+## 16. Diagnostics and localization
 
 Whitaker already localizes diagnostics through Fluent bundles, uses stable
 slugs, and routes messages, notes, labels, and help text through shared
@@ -860,7 +870,7 @@ Diagnostic arguments should include concrete facts such as:
 As elsewhere in Whitaker, missing translations should degrade to deterministic
 English rather than panic.[^19]
 
-## Configuration
+## 17. Configuration
 
 Whitaker's longer-term roadmap is moving toward a unified command-line
 interface (CLI) and `whitaker.toml` configuration surface while retaining
@@ -893,9 +903,9 @@ ignore_trait_signature_constraints = true
 ignore_external_api_boundaries = true
 ```
 
-## Testing strategy
+## 18. Testing strategy
 
-### Unit tests
+### 18.1. Unit tests
 
 Pure tests in `common` should cover:
 
@@ -905,7 +915,7 @@ Pure tests in `common` should cover:
 - escape-kind reduction; and
 - diagnostic argument shaping.
 
-### Behaviour tests
+### 18.2. Behaviour tests
 
 Use Whitaker's existing `rstest-bdd` pattern for:
 
@@ -915,11 +925,11 @@ Use Whitaker's existing `rstest-bdd` pattern for:
 - callback-boundary suppression; and
 - representative machine-suggestion cases.[^2][^19]
 
-### UI tests
+### 18.3. UI tests
 
 Each lint crate should ship pass or fail fixtures.
 
-#### UI tests for `clone_only_used_by_borrow`
+#### 18.3.1. UI tests for `clone_only_used_by_borrow`
 
 Positive fixtures:
 
@@ -934,7 +944,7 @@ Negative fixtures:
 - unknown by-value call;
 - macro expansion.
 
-#### UI tests for `owned_param_causes_clone`
+#### 18.3.2. UI tests for `owned_param_causes_clone`
 
 Positive fixtures:
 
@@ -949,7 +959,7 @@ Negative fixtures:
 - async function;
 - source temporary rather than retained local.
 
-#### UI tests for `local_shared_ownership`
+#### 18.3.3. UI tests for `local_shared_ownership`
 
 Positive fixtures:
 
@@ -963,9 +973,9 @@ Negative fixtures:
 - `Rc<dyn Trait>` required by external API;
 - Servo-style legitimate builder and callback usage.
 
-## Rollout plan
+## 19. Rollout plan
 
-### Release 1
+### 19.1. Release 1
 
 - ship `clone_only_used_by_borrow` as experimental `warn`;
 - ship `owned_param_causes_clone` as experimental `warn` with exported-API
@@ -973,7 +983,7 @@ Negative fixtures:
 - ship `local_shared_ownership` as experimental and feature-gated, off by
   default.
 
-### Promotion criteria
+### 19.2. Promotion criteria
 
 Promote `clone_only_used_by_borrow` when:
 
@@ -998,7 +1008,7 @@ Keep `local_shared_ownership` experimental until:
 This mirrors the roadmap precedent for feature-gated experimental sets and
 explicit promotion criteria.[^12]
 
-## Open questions
+## 20. Open questions
 
 1. Which MIR query offers the best compromise between source-span fidelity and
    post-borrow-check accuracy for external Dylint lints in Whitaker's pinned
@@ -1013,7 +1023,7 @@ explicit promotion criteria.[^12]
 5. Should Whitaker eventually expose an `ownership` rule selection group in the
    planned unified CLI?
 
-## Decision summary
+## 21. Decision summary
 
 Whitaker should add a neutral, ownership-shape phase rather than a moralizing
 "borrow-checker workaround" lint. The suite should begin with one
@@ -1023,7 +1033,7 @@ Whitaker's current Dylint, localization, diagnostics, and pure-helper
 architecture, while treating framework and callback boundaries as suppressing
 evidence rather than anomalies.
 
-## References
+## 22. References
 
 [^1]: Whitaker README, current lint inventory and project
     framing. <https://github.com/leynos/whitaker>

--- a/docs/ownership-shape-lints-design.md
+++ b/docs/ownership-shape-lints-design.md
@@ -1,11 +1,13 @@
 ---
-Status: Proposed design for a future Whitaker lint phase.
-Scope: Crate-local ownership-shape lints for clone pressure and local shared ownership patterns.
-Primary audience: Whitaker maintainers implementing lint crates, shared helpers, and roadmap tasks.
+Status: Proposed
+Scope: ownership-shape lints for Phase 9.
+Primary audience: Whitaker contributors and lint implementers.
+Review tags:
+  - "[type:docstyle]"
 Precedent documents:
-  - docs/whitaker-dylint-suite-design.md
-  - docs/brain-trust-lints-design.md
-  - docs/roadmap.md
+  - "[Whitaker Dylint suite design](whitaker-dylint-suite-design.md)"
+  - "[Brain trust lints design](brain-trust-lints-design.md)"
+  - "[Roadmap](roadmap.md)"
 ---
 
 # Ownership shape lints design for value clones and local shared ownership

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -556,111 +556,113 @@
 
 - [ ] 9.1.1. Add `common::ownership_shape` model types, evaluation helpers, and
   diagnostic argument builders. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Shared
-  implementation approach and §Diagnostics and localisation. Requires 1.1.1.
+  [ownership shape lints design](ownership-shape-lints-design.md) §11 Shared
+  implementation approach and §16 Diagnostics and localization. Requires 1.1.1.
 - [ ] 9.1.2. Add resolved-path classifiers for clone-like operations and
   wrapper constructors, following the `def_path_str` plus parsed-segment
   pattern used by `no_std_fs_operations`. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Resolution
-  strategy and §Common helper requirements. Requires 9.1.1.
+  [ownership shape lints design](ownership-shape-lints-design.md) §11.4
+  Resolution strategy and §15 Common helper requirements. Requires 9.1.1.
 - [ ] 9.1.3. Add exact borrow mappings for the initial concrete type set. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Lint 2:
-  `owned_param_causes_clone` and §Common helper requirements. Requires 9.1.1.
+  [ownership shape lints design](ownership-shape-lints-design.md) §13 Lint 2:
+  `owned_param_causes_clone` and §15 Common helper requirements. Requires 9.1.1.
 - [ ] 9.1.4. Add crate-local MIR summary helpers for local uses, escapes, and
   boundary classification. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §HIR
-  prefilter, MIR confirmation and §Worked exception model: Servo-style code
-  must stay quiet. Requires 9.1.1 and 9.1.2.
+  [ownership shape lints design](ownership-shape-lints-design.md) §11.5
+  High-level Intermediate Representation (HIR) prefilter, Mid-level
+  Intermediate Representation (MIR) confirmation and §10 Worked exception
+  model: Servo-style code must stay quiet. Requires 9.1.1 and 9.1.2.
 
 ### 9.2. `clone_only_used_by_borrow`
 
 - [ ] 9.2.1. Create the lint crate and register
   `CLONE_ONLY_USED_BY_BORROW`. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Lint 1:
+  [ownership shape lints design](ownership-shape-lints-design.md) §12 Lint 1:
   `clone_only_used_by_borrow`. Requires 9.1.1.
 - [ ] 9.2.2. Implement HIR candidate prefiltering for `clone` and `to_owned`
   forms. See [ownership shape lints design](ownership-shape-lints-design.md)
-  §Lint 1: `clone_only_used_by_borrow` and §HIR prefilter, MIR confirmation.
-  Requires 9.2.1 and 9.1.2.
+  §12 Lint 1: `clone_only_used_by_borrow` and §11.5 High-level Intermediate
+  Representation (HIR) prefilter, Mid-level Intermediate Representation (MIR)
+  confirmation. Requires 9.2.1 and 9.1.2.
 - [ ] 9.2.3. Implement MIR use classification and original-place conflict
   checks. See [ownership shape lints design](ownership-shape-lints-design.md)
-  §Lint 1: `clone_only_used_by_borrow`. Requires 9.2.2 and 9.1.4.
+  §12 Lint 1: `clone_only_used_by_borrow`. Requires 9.2.2 and 9.1.4.
 - [ ] 9.2.4. Add machine-applicable suggestions for direct-call and simple-let
   forms. See [ownership shape lints design](ownership-shape-lints-design.md)
-  §Suggestion policy. Requires 9.2.3.
+  §12.5 Suggestion policy. Requires 9.2.3.
 - [ ] 9.2.5. Add UI pass and fail coverage, including macro and mutable-conflict
   cases. See [ownership shape lints design](ownership-shape-lints-design.md)
-  §Testing strategy. Requires 9.2.3 and 1.2.1.
-
+  §18 Testing strategy. Requires 9.2.3 and 1.2.1.
 
 ### 9.4. `local_shared_ownership`
 
 - [ ] 9.4.1. Create the lint crate and register `LOCAL_SHARED_OWNERSHIP` behind
   an experimental feature. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Lint 3:
-  `local_shared_ownership` and §Rollout plan. Requires 9.1.1.
+  [ownership shape lints design](ownership-shape-lints-design.md) §14 Lint 3:
+  `local_shared_ownership` and §19 Rollout plan. Requires 9.1.1.
 - [ ] 9.4.2. Implement wrapper-construction detection and non-escape
   classification for `Rc`, `Arc`, interior mutability, and shared-mutable
   combinations. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Scope and
-  §Detection model. Requires 9.4.1, 9.1.2, and 9.1.4.
+  [ownership shape lints design](ownership-shape-lints-design.md) §14.2 Scope
+  and §14.3 Detection model. Requires 9.4.1, 9.1.2, and 9.1.4.
 - [ ] 9.4.3. Implement callback, async, thread, trait-surface, and external-API
   suppression. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Servo-style
-  exemptions and §False-positive controls. Requires 9.4.2.
+  [ownership shape lints design](ownership-shape-lints-design.md) §14.6
+  Servo-style exemptions and §14.7 `local_shared_ownership` false-positive
+  controls. Requires 9.4.2.
 - [ ] 9.4.4. Add diagnostic classes for interior-mutability-only,
   shared-handle-only, and shared-mutable-wrapper cases. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Diagnostic
-  classes and §Suggestion policy. Requires 9.4.3.
+  [ownership shape lints design](ownership-shape-lints-design.md) §14.4
+  Diagnostic classes and §14.5 `local_shared_ownership` suggestion policy.
+  Requires 9.4.3.
 - [ ] 9.4.5. Add Servo-style regression fixtures and framework-boundary
   negatives. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Worked
-  exception model: Servo-style code must stay quiet and §Testing strategy.
+  [ownership shape lints design](ownership-shape-lints-design.md) §10 Worked
+  exception model: Servo-style code must stay quiet and §18 Testing strategy.
   Requires 9.4.4 and 1.2.1.
 
 
-### 9.5. Localisation, documentation, and promotion
+### 9.5. Localization, documentation, and promotion
 
 - [ ] 9.5.1. Add Fluent entries and diagnostic argument mappings for all three
   lints. See [ownership shape lints design](ownership-shape-lints-design.md)
-  §Diagnostics and localisation. Requires 9.2.5, 9.3.5, 9.4.5, and 2.3.3.
+  §16 Diagnostics and localization. Requires 9.2.5, 9.3.5, 9.4.5, and 2.3.3.
 - [ ] 9.5.2. Add Welsh and Gaelic smoke coverage for the ownership-shape
   diagnostics. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Diagnostics
-  and localisation and §Testing strategy. Requires 9.5.1.
+  [ownership shape lints design](ownership-shape-lints-design.md) §16
+  Diagnostics and localization and §18 Testing strategy. Requires 9.5.1.
 - [ ] 9.5.3. Update `docs/users-guide.md` and `docs/developers-guide.md` with
   lint intent, configuration, and rollout guidance for the ownership-shape
   suite. See [ownership shape lints design](ownership-shape-lints-design.md)
-  §Configuration and §Rollout plan. Requires 9.5.1.
+  §17 Configuration and §19 Rollout plan. Requires 9.5.1.
 - [ ] 9.5.4. Define promotion criteria from experimental to standard based on
   UI stability and false-positive tuning across representative repositories.
-  See [ownership shape lints design](ownership-shape-lints-design.md) §Rollout
-  plan. Requires 9.5.1 and 9.5.2.
-
+  See [ownership shape lints design](ownership-shape-lints-design.md) §19
+  Rollout plan. Requires 9.5.1 and 9.5.2.
 
 ## 10. Async-trait architecture hygiene lints
 
 ### 9.3. `owned_param_causes_clone`
 
 - [ ] 9.3.1. Create the lint crate and register `OWNED_PARAM_CAUSES_CLONE`.
-  See [ownership shape lints design](ownership-shape-lints-design.md) §Lint 2:
-  `owned_param_causes_clone`. Requires 9.1.1.
+  See [ownership shape lints design](ownership-shape-lints-design.md) §13 Lint
+  2: `owned_param_causes_clone`. Requires 9.1.1.
 - [ ] 9.3.2. Implement local call-site clone-pressure collection that records
   callee identity, argument index, source shape, and retained-source evidence.
-  See [ownership shape lints design](ownership-shape-lints-design.md) §Pass A:
-  collect clone-pressure evidence at call sites. Requires 9.3.1, 9.1.2, and
-  9.1.4.
+  See [ownership shape lints design](ownership-shape-lints-design.md) §13.2.1
+  Pass A: collect clone-pressure evidence at call sites. Requires 9.3.1, 9.1.2,
+  and 9.1.4.
 - [ ] 9.3.3. Implement callee parameter summaries and exported, trait, FFI, and
   async suppression rules. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Pass B:
-  summarise callee parameter usage and §Exemptions. Requires 9.3.2.
+  [ownership shape lints design](ownership-shape-lints-design.md) §13.2.2 Pass
+  B: summarize callee parameter usage and §13.3 Exemptions. Requires 9.3.2.
 - [ ] 9.3.4. Add exact borrow-type help for the initial mapping set without
   rewriting unsupported signatures. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Exact borrow
-  mappings and §Diagnostics. Requires 9.3.3 and 9.1.3.
+  [ownership shape lints design](ownership-shape-lints-design.md) §13.4 Exact
+  borrow mappings and §13.5 Diagnostics. Requires 9.3.3 and 9.1.3.
 - [ ] 9.3.5. Add UI coverage for private, exported, trait, async, and
   non-trigger scenarios. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §Testing
+  [ownership shape lints design](ownership-shape-lints-design.md) §18 Testing
   strategy. Requires 9.3.4 and 1.2.1.
 
 ### 12.3. `cargo-compile-hygiene` tool and checks

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,6 @@
 - [x] 1.2.1. Integrate `dylint_testing` harness boilerplate for UI tests across
   all lint crates.
 
-
 ### 1.3. Conditional Dylint `expect` support
 
 - [ ] 1.3.1. Add the `crates/whitaker_support_macros` proc-macro crate and
@@ -637,6 +636,10 @@
   UI stability and false-positive tuning across representative repositories.
   See [ownership shape lints design](ownership-shape-lints-design.md) §Rollout
   plan. Requires 9.5.1 and 9.5.2.
+
+
+## 10. Async-trait architecture hygiene lints
+
 ### 9.3. `owned_param_causes_clone`
 
 - [ ] 9.3.1. Create the lint crate and register `OWNED_PARAM_CAUSES_CLONE`.
@@ -659,3 +662,241 @@
   non-trigger scenarios. See
   [ownership shape lints design](ownership-shape-lints-design.md) §Testing
   strategy. Requires 9.3.4 and 1.2.1.
+
+### 12.3. `cargo-compile-hygiene` tool and checks
+
+- [ ] 12.3.1. Create the `cargo-compile-hygiene` Cargo subcommand with
+  `check`, `check --json`, `explain`, and `baseline --write` entrypoints, using
+  `cargo metadata --format-version 1` as the primary graph input. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Tool shape and why it is a Cargo subcommand and §Commands and CLI UX.
+  Requires 12.1.1.
+- [ ] 12.3.2. Implement the `integration_target_budget`,
+  `heavy_dependency_not_optional`, and `duplicate_major_version_hotspots`
+  checks with shortest-path or hotspot explanations in reports. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Checks. Requires 12.3.1.
+- [ ] 12.3.3. Implement the `tls_backend_multiplicity` and
+  `package_boundary_purity` checks, including per-configuration graph analysis
+  for feature-matrix runs. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Checks and §Invocation patterns and feature-matrix handling. Requires
+  12.3.1.
+- [ ] 12.3.4. Add human-readable and JSON reporting with finding IDs, metrics,
+  remediation guidance, and CI-oriented exit semantics. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Output formats and example reports. Requires 12.3.2 and 12.3.3.
+
+
+### 12.4. CI, rollout, and migration guidance
+
+- [ ] 12.4.1. Add default, minimal, and all-features CI jobs that run both the
+  Whitaker lint set and `cargo-compile-hygiene` across the same feature matrix.
+  See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Invocation patterns and feature-matrix handling. Requires 12.2.3, 12.3.4,
+  and 4.1.1.
+- [ ] 12.4.2. Update `docs/users-guide.md`, `docs/developers-guide.md`, and
+  CLI-facing workflow documentation with shared policy examples, report
+  interpretation guidance, and migration sequencing for downstream adopters.
+  See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Comparison table: what belongs where and §Migration guidance for Axinite
+  and Gauss. Requires 12.2.3 and 12.3.4.
+- [ ] 12.4.3. Define staged rollout criteria for promoting selected
+  architecture and compile-hygiene findings from report-only or `warn` status
+  to CI-failing policy. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Severity levels and build gating and §Integration, CI, and rollout.
+  Requires 12.4.1.
+
+### 10.2. Inventory and family-completeness lints
+
+- [ ] 10.2.1. Create the `async_trait_concrete_only` and
+  `async_trait_signature_markers_present` lint crates with diagnostics wired to
+  the shared family index. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Proposed lint table. Requires 10.1.2 and 10.1.3.
+- [ ] 10.2.2. Create the `async_dyn_family_requires_native_sibling` and
+  `async_dyn_family_requires_blanket_adapter` lint crates, including
+  family-scoped allowlist support. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Proposed lint table and §Migration waves and default levels. Requires
+  10.2.1.
+- [ ] 10.2.3. Add UI coverage for dyn-required supertrait cases,
+  high-confidence async-trait marker detection, missing sibling traits, and
+  missing blanket adapters. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Proposed lint table. Requires 10.2.2 and 1.2.1.
+
+
+## 11. Test-support dead-code and masked-expectation analysis
+
+
+### 10.1. Shared family analysis and configuration
+
+- [ ] 10.1.1. Add `whitaker::async_trait_hygiene` modules behind the
+  `dylint-driver` feature and implement the `AsyncTraitFamilyIndex` data model.
+  See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Shared helper placement in Whitaker and §AsyncTraitFamilyIndex fields.
+  Requires 1.1.1.
+- [ ] 10.1.2. Implement dyn-use closure, supertrait closure, boxed-future
+  alias detection, sibling lookup, and adapter discovery with deterministic
+  ordering. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Algorithms and §AsyncTraitFamilyIndex fields. Requires 10.1.1.
+- [ ] 10.1.3. Add shared configuration types and loaders for suite defaults,
+  allowlists, alias policy, and `Send` policy overrides. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Configuration model. Requires 10.1.1 and 3.6.3.
+
+
+### 12.1. Shared policy schema and lint taxonomy
+
+- [ ] 12.1.1. Add shared `[workspace.metadata.whitaker]` policy parsing for
+  layers, forbidden dependencies, feature islands, compile-hygiene thresholds,
+  and allowlists. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Policy storage and shared configuration model. Requires 3.6.3.
+- [ ] 12.1.2. Register Whitaker lint groups and naming conventions for
+  `arch_*`, `hygiene_*`, `tests_*`, and `advisory_*` rules so CI and users can
+  enable coherent policy sets. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Whitaker lint namespaces and naming conventions and §Severity levels and
+  build gating. Requires 12.1.1.
+- [ ] 12.1.3. Document suppression guidance for early, late, and
+  pre-expansion Whitaker lints, including
+  `cfg_attr(dylint_lib = "whitaker", ...)` and `#[allow(unknown_lints)]` escape
+  hatches. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Feature-matrix and “unknown lint” ergonomics. Requires 12.1.2.
+
+
+### 10.4. Suite wiring, rollout, and documentation
+
+- [ ] 10.4.1. Add the async-trait hygiene lints either to a specialist suite or
+  to `whitaker_suite` behind an explicit opt-in feature, and expose selector
+  defaults for inventory versus ratchet waves. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Suite plumbing and §Migration waves and default levels. Requires 10.2.3,
+  10.3.3, and 3.6.2.
+- [ ] 10.4.2. Add CI and maintainer guidance that capture timing evidence
+  outside lint execution and document crate-local truth versus workspace-level
+  audit limits. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §CI and xtask responsibilities versus lints. Requires 10.4.1 and 4.1.1.
+- [ ] 10.4.3. Update `docs/users-guide.md` and `docs/developers-guide.md` with
+  the migration-wave model, configuration keys, and suppression guidance for
+  async-trait hygiene findings. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Configuration model and §Migration waves and default levels. Requires
+  10.4.1.
+
+
+### 10.3. Signature-shape and migration-ratchet lints
+
+- [ ] 10.3.1. Create the `async_dyn_direct_impl_prefers_native` and
+  `async_dyn_boxed_future_alias_required` lint crates and implement their
+  family-shape checks. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Proposed lint table. Requires 10.1.2 and 10.1.3.
+- [ ] 10.3.2. Create the `native_async_future_must_be_send` and
+  `native_async_multi_borrow_requires_named_lifetime` lint crates, including
+  per-family non-`Send` policy overrides. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Proposed lint table and §Pending architectural decisions and trade-offs.
+  Requires 10.3.1.
+- [ ] 10.3.3. Add UI coverage for direct dyn impls, raw boxed-future returns,
+  missing `+ Send`, allowed non-`Send` families, and multi-borrow lifetime
+  fixes. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Proposed lint table. Requires 10.3.2 and 1.2.1.
+
+
+### 11.3. Reporting, `whitaker check` integration, and validation
+
+- [ ] 11.3.1. Integrate the merged dead-code and stale-expectation report into
+  `whitaker check`, with per-item classifications for globally dead,
+  single-target live, shared, and synthetic-only support items. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Diagnostic model and report format. Requires 11.2.3 and 3.5.2.
+- [ ] 11.3.2. Add JSON output for the merged report so CI and follow-on tools
+  can consume item inventories, importer targets, and stale-expectation data.
+  See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Diagnostic model and report format. Requires 11.3.1 and 3.8.2.
+- [ ] 11.3.3. Add fixtures and behaviour coverage derived from the Axinite and
+  mdtablefix worked examples, including `#[path]` traversal, genuine shared
+  helpers, and synthetic keepalive shims. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Worked examples and §Constraints, failure modes, and rollout. Requires
+  11.3.1.
+- [ ] 11.3.4. Update `docs/users-guide.md` and `docs/developers-guide.md` with
+  the cleanup workflow, v1 non-goals, and guidance on when not to replace
+  `allow(dead_code)` with `expect(dead_code)`. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Constraints, failure modes, and rollout. Requires 11.3.1.
+
+
+### 12.2. Whitaker lint MVP for architecture and source-level hygiene
+
+- [ ] 12.2.1. Implement `whitaker::arch_hexagonal_layer_boundary` with
+  resolution-aware internal and external dependency checks, and port the
+  Wildside-style regression fixtures into Dylint UI tests. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §`whitaker::arch_hexagonal_layer_boundary`. Requires 12.1.1 and 1.2.1.
+- [ ] 12.2.2. Implement
+  `whitaker::hygiene_public_api_leaks_optional_dep` and
+  `whitaker::hygiene_feature_island_breach`, including feature-matrix coverage
+  for guarded and unguarded heavy-dependency paths. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §`whitaker::hygiene_public_api_leaks_optional_dep` and
+  §`whitaker::hygiene_feature_island_breach`. Requires 12.1.1 and 1.2.1.
+- [ ] 12.2.3. Implement `whitaker::tests_ui_test_macro_outside_app` as a
+  pre-expansion lint and keep `whitaker::advisory_async_trait_clear_misuse` as
+  an advisory-only rule with a conservative mode. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §`whitaker::tests_ui_test_macro_outside_app` and
+  §`whitaker::advisory_async_trait_clear_misuse`. Requires 12.1.3 and 1.2.1.
+
+
+### 11.1. Detector lints and module-graph discovery
+
+- [ ] 11.1.1. Create the `test_support_dead_code` lint crate and implement the
+  fast detector for dead-code suppressions in integration-test support modules.
+  See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Proposed rule contracts. Requires 1.1.1.
+- [ ] 11.1.2. Create the `masked_dead_code_expectations` lint crate and detect
+  `#[expect(dead_code)]` under `allow(unfulfilled_lint_expectations)` in the
+  same support-module scope. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Proposed rule contracts. Requires 11.1.1.
+- [ ] 11.1.3. Add integration-test module-graph discovery for `tests/*.rs`
+  harnesses, ordinary `mod` edges, and explicit `#[path]` edges so workspace
+  analysis can identify importer targets precisely. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Multi-pass execution path. Requires 11.1.1 and 3.5.2.
+
+
+### 11.2. Overlay builds and workspace analysis
+
+- [ ] 11.2.1. Implement overlay workspace creation and text-edit planning that
+  strips only `dead_code` suppressions, preserves unrelated lints, and inserts
+  probe items without mutating the working tree. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Multi-pass execution path. Requires 11.1.3.
+- [ ] 11.2.2. Add per-target `cargo check --message-format=json` replay plus a
+  collector that records organic and synthetic use sites for support items. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Multi-pass execution path and §Diagnostic model and report format. Requires
+  11.2.1.
+- [ ] 11.2.3. Add masked-expectation replay runs that remove
+  `allow(unfulfilled_lint_expectations)` only where needed and classify stale
+  expectations per importer target. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Multi-pass execution path. Requires 11.2.2.
+
+
+## 12. Architecture and compile-time hygiene enforcement

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -548,9 +548,7 @@
   [rstest fixture and test hygiene lints](lints-for-rstest-fixtures-and-test-hygiene.md)
    §Integration constraints. Requires 8.5.1.
 
-
 ## 9. Ownership shape lints
-
 
 ### 9.1. Shared foundations
 
@@ -594,6 +592,29 @@
   cases. See [ownership shape lints design](ownership-shape-lints-design.md)
   §18 Testing strategy. Requires 9.2.3 and 1.2.1.
 
+### 9.3. `owned_param_causes_clone`
+
+- [ ] 9.3.1. Create the lint crate and register `OWNED_PARAM_CAUSES_CLONE`.
+  See [ownership shape lints design](ownership-shape-lints-design.md) §13 Lint
+  2: `owned_param_causes_clone`. Requires 9.1.1.
+- [ ] 9.3.2. Implement local call-site clone-pressure collection that records
+  callee identity, argument index, source shape, and retained-source evidence.
+  See [ownership shape lints design](ownership-shape-lints-design.md) §13.2.1
+  Pass A: collect clone-pressure evidence at call sites. Requires 9.3.1, 9.1.2,
+  and 9.1.4.
+- [ ] 9.3.3. Implement callee parameter summaries and exported, trait, FFI, and
+  async suppression rules. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §13.2.2 Pass
+  B: summarize callee parameter usage and §13.3 Exemptions. Requires 9.3.2.
+- [ ] 9.3.4. Add exact borrow-type help for the initial mapping set without
+  rewriting unsupported signatures. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §13.4 Exact
+  borrow mappings and §13.5 Diagnostics. Requires 9.3.3 and 9.1.3.
+- [ ] 9.3.5. Add UI coverage for private, exported, trait, async, and
+  non-trigger scenarios. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §18 Testing
+  strategy. Requires 9.3.4 and 1.2.1.
+
 ### 9.4. `local_shared_ownership`
 
 - [ ] 9.4.1. Create the lint crate and register `LOCAL_SHARED_OWNERSHIP` behind
@@ -621,7 +642,6 @@
   exception model: Servo-style code must stay quiet and §18 Testing strategy.
   Requires 9.4.4 and 1.2.1.
 
-
 ### 9.5. Localization, documentation, and promotion
 
 - [ ] 9.5.1. Add Fluent entries and diagnostic argument mappings for all three
@@ -642,75 +662,23 @@
 
 ## 10. Async-trait architecture hygiene lints
 
-### 9.3. `owned_param_causes_clone`
+### 10.1. Shared family analysis and configuration
 
-- [ ] 9.3.1. Create the lint crate and register `OWNED_PARAM_CAUSES_CLONE`.
-  See [ownership shape lints design](ownership-shape-lints-design.md) §13 Lint
-  2: `owned_param_causes_clone`. Requires 9.1.1.
-- [ ] 9.3.2. Implement local call-site clone-pressure collection that records
-  callee identity, argument index, source shape, and retained-source evidence.
-  See [ownership shape lints design](ownership-shape-lints-design.md) §13.2.1
-  Pass A: collect clone-pressure evidence at call sites. Requires 9.3.1, 9.1.2,
-  and 9.1.4.
-- [ ] 9.3.3. Implement callee parameter summaries and exported, trait, FFI, and
-  async suppression rules. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §13.2.2 Pass
-  B: summarize callee parameter usage and §13.3 Exemptions. Requires 9.3.2.
-- [ ] 9.3.4. Add exact borrow-type help for the initial mapping set without
-  rewriting unsupported signatures. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §13.4 Exact
-  borrow mappings and §13.5 Diagnostics. Requires 9.3.3 and 9.1.3.
-- [ ] 9.3.5. Add UI coverage for private, exported, trait, async, and
-  non-trigger scenarios. See
-  [ownership shape lints design](ownership-shape-lints-design.md) §18 Testing
-  strategy. Requires 9.3.4 and 1.2.1.
-
-### 12.3. `cargo-compile-hygiene` tool and checks
-
-- [ ] 12.3.1. Create the `cargo-compile-hygiene` Cargo subcommand with
-  `check`, `check --json`, `explain`, and `baseline --write` entrypoints, using
-  `cargo metadata --format-version 1` as the primary graph input. See
-  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
-   §Tool shape and why it is a Cargo subcommand and §Commands and CLI UX.
-  Requires 12.1.1.
-- [ ] 12.3.2. Implement the `integration_target_budget`,
-  `heavy_dependency_not_optional`, and `duplicate_major_version_hotspots`
-  checks with shortest-path or hotspot explanations in reports. See
-  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
-   §Checks. Requires 12.3.1.
-- [ ] 12.3.3. Implement the `tls_backend_multiplicity` and
-  `package_boundary_purity` checks, including per-configuration graph analysis
-  for feature-matrix runs. See
-  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
-   §Checks and §Invocation patterns and feature-matrix handling. Requires
-  12.3.1.
-- [ ] 12.3.4. Add human-readable and JSON reporting with finding IDs, metrics,
-  remediation guidance, and CI-oriented exit semantics. See
-  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
-   §Output formats and example reports. Requires 12.3.2 and 12.3.3.
-
-
-### 12.4. CI, rollout, and migration guidance
-
-- [ ] 12.4.1. Add default, minimal, and all-features CI jobs that run both the
-  Whitaker lint set and `cargo-compile-hygiene` across the same feature matrix.
+- [ ] 10.1.1. Add `whitaker::async_trait_hygiene` modules behind the
+  `dylint-driver` feature and implement the `AsyncTraitFamilyIndex` data model.
   See
-  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
-   §Invocation patterns and feature-matrix handling. Requires 12.2.3, 12.3.4,
-  and 4.1.1.
-- [ ] 12.4.2. Update `docs/users-guide.md`, `docs/developers-guide.md`, and
-  CLI-facing workflow documentation with shared policy examples, report
-  interpretation guidance, and migration sequencing for downstream adopters.
-  See
-  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
-   §Comparison table: what belongs where and §Migration guidance for Axinite
-  and Gauss. Requires 12.2.3 and 12.3.4.
-- [ ] 12.4.3. Define staged rollout criteria for promoting selected
-  architecture and compile-hygiene findings from report-only or `warn` status
-  to CI-failing policy. See
-  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
-   §Severity levels and build gating and §Integration, CI, and rollout.
-  Requires 12.4.1.
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Shared helper placement in Whitaker and §AsyncTraitFamilyIndex fields.
+  Requires 1.1.1.
+- [ ] 10.1.2. Implement dyn-use closure, supertrait closure, boxed-future
+  alias detection, sibling lookup, and adapter discovery with deterministic
+  ordering. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Algorithms and §AsyncTraitFamilyIndex fields. Requires 10.1.1.
+- [ ] 10.1.3. Add shared configuration types and loaders for suite defaults,
+  allowlists, alias policy, and `Send` policy overrides. See
+  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
+   §Configuration model. Requires 10.1.1 and 3.6.3.
 
 ### 10.2. Inventory and family-completeness lints
 
@@ -731,49 +699,24 @@
   [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
    §Proposed lint table. Requires 10.2.2 and 1.2.1.
 
+### 10.3. Signature-shape and migration-ratchet lints
 
-## 11. Test-support dead-code and masked-expectation analysis
-
-
-### 10.1. Shared family analysis and configuration
-
-- [ ] 10.1.1. Add `whitaker::async_trait_hygiene` modules behind the
-  `dylint-driver` feature and implement the `AsyncTraitFamilyIndex` data model.
-  See
+- [ ] 10.3.1. Create the `async_dyn_direct_impl_prefers_native` and
+  `async_dyn_boxed_future_alias_required` lint crates and implement their
+  family-shape checks. See
   [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
-   §Shared helper placement in Whitaker and §AsyncTraitFamilyIndex fields.
-  Requires 1.1.1.
-- [ ] 10.1.2. Implement dyn-use closure, supertrait closure, boxed-future
-  alias detection, sibling lookup, and adapter discovery with deterministic
-  ordering. See
+   §Proposed lint table. Requires 10.1.2 and 10.1.3.
+- [ ] 10.3.2. Create the `native_async_future_must_be_send` and
+  `native_async_multi_borrow_requires_named_lifetime` lint crates, including
+  per-family non-`Send` policy overrides. See
   [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
-   §Algorithms and §AsyncTraitFamilyIndex fields. Requires 10.1.1.
-- [ ] 10.1.3. Add shared configuration types and loaders for suite defaults,
-  allowlists, alias policy, and `Send` policy overrides. See
+   §Proposed lint table and §Pending architectural decisions and trade-offs.
+  Requires 10.3.1.
+- [ ] 10.3.3. Add UI coverage for direct dyn impls, raw boxed-future returns,
+  missing `+ Send`, allowed non-`Send` families, and multi-borrow lifetime
+  fixes. See
   [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
-   §Configuration model. Requires 10.1.1 and 3.6.3.
-
-
-### 12.1. Shared policy schema and lint taxonomy
-
-- [ ] 12.1.1. Add shared `[workspace.metadata.whitaker]` policy parsing for
-  layers, forbidden dependencies, feature islands, compile-hygiene thresholds,
-  and allowlists. See
-  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
-   §Policy storage and shared configuration model. Requires 3.6.3.
-- [ ] 12.1.2. Register Whitaker lint groups and naming conventions for
-  `arch_*`, `hygiene_*`, `tests_*`, and `advisory_*` rules so CI and users can
-  enable coherent policy sets. See
-  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
-   §Whitaker lint namespaces and naming conventions and §Severity levels and
-  build gating. Requires 12.1.1.
-- [ ] 12.1.3. Document suppression guidance for early, late, and
-  pre-expansion Whitaker lints, including
-  `cfg_attr(dylint_lib = "whitaker", ...)` and `#[allow(unknown_lints)]` escape
-  hatches. See
-  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
-   §Feature-matrix and “unknown lint” ergonomics. Requires 12.1.2.
-
+   §Proposed lint table. Requires 10.3.2 and 1.2.1.
 
 ### 10.4. Suite wiring, rollout, and documentation
 
@@ -795,26 +738,43 @@
    §Configuration model and §Migration waves and default levels. Requires
   10.4.1.
 
+## 11. Test-support dead-code and masked-expectation analysis
 
-### 10.3. Signature-shape and migration-ratchet lints
+### 11.1. Detector lints and module-graph discovery
 
-- [ ] 10.3.1. Create the `async_dyn_direct_impl_prefers_native` and
-  `async_dyn_boxed_future_alias_required` lint crates and implement their
-  family-shape checks. See
-  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
-   §Proposed lint table. Requires 10.1.2 and 10.1.3.
-- [ ] 10.3.2. Create the `native_async_future_must_be_send` and
-  `native_async_multi_borrow_requires_named_lifetime` lint crates, including
-  per-family non-`Send` policy overrides. See
-  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
-   §Proposed lint table and §Pending architectural decisions and trade-offs.
-  Requires 10.3.1.
-- [ ] 10.3.3. Add UI coverage for direct dyn impls, raw boxed-future returns,
-  missing `+ Send`, allowed non-`Send` families, and multi-borrow lifetime
-  fixes. See
-  [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md)
-   §Proposed lint table. Requires 10.3.2 and 1.2.1.
+- [ ] 11.1.1. Create the `test_support_dead_code` lint crate and implement the
+  fast detector for dead-code suppressions in integration-test support modules.
+  See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Proposed rule contracts. Requires 1.1.1.
+- [ ] 11.1.2. Create the `masked_dead_code_expectations` lint crate and detect
+  `#[expect(dead_code)]` under `allow(unfulfilled_lint_expectations)` in the
+  same support-module scope. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Proposed rule contracts. Requires 11.1.1.
+- [ ] 11.1.3. Add integration-test module-graph discovery for `tests/*.rs`
+  harnesses, ordinary `mod` edges, and explicit `#[path]` edges so workspace
+  analysis can identify importer targets precisely. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Multi-pass execution path. Requires 11.1.1 and 3.5.2.
 
+### 11.2. Overlay builds and workspace analysis
+
+- [ ] 11.2.1. Implement overlay workspace creation and text-edit planning that
+  strips only `dead_code` suppressions, preserves unrelated lints, and inserts
+  probe items without mutating the working tree. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Multi-pass execution path. Requires 11.1.3.
+- [ ] 11.2.2. Add per-target `cargo check --message-format=json` replay plus a
+  collector that records organic and synthetic use sites for support items. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Multi-pass execution path and §Diagnostic model and report format. Requires
+  11.2.1.
+- [ ] 11.2.3. Add masked-expectation replay runs that remove
+  `allow(unfulfilled_lint_expectations)` only where needed and classify stale
+  expectations per importer target. See
+  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
+   §Multi-pass execution path. Requires 11.2.2.
 
 ### 11.3. Reporting, `whitaker check` integration, and validation
 
@@ -840,6 +800,27 @@
   [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
    §Constraints, failure modes, and rollout. Requires 11.3.1.
 
+## 12. Architecture and compile-time hygiene enforcement
+
+### 12.1. Shared policy schema and lint taxonomy
+
+- [ ] 12.1.1. Add shared `[workspace.metadata.whitaker]` policy parsing for
+  layers, forbidden dependencies, feature islands, compile-hygiene thresholds,
+  and allowlists. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Policy storage and shared configuration model. Requires 3.6.3.
+- [ ] 12.1.2. Register Whitaker lint groups and naming conventions for
+  `arch_*`, `hygiene_*`, `tests_*`, and `advisory_*` rules so CI and users can
+  enable coherent policy sets. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Whitaker lint namespaces and naming conventions and §Severity levels and
+  build gating. Requires 12.1.1.
+- [ ] 12.1.3. Document suppression guidance for early, late, and
+  pre-expansion Whitaker lints, including
+  `cfg_attr(dylint_lib = "whitaker", ...)` and `#[allow(unknown_lints)]` escape
+  hatches. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Feature-matrix and “unknown lint” ergonomics. Requires 12.1.2.
 
 ### 12.2. Whitaker lint MVP for architecture and source-level hygiene
 
@@ -862,43 +843,48 @@
    §`whitaker::tests_ui_test_macro_outside_app` and
   §`whitaker::advisory_async_trait_clear_misuse`. Requires 12.1.3 and 1.2.1.
 
+### 12.3. `cargo-compile-hygiene` tool and checks
 
-### 11.1. Detector lints and module-graph discovery
+- [ ] 12.3.1. Create the `cargo-compile-hygiene` Cargo subcommand with
+  `check`, `check --json`, `explain`, and `baseline --write` entrypoints, using
+  `cargo metadata --format-version 1` as the primary graph input. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Tool shape and why it is a Cargo subcommand and §Commands and CLI UX.
+  Requires 12.1.1.
+- [ ] 12.3.2. Implement the `integration_target_budget`,
+  `heavy_dependency_not_optional`, and `duplicate_major_version_hotspots`
+  checks with shortest-path or hotspot explanations in reports. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Checks. Requires 12.3.1.
+- [ ] 12.3.3. Implement the `tls_backend_multiplicity` and
+  `package_boundary_purity` checks, including per-configuration graph analysis
+  for feature-matrix runs. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Checks and §Invocation patterns and feature-matrix handling. Requires
+  12.3.1.
+- [ ] 12.3.4. Add human-readable and JSON reporting with finding IDs, metrics,
+  remediation guidance, and CI-oriented exit semantics. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Output formats and example reports. Requires 12.3.2 and 12.3.3.
 
-- [ ] 11.1.1. Create the `test_support_dead_code` lint crate and implement the
-  fast detector for dead-code suppressions in integration-test support modules.
+### 12.4. CI, rollout, and migration guidance
+
+- [ ] 12.4.1. Add default, minimal, and all-features CI jobs that run both the
+  Whitaker lint set and `cargo-compile-hygiene` across the same feature matrix.
   See
-  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
-   §Proposed rule contracts. Requires 1.1.1.
-- [ ] 11.1.2. Create the `masked_dead_code_expectations` lint crate and detect
-  `#[expect(dead_code)]` under `allow(unfulfilled_lint_expectations)` in the
-  same support-module scope. See
-  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
-   §Proposed rule contracts. Requires 11.1.1.
-- [ ] 11.1.3. Add integration-test module-graph discovery for `tests/*.rs`
-  harnesses, ordinary `mod` edges, and explicit `#[path]` edges so workspace
-  analysis can identify importer targets precisely. See
-  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
-   §Multi-pass execution path. Requires 11.1.1 and 3.5.2.
-
-
-### 11.2. Overlay builds and workspace analysis
-
-- [ ] 11.2.1. Implement overlay workspace creation and text-edit planning that
-  strips only `dead_code` suppressions, preserves unrelated lints, and inserts
-  probe items without mutating the working tree. See
-  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
-   §Multi-pass execution path. Requires 11.1.3.
-- [ ] 11.2.2. Add per-target `cargo check --message-format=json` replay plus a
-  collector that records organic and synthetic use sites for support items. See
-  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
-   §Multi-pass execution path and §Diagnostic model and report format. Requires
-  11.2.1.
-- [ ] 11.2.3. Add masked-expectation replay runs that remove
-  `allow(unfulfilled_lint_expectations)` only where needed and classify stale
-  expectations per importer target. See
-  [technical design for `test_support_dead_code` and `masked_dead_code_expectations`](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md)
-   §Multi-pass execution path. Requires 11.2.2.
-
-
-## 12. Architecture and compile-time hygiene enforcement
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Invocation patterns and feature-matrix handling. Requires 12.2.3, 12.3.4,
+  and 4.1.1.
+- [ ] 12.4.2. Update `docs/users-guide.md`, `docs/developers-guide.md`, and
+  CLI-facing workflow documentation with shared policy examples, report
+  interpretation guidance, and migration sequencing for downstream adopters.
+  See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Comparison table: what belongs where and §Migration guidance for Axinite
+  and Gauss. Requires 12.2.3 and 12.3.4.
+- [ ] 12.4.3. Define staged rollout criteria for promoting selected
+  architecture and compile-hygiene findings from report-only or `warn` status
+  to CI-failing policy. See
+  [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md)
+   §Severity levels and build gating and §Integration, CI, and rollout.
+  Requires 12.4.1.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -516,3 +516,116 @@
   UI stability and false-positive tuning across internal repositories. See
   [rstest fixture and test hygiene lints](lints-for-rstest-fixtures-and-test-hygiene.md)
    §Integration constraints. Requires 8.5.1.
+
+
+## 9. Ownership shape lints
+
+
+### 9.1. Shared foundations
+
+- [ ] 9.1.1. Add `common::ownership_shape` model types, evaluation helpers, and
+  diagnostic argument builders. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Shared
+  implementation approach and §Diagnostics and localization. Requires 1.1.1.
+- [ ] 9.1.2. Add resolved-path classifiers for clone-like operations and
+  wrapper constructors, following the `def_path_str` plus parsed-segment
+  pattern used by `no_std_fs_operations`. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Resolution
+  strategy and §Common helper requirements. Requires 9.1.1.
+- [ ] 9.1.3. Add exact borrow mappings for the initial concrete type set. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Lint 2:
+  `owned_param_causes_clone` and §Common helper requirements. Requires 9.1.1.
+- [ ] 9.1.4. Add crate-local MIR summary helpers for local uses, escapes, and
+  boundary classification. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §HIR
+  prefilter, MIR confirmation and §Worked exception model: Servo-style code
+  must stay quiet. Requires 9.1.1 and 9.1.2.
+
+
+### 9.2. `clone_only_used_by_borrow`
+
+- [ ] 9.2.1. Create the lint crate and register
+  `CLONE_ONLY_USED_BY_BORROW`. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Lint 1:
+  `clone_only_used_by_borrow`. Requires 9.1.1.
+- [ ] 9.2.2. Implement HIR candidate prefiltering for `clone` and `to_owned`
+  forms. See [ownership shape lints design](ownership-shape-lints-design.md)
+  §Lint 1: `clone_only_used_by_borrow` and §HIR prefilter, MIR confirmation.
+  Requires 9.2.1 and 9.1.2.
+- [ ] 9.2.3. Implement MIR use classification and original-place conflict
+  checks. See [ownership shape lints design](ownership-shape-lints-design.md)
+  §Lint 1: `clone_only_used_by_borrow`. Requires 9.2.2 and 9.1.4.
+- [ ] 9.2.4. Add machine-applicable suggestions for direct-call and simple-let
+  forms. See [ownership shape lints design](ownership-shape-lints-design.md)
+  §Suggestion policy. Requires 9.2.3.
+- [ ] 9.2.5. Add UI pass and fail coverage, including macro and mutable-conflict
+  cases. See [ownership shape lints design](ownership-shape-lints-design.md)
+  §Testing strategy. Requires 9.2.3 and 1.2.1.
+
+
+### 9.4. `local_shared_ownership`
+
+- [ ] 9.4.1. Create the lint crate and register `LOCAL_SHARED_OWNERSHIP` behind
+  an experimental feature. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Lint 3:
+  `local_shared_ownership` and §Rollout plan. Requires 9.1.1.
+- [ ] 9.4.2. Implement wrapper-construction detection and non-escape
+  classification for `Rc`, `Arc`, interior mutability, and shared-mutable
+  combinations. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Scope and
+  §Detection model. Requires 9.4.1, 9.1.2, and 9.1.4.
+- [ ] 9.4.3. Implement callback, async, thread, trait-surface, and external-API
+  suppression. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Servo-style
+  exemptions and §False-positive controls. Requires 9.4.2.
+- [ ] 9.4.4. Add diagnostic classes for interior-mutability-only,
+  shared-handle-only, and shared-mutable-wrapper cases. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Diagnostic
+  classes and §Suggestion policy. Requires 9.4.3.
+- [ ] 9.4.5. Add Servo-style regression fixtures and framework-boundary
+  negatives. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Worked
+  exception model: Servo-style code must stay quiet and §Testing strategy.
+  Requires 9.4.4 and 1.2.1.
+
+
+### 9.5. Localization, documentation, and promotion
+
+- [ ] 9.5.1. Add Fluent entries and diagnostic argument mappings for all three
+  lints. See [ownership shape lints design](ownership-shape-lints-design.md)
+  §Diagnostics and localization. Requires 9.2.5, 9.3.5, 9.4.5, and 2.3.3.
+- [ ] 9.5.2. Add Welsh and Gaelic smoke coverage for the ownership-shape
+  diagnostics. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Diagnostics
+  and localization and §Testing strategy. Requires 9.5.1.
+- [ ] 9.5.3. Update `docs/users-guide.md` and `docs/developers-guide.md` with
+  lint intent, configuration, and rollout guidance for the ownership-shape
+  suite. See [ownership shape lints design](ownership-shape-lints-design.md)
+  §Configuration and §Rollout plan. Requires 9.5.1.
+- [ ] 9.5.4. Define promotion criteria from experimental to standard based on
+  UI stability and false-positive tuning across representative repositories.
+  See [ownership shape lints design](ownership-shape-lints-design.md) §Rollout
+  plan. Requires 9.5.1 and 9.5.2.
+
+### 9.3. `owned_param_causes_clone`
+
+- [ ] 9.3.1. Create the lint crate and register `OWNED_PARAM_CAUSES_CLONE`.
+  See [ownership shape lints design](ownership-shape-lints-design.md) §Lint 2:
+  `owned_param_causes_clone`. Requires 9.1.1.
+- [ ] 9.3.2. Implement local call-site clone-pressure collection that records
+  callee identity, argument index, source shape, and retained-source evidence.
+  See [ownership shape lints design](ownership-shape-lints-design.md) §Pass A:
+  collect clone-pressure evidence at call sites. Requires 9.3.1, 9.1.2, and
+  9.1.4.
+- [ ] 9.3.3. Implement callee parameter summaries and exported, trait, FFI, and
+  async suppression rules. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Pass B:
+  summarise callee parameter usage and §Exemptions. Requires 9.3.2.
+- [ ] 9.3.4. Add exact borrow-type help for the initial mapping set without
+  rewriting unsupported signatures. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Exact borrow
+  mappings and §Diagnostics. Requires 9.3.3 and 9.1.3.
+- [ ] 9.3.5. Add UI coverage for private, exported, trait, async, and
+  non-trigger scenarios. See
+  [ownership shape lints design](ownership-shape-lints-design.md) §Testing
+  strategy. Requires 9.3.4 and 1.2.1.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,6 +25,28 @@
 - [x] 1.2.1. Integrate `dylint_testing` harness boilerplate for UI tests across
   all lint crates.
 
+
+### 1.3. Conditional Dylint `expect` support
+
+- [ ] 1.3.1. Add the `crates/whitaker_support_macros` proc-macro crate and
+  implement `#[whitaker_support::dylint_expect(...)]` with `lib`, `lints`, and
+  optional `reason` arguments. See
+  [ADR 002](adr-002-dylint-expect-attribute-macro.md) §Decision outcome /
+  proposed direction and §Functional requirements.
+- [ ] 1.3.2. Add the `crates/whitaker_support` re-export crate, wire both
+  support crates into the workspace, and document the supported attribute
+  surface with API examples. See
+  [ADR 002](adr-002-dylint-expect-attribute-macro.md) §Decision outcome /
+  proposed direction and §Migration plan.
+- [ ] 1.3.3. Add compatibility coverage that proves the attribute stays warning
+  free in non-Dylint builds, Clippy runs, and Dylint runs with the matching
+  `dylint_lib` value. See [ADR 002](adr-002-dylint-expect-attribute-macro.md)
+  §Technical requirements and §Migration plan. Requires 1.3.1 and 1.3.2.
+- [ ] 1.3.4. Document intended usage, narrow-scope review guidance, and
+  pre-expansion limitations for the conditional `expect` attribute. See
+  [ADR 002](adr-002-dylint-expect-attribute-macro.md) §Decision outcome /
+  proposed direction and §Known risks and limitations. Requires 1.3.3.
+
 ## 2. Core lint delivery
 
 ### 2.1. Lint crate template
@@ -47,6 +69,11 @@
 - [x] 2.2.6. Implement `module_max_lines` with configurable thresholds.
 - [x] 2.2.7. Implement `conditional_max_n_branches` for complex predicates.
 - [x] 2.2.8. Implement `no_unwrap_or_else_panic` with optional `clippy` helpers.
+- [ ] 2.2.9. Replace ad hoc conditional `allow` and `expect` sequences in
+  Whitaker-managed code with `#[whitaker_support::dylint_expect(...)]`, keeping
+  suppressions narrowly scoped to the item they justify. See
+  [ADR 002](adr-002-dylint-expect-attribute-macro.md) §Migration plan. Requires
+  1.3.1, 1.3.2, and 1.3.3.
 
 ### 2.3. Localisation enablement
 
@@ -108,7 +135,12 @@
   behaviour behind an internal library boundary. See
   [Whitaker CLI design](whitaker-cli-design.md) §Public CLI surface and
   §Compatibility and migration. Requires 3.2.1.
-- [ ] 3.5.2. Publish `whitaker` release artefacts with `cargo-binstall`
+- [ ] 3.5.2. Implement `whitaker check` as the default linting path, including
+  lazy dependency repair, `--no-install`, forwarded cargo arguments after `--`,
+  and operational error handling that preserves lint-failure exit semantics.
+  See [Whitaker CLI design](whitaker-cli-design.md) §Public CLI surface and
+  §`whitaker check`. Requires 3.6.3, 3.6.4, and 3.7.1.
+- [ ] 3.5.3. Publish `whitaker` release artefacts with `cargo-binstall`
   metadata that mirror the existing installer packaging flow. See
   [Whitaker CLI design](whitaker-cli-design.md) §Public CLI surface and
   §Compatibility and migration. Requires 3.5.1 and 4.3.1.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -602,8 +602,8 @@
   See [ownership shape lints design](ownership-shape-lints-design.md) §13.2.1
   Pass A: collect clone-pressure evidence at call sites. Requires 9.3.1, 9.1.2,
   and 9.1.4.
-- [ ] 9.3.3. Implement callee parameter summaries and exported, trait, FFI, and
-  async suppression rules. See
+- [ ] 9.3.3. Implement callee parameter summaries and exported, trait, foreign
+  function interface (FFI), and async suppression rules. See
   [ownership shape lints design](ownership-shape-lints-design.md) §13.2.2 Pass
   B: summarize callee parameter usage and §13.3 Exemptions. Requires 9.3.2.
 - [ ] 9.3.4. Add exact borrow-type help for the initial mapping set without

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -526,7 +526,7 @@
 - [ ] 9.1.1. Add `common::ownership_shape` model types, evaluation helpers, and
   diagnostic argument builders. See
   [ownership shape lints design](ownership-shape-lints-design.md) §Shared
-  implementation approach and §Diagnostics and localization. Requires 1.1.1.
+  implementation approach and §Diagnostics and localisation. Requires 1.1.1.
 - [ ] 9.1.2. Add resolved-path classifiers for clone-like operations and
   wrapper constructors, following the `def_path_str` plus parsed-segment
   pattern used by `no_std_fs_operations`. See
@@ -540,7 +540,6 @@
   [ownership shape lints design](ownership-shape-lints-design.md) §HIR
   prefilter, MIR confirmation and §Worked exception model: Servo-style code
   must stay quiet. Requires 9.1.1 and 9.1.2.
-
 
 ### 9.2. `clone_only_used_by_borrow`
 
@@ -589,15 +588,15 @@
   Requires 9.4.4 and 1.2.1.
 
 
-### 9.5. Localization, documentation, and promotion
+### 9.5. Localisation, documentation, and promotion
 
 - [ ] 9.5.1. Add Fluent entries and diagnostic argument mappings for all three
   lints. See [ownership shape lints design](ownership-shape-lints-design.md)
-  §Diagnostics and localization. Requires 9.2.5, 9.3.5, 9.4.5, and 2.3.3.
+  §Diagnostics and localisation. Requires 9.2.5, 9.3.5, 9.4.5, and 2.3.3.
 - [ ] 9.5.2. Add Welsh and Gaelic smoke coverage for the ownership-shape
   diagnostics. See
   [ownership shape lints design](ownership-shape-lints-design.md) §Diagnostics
-  and localization and §Testing strategy. Requires 9.5.1.
+  and localisation and §Testing strategy. Requires 9.5.1.
 - [ ] 9.5.3. Update `docs/users-guide.md` and `docs/developers-guide.md` with
   lint intent, configuration, and rollout guidance for the ownership-shape
   suite. See [ownership shape lints design](ownership-shape-lints-design.md)
@@ -606,7 +605,6 @@
   UI stability and false-positive tuning across representative repositories.
   See [ownership shape lints design](ownership-shape-lints-design.md) §Rollout
   plan. Requires 9.5.1 and 9.5.2.
-
 ### 9.3. `owned_param_causes_clone`
 
 - [ ] 9.3.1. Create the lint crate and register `OWNED_PARAM_CAUSES_CLONE`.

--- a/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
+++ b/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
@@ -11,8 +11,7 @@ only when that exact `expect` suppresses the lint; if some other lint-level
 attribute changes handling, the expectation goes stale and
 `unfulfilled_lint_expectations` should fire instead. In other words, the core
 pathology is real, upstream behaviour explains it, and a single-target lint
-cannot answer the whole question by itself.
-[^1]
+cannot answer the whole question by itself. [^1]
 
 I recommend a split design. `test_support_dead_code` should exist as a normal
 Whitaker lint crate in the Dylint suite, but only as a fast detector and
@@ -21,8 +20,7 @@ workspace analysis phase that runs under `whitaker check` and produces per-item
 inventories, target classifications, and usage sites. That split matches
 Dylint’s execution model, where lints run as dynamic libraries implementing
 `LateLintPass`, and it also fits Whitaker’s documented direction toward a
-first-class `whitaker` CLI that owns richer workspace-aware analysis.
-[^2][^3]
+first-class `whitaker` CLI that owns richer workspace-aware analysis. [^2][^3]
 
 Whitaker’s current workspace layout already accommodates this cleanly. The root
 workspace contains `common`, `crates/*`, `installer`, and `suite`, and the
@@ -60,8 +58,7 @@ consumers in the E2E metrics test and the test rig, while `TurnMetrics`,
 That makes `metrics.rs` an excellent worked example for a lint whose output
 should say “these items look globally dead” and “these items are single-target
 live”, rather than merely “5 dead, 4 alive”. The compiler run must remain the
-final oracle, but repository evidence already points in that direction.
-[^4]
+final oracle, but repository evidence already points in that direction. [^4]
 
 Axinite also contains a second, subtler smell that the design should account
 for: manual keepalive shims. `tests/support/mod.rs` defines `touch!`,
@@ -110,8 +107,7 @@ edges or `#[path]` edges. In plain Dylint mode it should emit a lightweight
 warning that says, in effect, “this suppression needs workspace analysis”. In
 full Whitaker mode it should emit an inventory-based report that classifies
 every suppressed item as globally dead, organic single-target live, organic
-multi-target live, or live only through synthetic keepalive shims.
-[^1][^2]
+multi-target live, or live only through synthetic keepalive shims. [^1][^2]
 
 `masked_dead_code_expectations` should stay narrower than a general “masked
 expectations” lint, at least in v1. It should fire only when
@@ -121,8 +117,7 @@ family of “I tried to be precise, then turned the alarm off” patterns that t
 exploration identified. In plain Dylint mode it should flag the mask
 immediately. In full Whitaker mode it should attach a stale-expectation
 inventory showing which `expect(dead_code)` annotations are stale in which
-targets and where the corresponding organic uses sit.
-[^1][^6]
+targets and where the corresponding organic uses sit. [^1][^6]
 
 Both rules should share one analysis engine and produce one merged report when
 they hit the same file. In mdtablefix, for example,
@@ -130,8 +125,7 @@ they hit the same file. In mdtablefix, for example,
 expectations”; it should also reuse the `test_support_dead_code` machinery to
 say which helpers are globally dead, which are genuinely shared, and which
 expectations are stale because the helper is live in at least one importer
-target. That keeps the user-facing story unified and actionable.
-[^6]
+target. That keeps the user-facing story unified and actionable. [^6]
 
 ## Multi-pass execution path
 
@@ -155,8 +149,7 @@ remove only `dead_code` suppressions from `allow` and `expect` attributes,
 preserve unrelated lints, and inject a probe item such as
 `fn whitaker_dead_code_probe_7f3c2e() {}` immediately after inner attributes.
 The probe must not begin with an underscore, because the compiler explicitly
-documents underscore-prefixed names as a way to silence `dead_code`.
-[^1]
+documents underscore-prefixed names as a way to silence `dead_code`. [^1]
 
 The third phase should run an instrumented per-target compilation. For each
 importer target, Whitaker should invoke
@@ -166,8 +159,7 @@ surrounding Whitaker invocation already resolved. The JSON stream gives
 Whitaker structured compiler diagnostics, and a small collector lint loaded
 during the same run can record def-use edges for the candidate support files.
 `cargo check` already supports selecting specific integration-test targets, and
-Cargo’s JSON message stream is designed for external tools.
-[^1]
+Cargo’s JSON message stream is designed for external tools. [^1]
 
 That instrumented run should collect two distinct classes of evidence. First,
 rustc’s own `dead_code` diagnostics remain the ground truth for whether an item
@@ -189,8 +181,7 @@ build in which it restores the original `expect(dead_code)` annotations but
 removes the mask. This pass should gather `unfulfilled_lint_expectations`
 diagnostics so Whitaker can say exactly which expectations are stale in which
 targets. That second pass is what turns “masked expectations exist” into “these
-eight expectations are stale in these four importer targets”.
-[^1]
+eight expectations are stale in these four importer targets”. [^1]
 
 The classification logic should stay simple:
 
@@ -272,8 +263,7 @@ That specific shape matches the current axinite evidence:
 already differentiates likely dead items such as `TurnMetrics`, `MetricDelta`,
 and `total_tool_time_ms` from items that the E2E metrics tests or test rig
 actively consume. The compiler run should still determine the final
-classification, but the report should look like this, not like a histogram.
-[^4]
+classification, but the report should look like this, not like a histogram. [^4]
 
 `masked_dead_code_expectations` should use the same idea. It should not stop at
 “scope contains `allow(unfulfilled_lint_expectations)`”. It should show exactly
@@ -322,8 +312,7 @@ warning[masked_dead_code_expectations]: dead_code expectations are masked by all
 That shape reflects the repository’s current state far better than a simple
 “masked expectation exists” warning. The Reference semantics justify the
 stale-expectation language, and the mdtablefix search results already show
-those helpers as live across real importer targets.
-[^1][^6][^7]
+those helpers as live across real importer targets. [^1][^6][^7]
 
 Whitaker should also expose the same inventory as machine-readable JSON. The
 CLI design already treats JSON output as a first-class interface for
@@ -343,8 +332,7 @@ many test targets”, but “under the current workspace configuration, this fil
 imports into one target, so the blanket suppression now masks dead or overly
 broad support code”. The same report should explicitly separate genuine test
 uses in `tests/e2e_traces/metrics.rs` and `tests/support/test_rig/rig.rs` from
-synthetic keepalive shims in `tests/support/mod.rs`.
-[^4][^5]
+synthetic keepalive shims in `tests/support/mod.rs`. [^4][^5]
 
 In mdtablefix, the worked example should show the opposite conclusion.
 `tests/common/mod.rs` really is shared support, because `tests/prelude/mod.rs`
@@ -354,8 +342,7 @@ helpers shared, delete anything globally dead, and stop pretending that every
 helper is expected dead everywhere”. The collector evidence already shows that
 several helpers are genuinely shared. That makes mdtablefix the canonical
 justification for a rule that inventories per-item target reach, rather than
-just yelling about the presence of `#[expect(dead_code)]`.
-[^6][^7]
+just yelling about the presence of `#[expect(dead_code)]`. [^6][^7]
 
 ## Constraints, failure modes, and rollout
 
@@ -364,16 +351,14 @@ support only, and only for the active package, feature set, and target triple.
 Cargo documentation explicitly frames target selection and feature selection as
 part of how external tools should integrate with builds, so Whitaker should
 report what is dead under the build the user actually asked for, not under an
-imagined cross-product of every feature combination.
-[^1]
+imagined cross-product of every feature combination. [^1]
 
 Whitaker should not auto-move code between files in v1. Deletion is tempting
 for items proved dead in all importer targets, but even there rustc’s own
 `dead_code` documentation warns about cases where apparently unused fields or
 items still matter through drop side effects or other type-level behaviour. The
 safe v1 contract is “report precisely, suggest concretely, and maybe offer a
-later opt-in fix for removing the suppression attribute itself”.
-[^1]
+later opt-in fix for removing the suppression attribute itself”. [^1]
 
 The design should also explicitly treat `#[expect(dead_code)]` as a dubious
 migration target rather than the canonical remedy. The Reference semantics
@@ -382,8 +367,7 @@ only fulfilled when that exact `expect` suppresses the lint. There is also at
 least one current rustc issue where `#[expect(dead_code)]` appears in an
 incremental-compilation ICE involving `shallow_lint_levels_on`. Whitaker
 therefore should not frame “replace `allow(dead_code)` with `expect(dead_code)`
-everywhere” as the recommended end state for shared test support.
-[^1]
+everywhere” as the recommended end state for shared test support. [^1]
 
 The rollout path should be incremental. First, add the two lint crates and the
 shared analyser crate or module, and wire the lightweight detector into the
@@ -393,8 +377,7 @@ and a small corpus of UI and behaviour tests drawn from the axinite and
 mdtablefix patterns. That path keeps Dylint compatibility, fits Whitaker’s
 existing architecture, and delivers the part the exploration asked for: a tool
 that helps people unbork the codebase by telling them which support items are
-actually dead, which are local, and which are truly shared.
-[^3]
+actually dead, which are local, and which are truly shared. [^3]
 
 ## References
 

--- a/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
+++ b/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
@@ -1,0 +1,455 @@
+# Technical design for `test_support_dead_code` and `masked_dead_code_expectations`
+
+## Design summary
+
+Whitaker should treat this problem as a workspace-cleanup and refactoring
+problem, not as a style scold. Cargo compiles each integration-test target
+under `tests/` as its own executable crate, so `dead_code` remains target-local
+even when projects follow the Book’s shared-support pattern with
+`tests/common/mod.rs`. The Reference also makes `#[expect(...)]` meaningful
+only when that exact `expect` suppresses the lint; if some other lint-level
+attribute changes handling, the expectation goes stale and
+`unfulfilled_lint_expectations` should fire instead. In other words, the core
+pathology is real, upstream behaviour explains it, and a single-target lint
+cannot answer the whole question by itself.
+[^1]
+
+I recommend a split design. `test_support_dead_code` should exist as a normal
+Whitaker lint crate in the Dylint suite, but only as a fast detector and
+metadata emitter. The fully actionable result should come from a Whitaker
+workspace analysis phase that runs under `whitaker check` and produces per-item
+inventories, target classifications, and usage sites. That split matches
+Dylint’s execution model, where lints run as dynamic libraries implementing
+`LateLintPass`, and it also fits Whitaker’s documented direction toward a
+first-class `whitaker` CLI that owns richer workspace-aware analysis.
+[^2][^3]
+
+Whitaker’s current workspace layout already accommodates this cleanly. The root
+workspace contains `common`, `crates/*`, `installer`, and `suite`, and the
+aggregated suite registry already enumerates individual lint crates. The
+existing design document also assumes separate lint crates plus shared
+infrastructure. Adding two new lint crates and one shared workspace-analysis
+engine therefore fits the repository’s architecture rather than fighting it.
+[^3]
+
+## Repository evidence and the actual pathology
+
+The axinite example matters because it shows how the original “shared bag of
+helpers” story can stop being true over time. The repository now has a
+consolidated test harness at `tests/e2e_traces.rs`, which declares
+`mod support;` once at the harness root and then pulls submodules in through
+`#[path = "..."]` attributes. Axinite’s own consolidation plan says the suite
+moved from 40 test binaries down to 9 and that only harnesses that actually
+need shared support declare `mod support;`. In the current layout, connector
+search for `support::metrics` only surfaced `tests/e2e_traces/metrics.rs` and
+`tests/support/test_rig/rig.rs`, which means `tests/support/metrics.rs` now
+looks like support for the `e2e_traces` harness rather than support for the
+whole integration-test universe. That makes the file-level
+`#![allow(dead_code)]` in `tests/support/metrics.rs` especially suspect: it no
+longer has a strong cross-target justification. [^4]
+
+Axinite also shows why the report must inventory real items rather than emit
+only counts. `tests/support/metrics.rs` defines `TraceMetrics`,
+`ToolInvocation`, `TurnMetrics`, `ScenarioResult`, `RunResult`, `MetricDelta`,
+and helper methods such as `total_tool_calls`, `failed_tool_calls`,
+`total_tool_time_ms`, `from_scenarios`, and `compare_runs`. Search results and
+direct file reads show that `TraceMetrics`, `ToolInvocation`, `RunResult`,
+`ScenarioResult`, `compare_runs`, and `from_scenarios` have downstream
+consumers in the E2E metrics test and the test rig, while `TurnMetrics`,
+`MetricDelta`, and `total_tool_time_ms` only surfaced in the defining file.
+That makes `metrics.rs` an excellent worked example for a lint whose output
+should say “these items look globally dead” and “these items are single-target
+live”, rather than merely “5 dead, 4 alive”. The compiler run must remain the
+final oracle, but repository evidence already points in that direction.
+[^4]
+
+Axinite also contains a second, subtler smell that the design should account
+for: manual keepalive shims. `tests/support/mod.rs` defines `touch!`,
+`touch_const!`, anonymous `const _:` type assertions, and whole families of
+`touch_*` functions whose only job is to reference support symbols so the
+compiler treats them as used. Those references are not genuine business or test
+uses. A cleanup tool that treats them as ordinary evidence of liveness will
+misclassify papered-over dead code as organically live. The design should
+therefore classify “synthetic keepalive uses” separately from ordinary uses.
+[^5]
+
+The mdtablefix example is the inverse pathology. `tests/common/mod.rs` begins
+with `#![allow(unfulfilled_lint_expectations)]` and then annotates individual
+helpers with `#[expect(dead_code, reason = "...")]`. `tests/prelude/mod.rs`
+imports `../common/mod.rs` via `#[path = "../common/mod.rs"] mod common;` and
+reexports `common::*`. Multiple test targets then pull `mod prelude;` in:
+search results surfaced `code_emphasis.rs`, `footnotes.rs`, `fences.rs`,
+`lists.rs`, `markdownlint.rs`, `parallel.rs`, `wrap_renumber.rs`, `cli.rs`,
+`breaks.rs`, and grouped harness roots such as `wrap/mod.rs` and
+`table/mod.rs`. That means `#[path]` is not the root cause, but it absolutely
+matters for module-graph traversal because it is the edge that leads Whitaker
+from `prelude` into `common`. [^6]
+
+Repository evidence already shows that several mdtablefix helpers are plainly
+live. `run_cli_with_args` appears in `parallel.rs` and `code_emphasis.rs`;
+`run_cli_with_stdin` appears in `wrap/cli.rs` and `code_emphasis.rs`;
+`assert_wrapped_list_item` appears in `wrap/lists.rs` and `wrap/footnotes.rs`;
+`assert_wrapped_blockquote` appears in `wrap/blockquotes.rs`; and
+`broken_table` appears in `parallel.rs`, `cli.rs`, and `table/reflow.rs`. Under
+the Reference semantics, any `#[expect(dead_code)]` on those helpers is stale
+in targets that actually use them, and the file-level
+`#![allow(unfulfilled_lint_expectations)]` removes the only warning that would
+tell the developer so. This is exactly what `masked_dead_code_expectations`
+should expose. [^6][^7][^1]
+
+## Proposed rule contracts
+
+`test_support_dead_code` should fire on non-top-level modules reachable from
+integration-test targets when Whitaker finds any of the following in scope:
+`#![allow(dead_code)]`, item-level `#[allow(dead_code)]`,
+`#[expect(dead_code)]`, or other dead-code suppression that prevents ordinary
+liveness reporting. The rule should restrict itself to test-support code: files
+under `tests/support/`, `tests/common/`, `tests/prelude/`, or any module
+reachable from a `tests/*.rs` integration-test target through ordinary `mod`
+edges or `#[path]` edges. In plain Dylint mode it should emit a lightweight
+warning that says, in effect, “this suppression needs workspace analysis”. In
+full Whitaker mode it should emit an inventory-based report that classifies
+every suppressed item as globally dead, organic single-target live, organic
+multi-target live, or live only through synthetic keepalive shims.
+[^1][^2]
+
+`masked_dead_code_expectations` should stay narrower than a general “masked
+expectations” lint, at least in v1. It should fire only when
+`#[expect(dead_code)]` sits inside a lexical scope dominated by
+`allow(unfulfilled_lint_expectations)`. That focuses the rule on the exact
+family of “I tried to be precise, then turned the alarm off” patterns that the
+exploration identified. In plain Dylint mode it should flag the mask
+immediately. In full Whitaker mode it should attach a stale-expectation
+inventory showing which `expect(dead_code)` annotations are stale in which
+targets and where the corresponding organic uses sit.
+[^1][^6]
+
+Both rules should share one analysis engine and produce one merged report when
+they hit the same file. In mdtablefix, for example,
+`masked_dead_code_expectations` should not merely say “you masked stale
+expectations”; it should also reuse the `test_support_dead_code` machinery to
+say which helpers are globally dead, which are genuinely shared, and which
+expectations are stale because the helper is live in at least one importer
+target. That keeps the user-facing story unified and actionable.
+[^6]
+
+## Multi-pass execution path
+
+The workspace analysis should run in four deliberate phases.
+
+The first phase should discover candidate files and importer targets. Whitaker
+should call `cargo metadata --format-version 1 --no-deps` to enumerate
+workspace members and targets, then filter to target kinds that Cargo reports
+as integration tests. Starting from each `tests/*.rs` harness, Whitaker should
+walk the local module graph, following both ordinary `mod foo;` edges and
+explicit `#[path = "..."] mod foo;` edges. This is the point where `#[path]`
+matters: not as the trigger, but as the mechanism required to discover support
+modules such as `mdtablefix/tests/common/mod.rs` behind `tests/prelude/mod.rs`.
+[^1][^6]
+
+The second phase should build a temporary overlay workspace and apply minimal
+source edits. Whitaker should never rewrite the user’s working tree in place.
+Instead it should copy the relevant package trees to a temporary directory and
+compute text edits for each candidate file. The dead-code replay edit should
+remove only `dead_code` suppressions from `allow` and `expect` attributes,
+preserve unrelated lints, and inject a probe item such as
+`fn whitaker_dead_code_probe_7f3c2e() {}` immediately after inner attributes.
+The probe must not begin with an underscore, because the compiler explicitly
+documents underscore-prefixed names as a way to silence `dead_code`.
+[^1]
+
+The third phase should run an instrumented per-target compilation. For each
+importer target, Whitaker should invoke
+`cargo check -p <package> --test <target> --message-format=json`, threading
+through the same feature flags, target triple, and manifest path that the
+surrounding Whitaker invocation already resolved. The JSON stream gives
+Whitaker structured compiler diagnostics, and a small collector lint loaded
+during the same run can record def-use edges for the candidate support files.
+`cargo check` already supports selecting specific integration-test targets, and
+Cargo’s JSON message stream is designed for external tools.
+[^1]
+
+That instrumented run should collect two distinct classes of evidence. First,
+rustc’s own `dead_code` diagnostics remain the ground truth for whether an item
+is dead in a given target. Second, the collector lint should record usage edges
+so Whitaker can produce the inventory the user actually wants. The collector
+should map each support-file item to a canonical identifier such as
+`fn compare_runs`, `struct TurnMetrics`, or
+`impl TraceMetrics::total_tool_time_ms`, then record every resolved path or
+method-call use site that points back to that item. When the collector cannot
+localize an organic use but rustc still treats the item as live, Whitaker
+should report that as “alive; usage not localized”, rather than pretending
+certainty. That keeps rustc as the liveness oracle while still giving a useful
+inventory. [^2][^1]
+
+The fourth phase should replay masked expectations only where needed. For files
+that contain `#[expect(dead_code)]` under
+`allow(unfulfilled_lint_expectations)`, Whitaker should run a second overlay
+build in which it restores the original `expect(dead_code)` annotations but
+removes the mask. This pass should gather `unfulfilled_lint_expectations`
+diagnostics so Whitaker can say exactly which expectations are stale in which
+targets. That second pass is what turns “masked expectations exist” into “these
+eight expectations are stale in these four importer targets”.
+[^1]
+
+The classification logic should stay simple:
+
+```text
+importer_targets(file)        = targets that emitted probe dead_code
+dead_targets(item)            = importer_targets(file) with a rustc dead_code warning on item
+alive_targets(item)           = importer_targets(file) - dead_targets(item)
+
+organic_use_targets(item)     = targets with at least one non-synthetic recorded use
+synthetic_use_targets(item)   = targets whose only uses are keepalive shims
+stale_expectation_targets(item) = targets that emitted unfulfilled_lint_expectations
+```
+
+From that, Whitaker can derive four useful states. If `alive_targets(item)` is
+empty, the item is globally dead. If `alive_targets(item)` is non-empty but
+`organic_use_targets(item)` is empty, the item is only being kept alive by
+synthetic assertions or keepalive shims. If `organic_use_targets(item)`
+contains one target, the item is not really shared support. If it contains two
+or more targets, the item is genuinely shared. The expectation replay then
+overlays “stale expectation” information on top of those states. This is the
+execution path that makes the lint genuinely multi-pass rather than just
+multi-target. The usefulness of the synthetic/organic split follows directly
+from axinite’s existing `touch!`, `touch_const!`, and anonymous `const _:`
+keepalive code. [^5]
+
+## Diagnostic model and report format
+
+The default human-readable diagnostic should inventory items, not counts. A
+file-level warning should lead with the suppression site, then group items
+under headings such as “globally dead”, “single-target live”, “shared across
+targets”, and “alive only via keepalive shims”. For each item Whitaker should
+print the importer targets, the use kind, and concrete use sites when the
+collector found them. That gives the developer the next edit to make, not just
+a bad feeling.
+
+A representative format looks like this:
+
+```text
+warning[test_support_dead_code]: dead_code suppression hides actionable cleanup
+  --> tests/support/metrics.rs:1:1
+   |
+ 1 | #![allow(dead_code)]
+   | ^^^^^^^^^^^^^^^^^^^^
+   |
+   = importer target:
+     - axinite::test/e2e_traces
+
+   = globally dead in all importers:
+     - struct TurnMetrics
+     - struct MetricDelta
+     - impl TraceMetrics::total_tool_time_ms
+
+   = live in exactly one importer:
+     - struct TraceMetrics
+       uses:
+         - tests/e2e_traces/metrics.rs
+         - tests/support/test_rig/rig.rs
+     - struct ToolInvocation
+       uses:
+         - tests/support/test_rig/rig.rs
+     - struct RunResult
+       uses:
+         - tests/e2e_traces/metrics.rs
+     - struct ScenarioResult
+       uses:
+         - tests/e2e_traces/metrics.rs
+     - fn compare_runs
+       uses:
+         - tests/e2e_traces/metrics.rs
+
+   = help: delete globally dead items, move single-target helpers closer to
+            the owning test target, and keep only truly shared helpers in
+            common support
+```
+
+That specific shape matches the current axinite evidence:
+`tests/support/metrics.rs` begins with `#![allow(dead_code)]`; only the
+`e2e_traces` path currently surfaced as an importer; and repository evidence
+already differentiates likely dead items such as `TurnMetrics`, `MetricDelta`,
+and `total_tool_time_ms` from items that the E2E metrics tests or test rig
+actively consume. The compiler run should still determine the final
+classification, but the report should look like this, not like a histogram.
+[^4]
+
+`masked_dead_code_expectations` should use the same idea. It should not stop at
+“scope contains `allow(unfulfilled_lint_expectations)`”. It should show exactly
+which expectations are stale and why:
+
+```text
+warning[masked_dead_code_expectations]: dead_code expectations are masked by allow(unfulfilled_lint_expectations)
+  --> tests/common/mod.rs:2:1
+   |
+ 2 | #![allow(unfulfilled_lint_expectations)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = masked stale expectations:
+     - fn run_cli_with_args
+       stale in:
+         - mdtablefix::test/code_emphasis
+         - mdtablefix::test/parallel
+       uses:
+         - tests/code_emphasis.rs
+         - tests/parallel.rs
+
+     - fn run_cli_with_stdin
+       stale in:
+         - mdtablefix::test/code_emphasis
+         - mdtablefix::test/wrap
+       uses:
+         - tests/code_emphasis.rs
+         - tests/wrap/cli.rs
+
+     - fn assert_wrapped_list_item
+       stale in:
+         - mdtablefix::test/wrap
+       uses:
+         - tests/wrap/lists.rs
+         - tests/wrap/footnotes.rs
+
+     - fn assert_wrapped_blockquote
+       stale in:
+         - mdtablefix::test/wrap
+       uses:
+         - tests/wrap/blockquotes.rs
+
+   = help: remove the mask, then keep expect(dead_code) only on items that are actually dead in a given importer target
+```
+
+That shape reflects the repository’s current state far better than a simple
+“masked expectation exists” warning. The Reference semantics justify the
+stale-expectation language, and the mdtablefix search results already show
+those helpers as live across real importer targets.
+[^1][^6][^7]
+
+Whitaker should also expose the same inventory as machine-readable JSON. The
+CLI design already treats JSON output as a first-class interface for
+operational summaries, and this analysis belongs in the same family. A JSON
+form makes later autofix or reporting work possible without locking Whitaker
+into automatic deletion or code movement in v1. [^3]
+
+## Worked examples
+
+In axinite, the most important design conclusion is that the tool should not
+hard-code the “shared across many test crates” story. The current repository
+layout consolidated the old explosion of integration-test binaries into grouped
+harnesses, and the current `support::metrics` evidence points to one effective
+importer harness, `e2e_traces`, not to the whole suite. That means Whitaker
+should phrase the output conservatively: not “this shared helper is used by
+many test targets”, but “under the current workspace configuration, this file
+imports into one target, so the blanket suppression now masks dead or overly
+broad support code”. The same report should explicitly separate genuine test
+uses in `tests/e2e_traces/metrics.rs` and `tests/support/test_rig/rig.rs` from
+synthetic keepalive shims in `tests/support/mod.rs`.
+[^4][^5]
+
+In mdtablefix, the worked example should show the opposite conclusion.
+`tests/common/mod.rs` really is shared support, because `tests/prelude/mod.rs`
+reexports it and many top-level test targets import `prelude`. The right output
+therefore is not “move everything local”; it is “keep the genuinely shared
+helpers shared, delete anything globally dead, and stop pretending that every
+helper is expected dead everywhere”. The collector evidence already shows that
+several helpers are genuinely shared. That makes mdtablefix the canonical
+justification for a rule that inventories per-item target reach, rather than
+just yelling about the presence of `#[expect(dead_code)]`.
+[^6][^7]
+
+## Constraints, failure modes, and rollout
+
+The scope should stay tight in v1. Whitaker should analyse integration-test
+support only, and only for the active package, feature set, and target triple.
+Cargo documentation explicitly frames target selection and feature selection as
+part of how external tools should integrate with builds, so Whitaker should
+report what is dead under the build the user actually asked for, not under an
+imagined cross-product of every feature combination.
+[^1]
+
+Whitaker should not auto-move code between files in v1. Deletion is tempting
+for items proved dead in all importer targets, but even there rustc’s own
+`dead_code` documentation warns about cases where apparently unused fields or
+items still matter through drop side effects or other type-level behaviour. The
+safe v1 contract is “report precisely, suggest concretely, and maybe offer a
+later opt-in fix for removing the suppression attribute itself”.
+[^1]
+
+The design should also explicitly treat `#[expect(dead_code)]` as a dubious
+migration target rather than the canonical remedy. The Reference semantics
+already make it awkward in this domain, since expectations are per-target and
+only fulfilled when that exact `expect` suppresses the lint. There is also at
+least one current rustc issue where `#[expect(dead_code)]` appears in an
+incremental-compilation ICE involving `shallow_lint_levels_on`. Whitaker
+therefore should not frame “replace `allow(dead_code)` with `expect(dead_code)`
+everywhere” as the recommended end state for shared test support.
+[^1]
+
+The rollout path should be incremental. First, add the two lint crates and the
+shared analyser crate or module, and wire the lightweight detector into the
+suite. Second, integrate full workspace analysis into `whitaker check`, where
+Whitaker already plans richer workspace-aware behaviour. Third, add JSON output
+and a small corpus of UI and behaviour tests drawn from the axinite and
+mdtablefix patterns. That path keeps Dylint compatibility, fits Whitaker’s
+existing architecture, and delivers the part the exploration asked for: a tool
+that helps people unbork the codebase by telling them which support items are
+actually dead, which are local, and which are truly shared.
+[^3]
+
+## References
+
+[^1]: Cargo and Rust documentation covering integration-test target structure,
+      `dead_code`, `#[expect(...)]`, `unfulfilled_lint_expectations`,
+      underscore-name suppression, and external-tool integration.
+      <https://doc.rust-lang.org/cargo/reference/cargo-targets.html?highlight=test&utm_source=chatgpt.com>
+      <https://doc.rust-lang.org/cargo/reference/external-tools.html?utm_source=chatgpt.com>
+      <https://doc.rust-lang.org/reference/attributes/diagnostics.html?utm_source=chatgpt.com>
+      <https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.DEAD_CODE.html?utm_source=chatgpt.com>
+[^2]: Dylint documentation describing dynamic-library lint execution and the
+      `LateLintPass` model.
+      <https://github.com/trailofbits/dylint?utm_source=chatgpt.com>
+[^3]: Whitaker workspace references used for the proposed split between
+      lint-time detection and richer `whitaker check` analysis: the CLI design,
+      workspace manifest, suite registry, and Dylint suite design.
+      <https://github.com/leynos/whitaker/blob/HEAD/docs/whitaker-cli-design.md>
+      <https://github.com/leynos/whitaker/blob/HEAD/Cargo.toml>
+      <https://github.com/leynos/whitaker/blob/HEAD/suite/src/lints.rs>
+      <https://github.com/leynos/whitaker/blob/HEAD/docs/whitaker-dylint-suite-design.md>
+[^4]: Axinite repository evidence for the consolidated `e2e_traces` harness and
+      the support metrics module plus its organic use sites.
+      <https://github.com/leynos/axinite/blob/HEAD/tests/e2e_traces.rs>
+      <https://github.com/leynos/axinite/blob/HEAD/docs/execplans/consolidate-test-binaries.md>
+      <https://github.com/leynos/axinite/blob/HEAD/tests/support/metrics.rs>
+      <https://github.com/leynos/axinite/blob/a824bb0bcab672e353e607ba6c785f5a83f6f2ce/tests/support/metrics.rs>
+      <https://github.com/leynos/axinite/blob/a824bb0bcab672e353e607ba6c785f5a83f6f2ce/tests/e2e_traces/metrics.rs>
+      <https://github.com/leynos/axinite/blob/HEAD/tests/e2e_traces/metrics.rs>
+      <https://github.com/leynos/axinite/blob/a824bb0bcab672e353e607ba6c785f5a83f6f2ce/tests/support/test_rig/rig.rs>
+      <https://github.com/leynos/axinite/blob/HEAD/tests/support/test_rig/rig.rs>
+[^5]: Axinite keepalive shim examples in `tests/support/mod.rs`.
+      <https://github.com/leynos/axinite/blob/HEAD/tests/support/mod.rs>
+[^6]: mdtablefix module-graph evidence showing how `tests/prelude/mod.rs` pulls
+      `tests/common/mod.rs` into many importer targets via ordinary `mod` and
+      `#[path]` edges.
+      <https://github.com/leynos/mdtablefix/blob/HEAD/tests/common/mod.rs>
+      <https://github.com/leynos/mdtablefix/blob/HEAD/tests/prelude/mod.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/wrap/mod.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/footnotes.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/fences.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/wrap_renumber.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/table/mod.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/markdownlint.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/lists.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/parallel.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/cli.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/breaks.rs>
+[^7]: mdtablefix helper use sites demonstrating genuinely shared helpers and
+      stale `dead_code` expectations.
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/code_emphasis.rs>
+      <https://github.com/leynos/mdtablefix/blob/HEAD/tests/code_emphasis.rs>
+      <https://github.com/leynos/mdtablefix/blob/HEAD/tests/parallel.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/table/reflow.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/wrap/lists.rs>
+      <https://github.com/leynos/mdtablefix/blob/HEAD/tests/wrap/lists.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/wrap/footnotes.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/wrap/blockquotes.rs>
+      <https://github.com/leynos/mdtablefix/blob/8c50fc81b2ae0220672b7afc62792911e9930c43/tests/wrap/cli.rs>

--- a/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
+++ b/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
@@ -13,14 +13,14 @@ attribute changes handling, the expectation goes stale and
 pathology is real, upstream behaviour explains it, and a single-target lint
 cannot answer the whole question by itself. [^1]
 
-I recommend a split design. `test_support_dead_code` should exist as a normal
-Whitaker lint crate in the Dylint suite, but only as a fast detector and
-metadata emitter. The fully actionable result should come from a Whitaker
-workspace analysis phase that runs under `whitaker check` and produces per-item
-inventories, target classifications, and usage sites. That split matches
-Dylint’s execution model, where lints run as dynamic libraries implementing
-`LateLintPass`, and it also fits Whitaker’s documented direction toward a
-first-class `whitaker` CLI that owns richer workspace-aware analysis. [^2][^3]
+A split design is appropriate. `test_support_dead_code` should exist as a
+normal Whitaker lint crate in the Dylint suite, but only as a fast detector and
+metadata emitter, while a Whitaker workspace analysis phase invoked via
+`whitaker check` should produce per-item inventories, target classifications,
+and usage sites. That split matches Dylint’s execution model, where lints run
+as dynamic libraries implementing `LateLintPass`, and it also fits Whitaker’s
+documented direction toward a first-class `whitaker` CLI that owns richer
+workspace-aware analysis. [^2][^3]
 
 Whitaker’s current workspace layout already accommodates this cleanly. The root
 workspace contains `common`, `crates/*`, `installer`, and `suite`, and the

--- a/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
+++ b/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
@@ -1,6 +1,12 @@
 # Technical design for `test_support_dead_code` and `masked_dead_code_expectations`
 
-## Design summary
+Status: Proposed Scope: Crate-local detector lints plus workspace analysis for
+dead or over-suppressed test-support code. Primary audience: Whitaker
+contributors, lint authors, reviewers, and QA engineers. Precedence documents:
+`docs/whitaker-dylint-suite-design.md`, `docs/whitaker-cli-design.md`, and
+later ADRs or roadmap decisions that supersede this design.
+
+## 1. Design summary
 
 Whitaker should treat this problem as a workspace-cleanup and refactoring
 problem, not as a style scold. Cargo compiles each integration-test target
@@ -30,7 +36,7 @@ infrastructure. Adding two new lint crates and one shared workspace-analysis
 engine therefore fits the repository’s architecture rather than fighting it.
 [^3]
 
-## Repository evidence and the actual pathology
+## 2. Repository evidence and the actual pathology
 
 The axinite example matters because it shows how the original “shared bag of
 helpers” story can stop being true over time. The repository now has a
@@ -94,7 +100,7 @@ in targets that actually use them, and the file-level
 tell the developer so. This is exactly what `masked_dead_code_expectations`
 should expose. [^6][^7][^1]
 
-## Proposed rule contracts
+## 3. Proposed rule contracts
 
 `test_support_dead_code` should fire on non-top-level modules reachable from
 integration-test targets when Whitaker finds any of the following in scope:
@@ -127,7 +133,7 @@ say which helpers are globally dead, which are genuinely shared, and which
 expectations are stale because the helper is live in at least one importer
 target. That keeps the user-facing story unified and actionable. [^6]
 
-## Multi-pass execution path
+## 4. Multi-pass execution path
 
 The workspace analysis should run in four deliberate phases.
 
@@ -207,7 +213,7 @@ multi-target. The usefulness of the synthetic/organic split follows directly
 from axinite’s existing `touch!`, `touch_const!`, and anonymous `const _:`
 keepalive code. [^5]
 
-## Diagnostic model and report format
+## 5. Diagnostic model and report format
 
 The default human-readable diagnostic should inventory items, not counts. A
 file-level warning should lead with the suppression site, then group items
@@ -320,7 +326,7 @@ operational summaries, and this analysis belongs in the same family. A JSON
 form makes later autofix or reporting work possible without locking Whitaker
 into automatic deletion or code movement in v1. [^3]
 
-## Worked examples
+## 6. Worked examples
 
 In axinite, the most important design conclusion is that the tool should not
 hard-code the “shared across many test crates” story. The current repository
@@ -344,7 +350,7 @@ several helpers are genuinely shared. That makes mdtablefix the canonical
 justification for a rule that inventories per-item target reach, rather than
 just yelling about the presence of `#[expect(dead_code)]`. [^6][^7]
 
-## Constraints, failure modes, and rollout
+## 7. Constraints, failure modes, and rollout
 
 The scope should stay tight in v1. Whitaker should analyse integration-test
 support only, and only for the active package, feature set, and target triple.
@@ -379,7 +385,7 @@ existing architecture, and delivers the part the exploration asked for: a tool
 that helps people unbork the codebase by telling them which support items are
 actually dead, which are local, and which are truly shared. [^3]
 
-## References
+## 8. References
 
 [^1]: Cargo and Rust documentation covering integration-test target structure,
       `dead_code`, `#[expect(...)]`, `unfulfilled_lint_expectations`,

--- a/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
+++ b/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
@@ -1,10 +1,13 @@
 # Technical design for `test_support_dead_code` and `masked_dead_code_expectations`
 
-Status: Proposed Scope: Crate-local detector lints plus workspace analysis for
-dead or over-suppressed test-support code. Primary audience: Whitaker
-contributors, lint authors, reviewers, and QA engineers. Precedence documents:
-`docs/whitaker-dylint-suite-design.md`, `docs/whitaker-cli-design.md`, and
-later ADRs or roadmap decisions that supersede this design.
+- Status: Proposed
+- Scope: Crate-local detector lints plus workspace analysis for dead or
+  over-suppressed test-support code.
+- Primary audience: Whitaker contributors, lint authors, reviewers, and QA
+  engineers.
+- Precedence documents: `docs/whitaker-dylint-suite-design.md`,
+  `docs/whitaker-cli-design.md`, and later ADRs or roadmap decisions that
+  supersede this design.
 
 ## 1. Design summary
 

--- a/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
+++ b/docs/technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md
@@ -384,13 +384,13 @@ actually dead, which are local, and which are truly shared. [^3]
 [^1]: Cargo and Rust documentation covering integration-test target structure,
       `dead_code`, `#[expect(...)]`, `unfulfilled_lint_expectations`,
       underscore-name suppression, and external-tool integration.
-      <https://doc.rust-lang.org/cargo/reference/cargo-targets.html?highlight=test&utm_source=chatgpt.com>
-      <https://doc.rust-lang.org/cargo/reference/external-tools.html?utm_source=chatgpt.com>
-      <https://doc.rust-lang.org/reference/attributes/diagnostics.html?utm_source=chatgpt.com>
-      <https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.DEAD_CODE.html?utm_source=chatgpt.com>
+      <https://doc.rust-lang.org/cargo/reference/cargo-targets.html?highlight=test>
+      <https://doc.rust-lang.org/cargo/reference/external-tools.html>
+      <https://doc.rust-lang.org/reference/attributes/diagnostics.html>
+      <https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.DEAD_CODE.html>
 [^2]: Dylint documentation describing dynamic-library lint execution and the
       `LateLintPass` model.
-      <https://github.com/trailofbits/dylint?utm_source=chatgpt.com>
+      <https://github.com/trailofbits/dylint>
 [^3]: Whitaker workspace references used for the proposed split between
       lint-time detection and richer `whitaker check` analysis: the CLI design,
       workspace manifest, suite registry, and Dylint suite design.

--- a/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
+++ b/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
@@ -1,4 +1,4 @@
-# Whitaker and cargo-compile-hygiene Technical Design
+# Whitaker and cargo-compile-hygiene technical design
 
 - Status: Proposed
 - Scope: Whitaker lint and Cargo-subcommand enforcement for architecture and
@@ -81,7 +81,7 @@ The goals therefore separate cleanly into two enforcement planes:
   constraints (how many test targets; duplicate versions; heavy dependency
   “optionality”; TLS backend multiplicity; package boundary purity). This is
   `cargo-compile-hygiene`’s remit, implemented using `cargo metadata`’s JSON.
-  Cargo recommends using `--format-version` to stabilise expectations. [^2]
+  Cargo recommends using `--format-version` to stabilize expectations. [^2]
 
 A critical design constraint: Dylint’s lints rely on `rustc` internal APIs (as
 Clippy does), so Whitaker must be versioned and maintained with the Rust
@@ -151,7 +151,7 @@ Rustc defines several lint levels (`allow`, `expect`, `warn`, `force-warn`,
 `deny`, `forbid`). “Forbid” prevents lowering the level via attributes (subject
 to lint capping). [^3]
 
-Whitaker should standardise on three policy severities (mapped onto rustc
+Whitaker should standardize on three policy severities (mapped onto rustc
 levels):
 
 - **hard policy (default `deny`):** architectural boundary violations that
@@ -217,7 +217,7 @@ late. [^3]
 
 ### 4.2 Common configuration schema shapes
 
-Whitaker should standardise configuration like this (examples; open-ended
+Whitaker should standardize configuration like this (examples; open-ended
 defaults):
 
 ```toml
@@ -1220,16 +1220,16 @@ A practical migration sequence:
    ```
 
 4. **Enable `tls_backend_multiplicity`**  
-   Once feature sets stabilise, make that check a failure in CI for default
-   features if the project intends to standardise on one TLS backend. Axinite
+   Once feature sets stabilize, that check should fail in CI for default
+   features if the project intends to standardize on one TLS backend. Axinite
    explicitly observed dual stacks due to conflicting reqwest defaults. [^4]
 
-5. **Track duplicates as hotspots, not “must fix”**  
+5. **Duplicate hotspots tracked as advisory, not “must fix”**
    Axinite’s duplicate stacks are partly upstream (libsql pulling older
-   ecosystems). Use `duplicate_major_version_hotspots` to surface and rank
-   them, but keep failures off unless you have a realistic remediation path.
-   Cargo’s docs frame duplicates as something to identify and investigate; they
-   do not guarantee easy resolution. [^2][^4]
+   ecosystems). `duplicate_major_version_hotspots` should surface and rank
+   duplicates, while CI failures remain disabled unless a realistic remediation
+   path exists. Cargo’s docs frame duplicates as something to identify and
+   investigate; they do not guarantee easy resolution. [^2][^4]
 
 6. **Keep async-trait migration lint advisory**  
    Axinite’s own audit shows most async-trait uses are blocked by trait-object
@@ -1255,12 +1255,12 @@ A Gauss-focused migration sequence:
    outside the app crate, consistent with planned test relocation and crate
    purity. [^4]
 
-3. **Treat integration test target budgets cautiously**  
+3. **Integration test target budgets treated cautiously**
    Gauss’s integration-test consolidation plan ended up preserving target
    counts for pragmatic reasons (naming convention instead of module
-   consolidation). If you later decide build-time reductions matter more than
-   isolation, set budgets that reflect a desired future state and use the
-   tool’s reporting to drive an incremental consolidation project. [^4]
+   consolidation). If build-time reduction later matters more than isolation,
+   budgets can reflect a desired future state, and the tool’s reporting can
+   drive an incremental consolidation project. [^4]
 
 4. **Add architectural lints only where architecture is explicit**  
    If Gauss has explicit layer boundaries akin to Wildside’s

--- a/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
+++ b/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
@@ -9,7 +9,7 @@
   `docs/whitaker-cli-design.md`, and any later ADRs or roadmap decisions that
   supersede this design.
 
-## Executive summary
+## 1. Executive summary
 
 This design proposes a two-part enforcement system for Rust workspaces:
 
@@ -43,7 +43,7 @@ Non-goals: debuginfo/profile tuning (explicitly out of scope), UI feature
 auditing, and whole-workspace async-trait migration auditing (both explicitly
 excluded). [^4]
 
-## Problem statement and goals
+## 2. Problem statement and goals
 
 Large Rust workspaces often accumulate “hidden” compile-time costs that do not
 show up as obvious code smells: integration tests proliferate as dozens of
@@ -88,9 +88,9 @@ Clippy does), so Whitaker must be versioned and maintained with the Rust
 toolchain; Dylint’s design amortises cost by grouping lints by compiler version
 and sharing intermediate compilation results. [^1]
 
-## Configuration, taxonomy, and developer experience
+## 3. Configuration, taxonomy, and developer experience
 
-### Policy storage and shared configuration model
+### 3.1 Policy storage and shared configuration model
 
 Cargo explicitly allows third-party tools to store configuration in
 `Cargo.toml` via `package.metadata` (and, by extension, workspace metadata),
@@ -117,7 +117,7 @@ Whitaker should therefore adopt a two-tier configuration model:
   configurable libraries. For multi-lint libraries, Dylint’s `dylint_linting`
   utilities require an explicit `register_lints` and `init_config` call. [^1]
 
-### Whitaker lint namespaces and naming conventions
+### 3.2 Whitaker lint namespaces and naming conventions
 
 Rust tool lints conventionally use a `tool::lint_name` namespace (e.g.,
 `clippy::…`). The `rustc_session::declare_tool_lint!` macro directly encodes
@@ -145,7 +145,7 @@ Discovery/navigation guidance:
   `whitaker::hygiene_*` at `warn` locally, escalate in CI. Rust supports
   multiple lint levels and configuration via attributes and CLI flags. [^3]
 
-### Severity levels and build gating
+### 3.3 Severity levels and build gating
 
 Rustc defines several lint levels (`allow`, `expect`, `warn`, `force-warn`,
 `deny`, `forbid`). “Forbid” prevents lowering the level via attributes (subject
@@ -169,7 +169,7 @@ This separation aligns with the Rust community’s broader warning-fatigue
 concerns: warnings should remain meaningful and not drown developers; hard
 failures should be reserved for clear architectural contracts. [^3]
 
-### Feature-matrix and “unknown lint” ergonomics
+### 3.4 Feature-matrix and “unknown lint” ergonomics
 
 Dylint passes `--cfg=dylint_lib="LIBRARY_NAME"` during lint runs, enabling
 `cfg_attr`-based suppression without “unknown lint” warnings when Dylint is not
@@ -191,9 +191,9 @@ warnings and provide a workspace-level `.toml` snippet to whitelist
 `cfg(dylint_lib, values(any()))`. Whitaker should include this in the standard
 rollout. [^1]
 
-## Whitaker lint suite design
+## 4. Whitaker lint suite design
 
-### Implementation architecture
+### 4.1 Implementation architecture
 
 Whitaker is a **single Dylint library** named `whitaker` (crate name
 `whitaker_lints` or similar), exporting multiple lints. Because Dylint’s macro
@@ -215,7 +215,7 @@ Rustc/Clippy guidance: a `LateLintPass` has access to type and symbol
 information that an `EarlyLintPass` does not. Most “semantic” lints should be
 late. [^3]
 
-### Common configuration schema shapes
+### 4.2 Common configuration schema shapes
 
 Whitaker should standardise configuration like this (examples; open-ended
 defaults):
@@ -272,12 +272,12 @@ policy_version = 1
 Dylint supports configurable libraries via `dylint.toml` keyed by library name,
 and `dylint_linting` provides config parsing helpers. [^1]
 
-### Lint designs
+### 4.3 Lint designs
 
 Below, each lint includes: purpose, scope, false-positive risks, phase/type
 needs, config examples, diagnostics, autofix feasibility, and test plan.
 
-#### `whitaker::hygiene_forbidden_external_crate_in_layer`
+#### 4.3.1 `whitaker::hygiene_forbidden_external_crate_in_layer`
 
 Purpose: enforce that specific layers (defined by package + path prefix) do not
 reference specific external crates. This is the “external-crate half” of
@@ -344,7 +344,7 @@ Test plan:
   - **Edge:** `use diesel as db;` should still flag `diesel` (requires
     resolution, not lexical segment matching).
 
-#### `whitaker::hygiene_public_api_leaks_optional_dep`
+#### 4.3.2 `whitaker::hygiene_public_api_leaks_optional_dep`
 
 Purpose: prevent public API surfaces from exposing types from dependencies that
 are intended to be optional/feature-gated. This directly supports
@@ -422,7 +422,7 @@ Test plan:
 - Include regression tests derived from Axinite’s identified leakage points to
   ensure the lint matches real patterns. [^4]
 
-#### `whitaker::hygiene_feature_island_breach`
+#### 4.3.3 `whitaker::hygiene_feature_island_breach`
 
 Purpose: enforce that “heavy optional” subsystems remain confined to configured
 **feature islands**: code that depends on a heavy crate (or its transitive
@@ -503,7 +503,7 @@ Test plan:
   - `src/sandbox/container.rs` uses `bollard` but file lacks cfg → fail.
     [^4]
 
-#### `whitaker::tests_ui_test_macro_outside_app`
+#### 4.3.4 `whitaker::tests_ui_test_macro_outside_app`
 
 Purpose: enforce that UI integration testing harnesses (specifically
 `#[gpui::test]`) remain confined to app crates, preventing UI dependencies from
@@ -561,7 +561,7 @@ Test plan:
 - Document suppression mechanics for pre-expansion lints
   (`#[allow(unknown_lints)]`) per Dylint guidance. [^1]
 
-#### `whitaker::arch_hexagonal_layer_boundary` (internal + external rules)
+#### 4.3.5 `whitaker::arch_hexagonal_layer_boundary` (internal + external rules)
 
 Purpose: replicate (and improve upon) Wildside’s repo-local architecture lint
 inside Whitaker/Dylint:
@@ -656,7 +656,7 @@ Test plan:
   - A local module called `diesel` should *not* be treated as external if it
     resolves locally (resolution-based correctness).
 
-#### `whitaker::advisory_async_trait_clear_misuse`
+#### 4.3.6 `whitaker::advisory_async_trait_clear_misuse`
 
 Purpose: provide low-confidence, non-blocking guidance where `#[async_trait]`
 usage is locally migratable to native async traits, without attempting
@@ -727,9 +727,9 @@ Test plan:
 - Include a regression check that the lint does not trigger on known dyn-heavy
   patterns (consistent with Axinite’s classification). [^4]
 
-## cargo-compile-hygiene design
+## 5. cargo-compile-hygiene design
 
-### Tool shape and why it is a Cargo subcommand
+### 5.1 Tool shape and why it is a Cargo subcommand
 
 Cargo explicitly supports third-party tooling via custom subcommands, and it
 provides `cargo metadata` for machine-readable workspace structure and
@@ -743,7 +743,7 @@ Therefore, implement as a `cargo` plugin:
   `cargo metadata` output. Cargo docs recommend `--format-version`, and the
   `cargo_metadata` crate is the standard Rust API for parsing the JSON. [^2]
 
-### Commands and CLI UX
+### 5.2 Commands and CLI UX
 
 Proposed subcommands:
 
@@ -766,7 +766,7 @@ Core flags:
 - `--target …` and `--filter-platform …` where applicable (Cargo supports
   `--filter-platform` for `cargo metadata`). [^2]
 
-### Inputs and data sources
+### 5.3 Inputs and data sources
 
 Primary inputs:
 
@@ -783,9 +783,9 @@ Secondary inputs (optional enhancements; not required for initial MVP):
   duplicates matter for build time and show how `--duplicates` highlights them.
   [^2]
 
-### Checks
+### 5.4 Checks
 
-#### `integration_target_budget`
+#### 5.4.1 `integration_target_budget`
 
 What it checks:
 
@@ -830,7 +830,7 @@ Outputs:
 - Human report includes top offending packages, counts, and suggested
   consolidation strategy referencing Cargo’s recommended approach. [^2]
 
-#### `heavy_dependency_not_optional`
+#### 5.4.2 `heavy_dependency_not_optional`
 
 What it checks:
 
@@ -872,7 +872,7 @@ Outputs:
 - Provide transitive count, and a “how to fix” note: make dep optional + gate
   behind feature + rerun feature matrix.
 
-#### `duplicate_major_version_hotspots`
+#### 5.4.3 `duplicate_major_version_hotspots`
 
 What it checks:
 
@@ -912,7 +912,7 @@ Outputs:
 - Provide hints: update the older dependency; align feature flags; consider
   dependency replacement.
 
-#### `tls_backend_multiplicity`
+#### 5.4.4 `tls_backend_multiplicity`
 
 What it checks:
 
@@ -959,7 +959,7 @@ Outputs:
   crates).”
 - Show a short list of introducer packages (reverse dependency roots).
 
-#### `package_boundary_purity`
+#### 5.4.5 `package_boundary_purity`
 
 What it checks:
 
@@ -996,7 +996,7 @@ Outputs:
 - List the forbidden package found and the shortest path
   (`gauss-core -> … -> gpui`), using metadata graph traversal.
 
-### Output formats and example reports
+### 5.5 Output formats and example reports
 
 Human-readable (default):
 
@@ -1031,9 +1031,9 @@ CI integration:
 This aligns with standard CLI tooling expectations and Cargo subcommand
 ergonomics. [^2]
 
-## Integration, CI, and rollout
+## 6. Integration, CI, and rollout
 
-### Component interaction and data flow
+### 6.1 Component interaction and data flow
 
 This diagram describes how Dylint-based Whitaker checks and the
 `cargo-compile-hygiene` subcommand consume workspace data and emit findings.
@@ -1067,7 +1067,7 @@ Cargo-compile-hygiene uses Cargo’s external tool facilities: custom subcommand
 plus `cargo metadata` JSON. Cargo recommends passing `--format-version` because
 output can evolve. [^2]
 
-### Invocation patterns and feature-matrix handling
+### 6.2 Invocation patterns and feature-matrix handling
 
 Because both code-level and graph-level findings can vary with features,
 enforce under a feature matrix aligned with existing project practices:
@@ -1100,7 +1100,7 @@ running with `--all-targets` ensures non-default targets
 (examples/tests/benches) are included, matching the practical locations where
 boundary violations often hide. [^2][^3]
 
-### Comparison table: what belongs where
+### 6.3 Comparison table: what belongs where
 
 | Check / policy                                        | Whitaker (Dylint) | cargo-compile-hygiene | Repo-specific checker | Rationale                                                                                               |
 | ----------------------------------------------------- | ----------------- | --------------------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
@@ -1117,7 +1117,10 @@ boundary violations often hide. [^2][^3]
 | `package_boundary_purity`                             | No                | Yes                   | No                    | Package dependency purity is a Cargo graph property; complements Whitaker. [^4]                         |
 | Redundant `make` pipelines (e.g., `check` + `clippy`) | No                | No                    | Yes                   | Not a Rust/Cargo semantic issue; a repo build orchestration issue. [^4]                                 |
 
-### Rollout timeline
+*Table: Ownership split between Whitaker lints and `cargo-compile-hygiene`
+checks.*
+
+### 6.4 Rollout timeline
 
 This diagram shows the delivery sequence and measurable completion criteria for
 the foundation, MVP, and stabilization workstreams.
@@ -1168,9 +1171,9 @@ keep compile-time hygiene checks initially as warning/reporting, then promote
 once noise is understood. This matches the risk profile implied by Rust lint
 levels and the desire to avoid warning fatigue. [^3]
 
-## Migration guidance for Axinite and Gauss
+## 7. Migration guidance for Axinite and Gauss
 
-### Axinite migration steps (concrete)
+### 7.1 Axinite migration steps (concrete)
 
 Axinite’s build-time investigation identifies: many integration test binaries;
 always-compiled heavy dependencies intended to be optional (wasmtime, bollard,
@@ -1234,7 +1237,7 @@ A practical migration sequence:
    Only ship `async_trait_clear_misuse` as advisory with a conservative mode.
    [^4]
 
-### Gauss migration steps (concrete)
+### 7.2 Gauss migration steps (concrete)
 
 Gauss’s crate split is complete and establishes a clear graph: `gauss` (app)
 depends on `gauss-core` and `gauss-svg`, and `gauss-svg` depends on
@@ -1266,7 +1269,7 @@ A Gauss-focused migration sequence:
    and on optional heavy features (if any). Wildside’s success rests on
    path-based layer inference and explicit forbidden root lists. [^4]
 
-### Example combined config snippets
+### 7.3 Example combined config snippets
 
 Gauss (workspace root):
 
@@ -1306,7 +1309,7 @@ illustrate the default shape rather than asserting a single “correct” budget
 Cargo’s manifest metadata mechanism exists precisely to support that sort of
 tool configuration. [^2]
 
-## References
+## 8. References
 
 [^1]: Dylint references covering the execution model, `rustc_private` coupling,
       configuration, conditional compilation, pre-expansion lints, and

--- a/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
+++ b/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
@@ -1,0 +1,1350 @@
+# Whitaker and cargo-compile-hygiene Technical Design
+
+## Executive summary
+
+This design proposes a two-part enforcement system for Rust workspaces:
+
+Whitaker, a **Dylint-based** lint suite that runs inside `rustc` and enforces
+(a) **architectural boundaries** (including a hexagonal “domain / inbound /
+outbound” rule-set modelled on the existing Wildside architecture lint) and (b)
+**compile-time hygiene** rules that are best expressed at the **source/HIR**
+level. [^1][^4]
+
+`cargo-compile-hygiene`, a **Cargo-aware tool** (a `cargo` custom subcommand)
+that consumes `Cargo.toml` plus `cargo metadata` output to enforce compile-time
+hygiene rules that are best expressed at the **package/target/dependency
+graph** level (integration test target budgets, heavy dependency gating,
+duplicate version hotspots, TLS backend multiplicity, and package boundary
+purity). [^2][^1]
+
+Both tools share configuration via `Cargo.toml` workspace metadata (and
+optionally `dylint.toml`/`dylint.toml`-style tables for Dylint), enabling a
+single policy source of truth (layer definitions, forbidden dependencies,
+feature “islands”, thresholds). Cargo explicitly supports third-party tooling
+via (a) `cargo metadata`, (b) stable JSON message formats, and (c) custom
+subcommands, and it also supports manifest metadata intended for external
+tools. [^2]
+
+The design is driven by the concrete failures seen in Axinite and Gauss:
+repeated link/compile work due to many integration test crates, always-compiled
+heavy optional dependencies, duplicate dependency stacks, and package boundary
+contamination (notably UI dependencies leaking into “core” layers).
+[^4]
+
+Non-goals: debuginfo/profile tuning (explicitly out of scope), UI feature
+auditing, and whole-workspace async-trait migration auditing (both explicitly
+excluded). [^4]
+
+## Problem statement and goals
+
+Large Rust workspaces often accumulate “hidden” compile-time costs that do not
+show up as obvious code smells: integration tests proliferate as dozens of
+separate crates; heavyweight subsystems (WASM runtimes, Docker clients, PDF
+toolchains) stay always-on; dependency resolution drags in parallel HTTP/TLS
+stacks; and architectural layering decays until a change in one corner forces
+costly recompilation everywhere. Axinite’s investigation quantified these
+effects: hundreds of crates in the graph, many integration test binaries, and
+heavy dependencies contributing significant compile-time and link-time
+overhead. [^4]
+
+Cargo’s own documentation highlights one of the major mechanisms: **each file
+under `tests/` is compiled as a separate crate**, and Cargo explicitly notes
+that “a lot of integration tests” can be inefficient and suggests consolidating
+into fewer targets split into modules. This aligns with Axinite’s measured
+link-time bottleneck and the consolidation plan that reduced test binaries
+substantially. [^2][^4]
+
+Gauss’s work shows the dual: even if the “clean build” remains dominated by
+heavy upstream GUI dependencies, **package boundaries enable selective
+compilation** (`cargo test -p gauss-core`) that avoids pulling UI dependencies
+when working on pure model/SVG logic. This is fundamentally a package graph
+property, not a source-only property. [^4]
+
+The goals therefore separate cleanly into two enforcement planes:
+
+- **Plane A (inside rustc / HIR):** enforce architectural boundaries and
+  code-level constraints (who may import what; public API does not leak
+  optional deps; feature-gated “islands” remain bounded; UI test harness macros
+  do not appear in non-app crates). This is Whitaker’s remit, implemented as
+  Dylint lints. Dylint runs lints loaded from dynamic libraries, and—like
+  Clippy—operates by registering lint passes with `rustc`.
+  [^1]
+
+- **Plane B (workspace graph / Cargo metadata):** enforce packaging-and-graph
+  constraints (how many test targets; duplicate versions; heavy dependency
+  “optionality”; TLS backend multiplicity; package boundary purity). This is
+  `cargo-compile-hygiene`’s remit, implemented using `cargo metadata`’s JSON.
+  Cargo recommends using `--format-version` to stabilise expectations.
+  [^2]
+
+A critical design constraint: Dylint’s lints rely on `rustc` internal APIs (as
+Clippy does), so Whitaker must be versioned and maintained with the Rust
+toolchain; Dylint’s design amortises cost by grouping lints by compiler version
+and sharing intermediate compilation results. [^1]
+
+## Configuration, taxonomy, and developer experience
+
+### Policy storage and shared configuration model
+
+Cargo explicitly allows third-party tools to store configuration in
+`Cargo.toml` via `package.metadata` (and, by extension, workspace metadata),
+and Cargo ignores those metadata keys rather than warning about them. This
+provides the canonical place to define Whitaker/cargo-compile-hygiene policy
+without inventing a bespoke file format. [^2]
+
+Dylint also supports **workspace metadata**: a workspace can declare the Dylint
+libraries it should be linted with under `workspace.metadata.dylint.libraries`
+in `Cargo.toml` or `dylint.toml`. Dylint will download/build those entries
+similarly to dependencies. [^1]
+
+Whitaker should therefore adopt a two-tier configuration model:
+
+- **Tool wiring:** `[workspace.metadata.dylint]` declares the Whitaker Dylint
+  library location (path or git) as Dylint expects. [^1]
+- **Policy:** `[workspace.metadata.whitaker]` (or
+  `[workspace.metadata.whitaker.*]`) stores shared policy consumed by both
+  Whitaker and `cargo-compile-hygiene`. This keeps Dylint’s own metadata
+  namespace reserved for Dylint configuration. [^2][^1]
+- **Per-lint tunables:** either (a) keep them under
+  `[workspace.metadata.whitaker.lints.<lint>]`, or (b) expose a Dylint-native
+  `dylint.toml` configuration table keyed by library name, as Dylint supports
+  configurable libraries. For multi-lint libraries, Dylint’s `dylint_linting`
+  utilities require an explicit `register_lints` and `init_config` call.
+  [^1]
+
+### Whitaker lint namespaces and naming conventions
+
+Rust tool lints conventionally use a `tool::lint_name` namespace (e.g.,
+`clippy::…`). The `rustc_session::declare_tool_lint!` macro directly encodes
+this `tool :: NAME, Level, desc` shape. [^3]
+
+Whitaker should use **one tool namespace**: `whitaker::…`. Because tool lints
+do not support multi-segment namespaces beyond the tool name, Whitaker
+namespaces should be encoded as prefixes in the lint name:
+
+- `whitaker::arch_*` for architectural boundary lints
+- `whitaker::hygiene_*` for compile-time hygiene lints
+- `whitaker::tests_*` for test-graph and harness-related lints
+- `whitaker::advisory_*` for best-effort/low-confidence lints
+
+Discovery/navigation guidance:
+
+- `cargo dylint list …` is the primary “what lints exist?” interface (Dylint’s
+  own docs use `cargo dylint … list`). [^1]
+- Whitaker should create **lint groups** (registering groups with rustc’s lint
+  store) analogous to `clippy::all` and Clippy’s category approach, enabling
+  “turn on everything in CI” without manually listing dozens of lints. (This is
+  a design choice; rustc supports lint grouping machinery via the lint store
+  model described in the compiler dev guide.) [^3]
+- Default “developer local” guidance: enable `whitaker::arch_*` and
+  `whitaker::hygiene_*` at `warn` locally, escalate in CI. Rust supports
+  multiple lint levels and configuration via attributes and CLI flags.
+  [^3]
+
+### Severity levels and build gating
+
+Rustc defines several lint levels (`allow`, `expect`, `warn`, `force-warn`,
+`deny`, `forbid`). “Forbid” prevents lowering the level via attributes (subject
+to lint capping). [^3]
+
+Whitaker should standardise on three policy severities (mapped onto rustc
+levels):
+
+- **hard policy (default `deny`):** architectural boundary violations that
+  should never ship (e.g., a “domain” layer importing infrastructure crates, or
+  `gauss-core` importing `gpui`). These should fail CI by default.
+  [^3][^4]
+- **soft policy (default `warn`):** compile-time hygiene issues that merit
+  action but may have local exceptions (e.g., a public API uses an optional dep
+  type in a non-critical surface; a feature-island rule triggers in
+  transitional code). [^3][^4]
+- **advisory (default `allow` or `warn` behind a group):** low-confidence
+  suggestions such as `async_trait_clear_misuse`, which should not block merges
+  and should avoid warning fatigue. [^3][^4]
+
+This separation aligns with the Rust community’s broader warning-fatigue
+concerns: warnings should remain meaningful and not drown developers; hard
+failures should be reserved for clear architectural contracts.
+[^3]
+
+### Feature-matrix and “unknown lint” ergonomics
+
+Dylint passes `--cfg=dylint_lib="LIBRARY_NAME"` during lint runs, enabling
+`cfg_attr`-based suppression without “unknown lint” warnings when Dylint is not
+running. Dylint documents both the mechanism and the limitation: this does
+**not** work for pre-expansion lints, where the workaround is
+`#[allow(unknown_lints)]`. [^1]
+
+Whitaker should codify a convention:
+
+- For **early/late** Whitaker lints: allow suppressions using
+  `#[cfg_attr(dylint_lib = "whitaker", allow(whitaker::…))]`. [^1]
+- For **pre-expansion** Whitaker lints (notably `ui_test_macro_outside_app` and
+  likely `async_trait_clear_misuse` if it keys off attribute macros): suppress
+  with `#[allow(unknown_lints)] #[allow(whitaker::…)]` and document this as a
+  rare escape hatch. [^1]
+
+For workspaces using recent rustc, Dylint’s docs also note `unexpected_cfg`
+warnings and provide a workspace-level `.toml` snippet to whitelist
+`cfg(dylint_lib, values(any()))`. Whitaker should include this in the standard
+rollout. [^1]
+
+## Whitaker lint suite design
+
+### Implementation architecture
+
+Whitaker is a **single Dylint library** named `whitaker` (crate name
+`whitaker_lints` or similar), exporting multiple lints. Because Dylint’s macro
+helpers vary between single-lint libraries and multi-lint libraries, Whitaker
+should implement an explicit `register_lints(sess, lint_store)` and call
+`dylint_linting::init_config(sess)` before reading configuration.
+[^1]
+
+Whitaker will implement a mixture of:
+
+- **Late lints** (HIR + type information) for API-shape analyses and precise
+  name resolution.
+- **Early lints** (AST, no type information) for purely syntactic imports/paths
+  where resolution suffices.
+- **Pre-expansion lints** for rules that must observe attribute-macro syntax
+  prior to expansion. Dylint’s tooling explicitly supports
+  `declare_pre_expansion_lint!` / `impl_pre_expansion_lint!`.
+  [^1][^3]
+
+Rustc/Clippy guidance: a `LateLintPass` has access to type and symbol
+information that an `EarlyLintPass` does not. Most “semantic” lints should be
+late. [^3]
+
+### Common configuration schema shapes
+
+Whitaker should standardise configuration like this (examples; open-ended
+defaults):
+
+```toml
+# Cargo.toml (workspace root)
+
+[workspace.metadata.dylint]
+libraries = [{ path = "tools/whitaker" }]
+
+[workspace.metadata.whitaker]
+# Global defaults for both Whitaker and cargo-compile-hygiene
+policy_version = 1
+
+[workspace.metadata.whitaker.layers]
+# Layer names are stable identifiers used by multiple lints.
+# Each layer maps to a set of (packages, paths) that belong to it.
+domain = { packages = ["backend"], path_prefixes = ["backend/src/domain/"] }
+inbound = { packages = ["backend"], path_prefixes = ["backend/src/inbound/"] }
+outbound = { packages = ["backend"], path_prefixes = ["backend/src/outbound/"] }
+
+[workspace.metadata.whitaker.lints.arch_hexagonal_layer_boundary]
+# Internal module roots that each layer must not depend on.
+forbid_internal = { domain = ["inbound", "outbound"], inbound = ["outbound"], outbound = ["inbound"] }
+# External crates forbidden per layer.
+forbid_external = { domain = ["diesel", "utoipa"], inbound = ["diesel"], outbound = ["actix_web"] }
+
+[workspace.metadata.whitaker.lints.hygiene_feature_island_breach]
+# Feature islands define “heavy optional subsystems” that must remain bounded.
+islands = [
+  { name = "wasm", feature = "wasm", deps = [
+    "wasmtime", "wasmtime_wasi", "wasmparser",
+  ], allowed_paths = ["src/tools/wasm/", "src/channels/wasm/"] },
+  { name = "docker", feature = "docker", deps = ["bollard"],
+    allowed_paths = ["src/sandbox/", "src/orchestrator/"] },
+]
+
+[workspace.metadata.whitaker.lints.tests_ui_test_macro_outside_app]
+app_packages = ["gauss"] # only the app crate may contain gpui::test
+```
+
+This uses Cargo’s manifest metadata facility for tool configuration.
+[^2]
+
+Where per-lint tunables need a Dylint-native `dylint.toml`, Whitaker can also
+expose:
+
+```toml
+# dylint.toml (workspace root)
+[whitaker]
+# A single table for the Whitaker library; Whitaker interprets its structure.
+policy_version = 1
+```
+
+Dylint supports configurable libraries via `dylint.toml` keyed by library name,
+and `dylint_linting` provides config parsing helpers.
+[^1]
+
+### Lint designs
+
+Below, each lint includes: purpose, scope, false-positive risks, phase/type
+needs, config examples, diagnostics, autofix feasibility, and test plan.
+
+#### `whitaker::hygiene_forbidden_external_crate_in_layer`
+
+Purpose: enforce that specific layers (defined by package + path prefix) do not
+reference specific external crates. This is the “external-crate half” of
+Wildside’s architecture lint, and it is also useful for compile-time hygiene
+(“heavy deps should not be imported by most of the codebase”).
+[^4]
+
+Scope: counts *resolved* uses of external crates in paths (`use`, type paths,
+expression paths), within files that Whitaker maps into a configured layer.
+Should operate at crate scope across all targets selected by the invocation
+(`--all-targets` recommended). [^2][^1][^3]
+
+False-positive risks:
+
+- Lexical path scanning (as Wildside currently does via `syn`) can misclassify
+  local modules named like external crates or fail to resolve renamed imports.
+  Whitaker should prefer rustc name resolution (HIR `Res`) where possible.
+  [^4][^3]
+- Re-exports: a layer might legitimately depend on a local façade crate that
+  re-exports a forbidden crate; policy must decide whether to forbid the façade
+  or the underlying crate.
+
+Phase and type info:
+
+- Recommended: **Late lint** to use HIR and resolution. Late lints run on HIR
+  and have full type/symbol information; early lints do not.
+  [^3]
+- HIR needs: path resolution (`Res::Def` / crate root), span-to-file mapping
+  for layer inference.
+
+Config example:
+
+```toml
+[workspace.metadata.whitaker.lints.hygiene_forbidden_external_crate_in_layer]
+rules = [
+  { layer = "domain", forbid = ["diesel", "utoipa"] },
+  { layer = "inbound", forbid = ["diesel"] },
+]
+```
+
+Diagnostics/messages:
+
+- Primary message: `layer '{layer}' must not depend on external crate '{crate}'`
+- Include note with: configured rule origin (policy key), and hint to move code
+  behind an adapter boundary or feature gate.
+- Provide a “help” line pointing to the allowed layer or façade crate, if
+  configured.
+
+Autofix feasibility:
+
+- Generally **not machine-applicable**. Automatic refactors (moving code across
+  layers, introducing adapters) are semantic and project-specific. Provide
+  “guidance-only” suggestions (Applicability: `MaybeIncorrect`), not
+  `MachineApplicable`. This matches Clippy’s general caution where suggestions
+  may be non-trivial. [^3]
+
+Test plan:
+
+- Use Dylint UI testing harness (`dylint_uitesting`) to verify diagnostics and
+  spans; the crate is designed to run compiletest-style UI tests for Dylint
+  libraries. [^1]
+- Sample tests (positive/negative):
+  - **OK:** a domain file imports `crate::domain::…` and `serde`.
+  - **Fail:** a domain file imports `diesel::prelude::*`.
+  - **Fail:** an inbound file imports `utoipa::ToSchema` if inbound forbids it.
+  - **Edge:** `use diesel as db;` should still flag `diesel` (requires
+    resolution, not lexical segment matching).
+
+#### `whitaker::hygiene_public_api_leaks_optional_dep`
+
+Purpose: prevent public API surfaces from exposing types from dependencies that
+are intended to be optional/feature-gated. This directly supports
+feature-gating plans like Axinite’s `docker` gating, where
+`SandboxError::Docker` and `ContainerRunner` currently leak `bollard` in public
+shapes. [^4]
+
+Scope:
+
+- Public items: `pub fn`, `pub struct` fields (public), `pub enum` variants,
+  `pub trait` methods, `pub type`, and re-exports (`pub use`).
+- “Leakage” definition: a public signature or exported type mentions a type
+  whose defining crate is (a) listed as optional in Cargo metadata or (b)
+  listed in Whitaker’s optional-dep policy map.
+
+False-positive risks:
+
+- Some crates intentionally expose third-party types as part of their API
+  (e.g., façade crates). This needs allowlists per package/module.
+- Type alias indirection can hide direct references; need to walk the full type
+  graph of exported types (bounded for performance).
+
+Phase and type info:
+
+- Must be **Late lint**, because it must understand the *types* of signatures
+  and where those types are defined. Late lints have access to `LateContext`
+  and typeck results; early lints do not. [^3]
+- Needs:
+  - `LateContext::tcx` to map `Ty`/`AdtDef`/`DefId` to defining crate.
+  - Possibly HIR traversal to find public items and gather their exposed `Ty`s.
+
+Config example:
+
+```toml
+[workspace.metadata.whitaker.lints.hygiene_public_api_leaks_optional_dep]
+# Map optional deps to the Cargo feature that gates them (used for fix guidance).
+optional_deps = { bollard = "docker", wasmtime = "wasm", pdf_extract = "pdf" }
+
+# Allowlist exceptional modules or items.
+allow = [
+  { package = "some-facade", paths = ["src/public_api.rs"] }
+]
+```
+
+Diagnostics/messages:
+
+- Message:
+  `public API exposes optional dependency type '{crate}::{type}'`
+  `(gated by feature '{feature}')`
+- Help: “Introduce a project-owned error wrapper / newtype, or gate the API
+  with `#[cfg(feature = "...")]`”.
+- Note: include where the optional dep is configured (feature name), and the
+  exact public item path (symbol path) that leaks it.
+
+Autofix feasibility:
+
+- **Partially feasible** as a *guided edit*, not a one-click fix:
+  - If the leaked type appears in an error enum variant (like
+    `SandboxError::Docker(#[from] bollard::errors::Error)`), propose a wrapper
+    variant type `DockerError` behind `#[cfg(feature="docker")]` plus a
+    non-optional “opaque” error. This is non-trivial and should be
+    `MaybeIncorrect`. [^4]
+  - If the leaked type appears only in a `pub use`, an autofix could suggest
+    removing or gating the re-export (still risky).
+
+Test plan:
+
+- UI tests with small fixtures:
+  - A `pub enum Error { Docker(bollard::errors::Error) }` with `bollard` marked
+    optional in a test `Cargo.toml` should fail.
+  - Same enum but `#[cfg(feature="docker")]` on variant should pass when
+    feature is off (requires feature-matrix UI tests: run with and without
+    feature).
+  - A private function leaking optional type should not trigger.
+- Include regression tests derived from Axinite’s identified leakage points to
+  ensure the lint matches real patterns. [^4]
+
+#### `whitaker::hygiene_feature_island_breach`
+
+Purpose: enforce that “heavy optional” subsystems remain confined to configured
+**feature islands**: code that depends on a heavy crate (or its transitive
+surface) must live under specific paths/modules and be guarded by
+`#[cfg(feature="…")]` as required. This operationalises Axinite’s `wasm`
+(wasmtime) and `docker` (bollard) feature-gating plans.
+[^4]
+
+Scope:
+
+- Two constraints:
+  1. **Control-plane:** references to island dependency crates are only allowed
+     in configured `allowed_paths` (and optionally allowed modules).
+  2. **Feature-plane:** those references must be under effective
+     `cfg(feature="X")` (module-level or item-level).
+
+False-positive risks:
+
+- Transitive references can appear through re-exported types or trait bounds; a
+  strict “any mention of `wasmtime::…`” rule is clearer than trying to detect
+  semantic transitivity.
+- `cfg` evaluation is subtle: `cfg(any(feature="wasm", test))` may be
+  acceptable; policy must decide acceptable patterns.
+
+Phase and type info:
+
+- Recommended: **Late lint** for accurate path resolution and spans, plus
+  attribute inspection on HIR items/modules.
+- Needs:
+  - Map item spans to source file paths and check prefix matches.
+  - Inspect `#[cfg]` attributes in the HIR tree to compute an “effective cfg
+    environment” for each item (best-effort).
+
+Config example:
+
+```toml
+[workspace.metadata.whitaker.lints.hygiene_feature_island_breach]
+islands = [
+  { name = "wasm", feature = "wasm", crate_roots = [
+    "wasmtime", "wasmtime_wasi", "wasmparser",
+  ], allowed_paths = ["src/tools/wasm/", "src/channels/wasm/"] },
+  { name = "docker", feature = "docker", crate_roots = ["bollard"],
+    allowed_paths = ["src/sandbox/", "src/orchestrator/"] },
+]
+cfg_allow_patterns = [
+  "cfg(feature = \"{feature}\")",
+  "cfg(any(feature = \"{feature}\", test))",
+]
+```
+
+Diagnostics/messages:
+
+- If outside allowed paths:
+  `feature-island '{island}' dependency '{crate}' used outside allowed paths
+  (expected under: …)`
+- If missing cfg:
+  `feature-island '{island}' dependency '{crate}' used without
+  cfg(feature = "{feature}") guard`
+- Include actionable hint: “wrap the module/function in `#[cfg(feature="…")]`
+  or move this code under {allowed_paths[0]}”.
+
+Autofix feasibility:
+
+- For missing `cfg` guard on a whole module file, suggest adding
+  `#![cfg(feature="…")]` or `#[cfg(feature="…")] mod …;` (but do not apply
+  automatically; applicability depends on module structure).
+- For path relocation, no autofix.
+
+Test plan:
+
+- Feature-matrix UI tests:
+  - With `--no-default-features`: ensure non-island packages compile without
+    wasmtime/bollard references (matches Axinite’s validation pathways).
+    [^4]
+  - With `--all-features`: ensure islands compile when enabled.
+- Sample cases:
+  - `src/tools/wasm/runtime.rs` uses `wasmtime` under `#[cfg(feature="wasm")]`
+    → ok.
+  - `src/tools/mod.rs` uses `wasmtime` without guard → fail.
+  - `src/sandbox/container.rs` uses `bollard` but file lacks cfg → fail.
+    [^4]
+
+#### `whitaker::tests_ui_test_macro_outside_app`
+
+Purpose: enforce that UI integration testing harnesses (specifically
+`#[gpui::test]`) remain confined to app crates, preventing UI dependencies from
+creeping into pure crates and forcing expensive UI compilation during
+logic-only work. This supports Gauss’s package split goals and test relocation
+goals, where core/SVG crates must not pull GPUI.
+[^4]
+
+Scope:
+
+- Detect the attribute macro `gpui::test` (and optionally other UI test harness
+  macros) attached to functions or modules outside designated app packages.
+
+False-positive risks:
+
+- If a project uses a similarly named attribute in another crate, a purely
+  lexical check could misfire; use resolved attribute paths if possible.
+- Procedural attribute macros are expanded; after expansion, the original
+  attribute may not survive into HIR, so detection may require pre-expansion
+  analysis.
+
+Phase and type info:
+
+- Recommended: **Pre-expansion lint**, because the rule is about the presence
+  of an attribute macro before it is expanded away. Dylint tooling explicitly
+  supports pre-expansion lints (`declare_pre_expansion_lint!` /
+  `impl_pre_expansion_lint!`). [^1]
+- Type info: not required; attribute syntax is sufficient.
+
+Config example:
+
+```toml
+[workspace.metadata.whitaker.lints.tests_ui_test_macro_outside_app]
+app_packages = ["gauss"]
+forbid_attributes = ["gpui::test"]
+```
+
+Diagnostics/messages:
+
+- `UI test macro #[gpui::test] is not allowed outside app packages (allowed: gauss)`
+- Note: “Move this test into the app crate, or replace with non-UI test harness
+  if possible.”
+
+Autofix feasibility:
+
+- No safe autofix; moving tests across crates affects module paths, fixtures,
+  and build/test invocation.
+
+Test plan:
+
+- Pre-expansion UI tests:
+  - In a non-app crate, a function annotated `#[gpui::test]` should trigger.
+  - In the app crate, the same should not trigger.
+- Include a regression test using Gauss-like crate names: `gauss-core`
+  containing a `#[gpui::test]` should fail. [^4]
+- Document suppression mechanics for pre-expansion lints
+  (`#[allow(unknown_lints)]`) per Dylint guidance. [^1]
+
+#### `whitaker::arch_hexagonal_layer_boundary` (internal + external rules)
+
+Purpose: replicate (and improve upon) Wildside’s repo-local architecture lint
+inside Whitaker/Dylint:
+
+- forbid **internal layer crossings** (domain ↛ inbound/outbound; inbound ↛
+  outbound; outbound ↛ inbound)
+- forbid **external framework/infrastructure crates** per layer (e.g., domain
+  must not depend on `diesel`, `utoipa`, `actix_web`, etc.)
+- infer layer membership from file path under a configured root, mirroring
+  Wildside’s `backend/src/{domain,inbound,outbound}/…` convention.
+  [^4]
+
+This lint is the primary “architectural boundary” mechanism;
+`forbidden_external_crate_in_layer` is effectively its external-only subset and
+can be implemented either as a separate lint (for narrower policy use) or as
+one rule-family under this umbrella lint.
+
+Scope:
+
+- All Rust modules in configured layer roots.
+- Path uses appearing in `use` trees and ordinary path expressions/types.
+
+Wildside baseline behaviour:
+
+- Wildside collects `syn::Path` segments and determines whether a path root
+  indicates an internal module root (`crate::domain`, `backend::outbound`,
+  etc.) or an external crate root (first segment not
+  `crate/self/super/backend`). It then compares against per-layer forbidden
+  roots and emits one violation per file per unique message.
+  [^4]
+- It infers layer from the first path component under `backend/src` and errors
+  if it cannot infer. [^4]
+- Its unit tests demonstrate both internal and external violations.
+  [^4]
+
+False-positive/false-negative risks (and how Whitaker improves):
+
+- Lexical segment matching can mis-handle renamed imports, glob imports, or
+  local modules shadowing crate names. A rustc-based lint can use HIR
+  resolution to identify whether a path resolves to an external crate or a
+  local module. Late linting provides symbol information not available in early
+  passes. [^3]
+- Conversely, macro-generated imports may appear only after expansion; since
+  the intent is “architectural reality”, Whitaker should run post-expansion
+  (early/late), not pre-expansion, so it sees the actual expanded module graph.
+
+Phase and type info:
+
+- Recommended: **Late lint** for best precision (HIR + resolution). The
+  boundary rule is structural, but resolution accuracy matters enough to
+  justify late. [^3]
+- Type info: not required, but symbol resolution is highly desirable.
+
+Config example (Wildside-equivalent policy):
+
+```toml
+[workspace.metadata.whitaker.lints.arch_hexagonal_layer_boundary]
+root = "backend/src"
+layers = ["domain", "inbound", "outbound"]
+
+forbid_internal = { domain = ["inbound", "outbound"], inbound = ["outbound"], outbound = ["inbound"] }
+
+forbid_external = {
+  domain = ["diesel", "utoipa", "actix_web", "awc"],
+  inbound = ["diesel"],
+  outbound = ["actix_web", "awc"],
+}
+```
+
+Diagnostics/messages:
+
+- Mirror Wildside’s human-readable messages for familiarity:
+  - `domain module must not depend on crate::outbound`
+  - `inbound module must not depend on external crate 'diesel'`
+    [^4]
+- Add structured notes:
+  - Inferred layer (domain/inbound/outbound)
+  - Reference kind (use-path vs type-path vs expr-path)
+  - If available, resolved `DefId` / crate of origin.
+
+Autofix feasibility:
+
+- No safe autofix.
+
+Test plan:
+
+- Port Wildside’s test cases nearly verbatim into Dylint UI test fixtures:
+  - inbound importing `crate::domain::UserId` → ok
+  - inbound importing `crate::outbound::…` → fail
+  - inbound importing `diesel::prelude::*` → fail
+  - domain importing `utoipa::ToSchema` → fail [^4]
+- Add additional cases validating resolution improvements:
+  - `use diesel as db; use db::prelude::*;` should still fail.
+  - A local module called `diesel` should *not* be treated as external if it
+    resolves locally (resolution-based correctness).
+
+#### `whitaker::advisory_async_trait_clear_misuse`
+
+Purpose: provide low-confidence, non-blocking guidance where `#[async_trait]`
+usage is locally migratable to native async traits, without attempting
+whole-workspace auditing (explicitly excluded). The Axinite audit found that
+native async traits are not object-safe and that most uses are blocked by
+`dyn Trait` call sites; only a small subset was verified migratable.
+[^4]
+
+Scope:
+
+- Only flag cases meeting *all* of:
+  - `#[async_trait]` appears on a trait definition or impl in the current crate,
+  - the trait is not used as a trait object (`dyn Trait`) within the current
+    crate (best-effort), and
+  - the trait is crate-private (or otherwise clearly local), reducing public
+    API churn risks.
+
+False-positive risks:
+
+- Trait-object usage may exist in downstream crates, or behind feature gates,
+  or in rarely compiled targets. Without whole-workspace analysis, the lint
+  must remain advisory and conservative. [^4]
+- `async-trait` imposes a default `Send` bound behaviour; native async traits
+  do not automatically impose equivalent bounds, so naive migration guidance
+  can be wrong. The migration plan explicitly calls this out as a risk.
+  [^4]
+
+Phase and type info:
+
+- Detection of `#[async_trait]` likely requires **pre-expansion linting**
+  (attribute macro), because the attribute macro expands away. Dylint supports
+  pre-expansion lints. [^1]
+- To check local `dyn Trait` usage robustly, use a **late pass** as a
+  second-stage analysis: record candidate traits in pre-expansion, then in late
+  lint evaluate whether there are `TyKind::Dynamic` uses referencing that
+  trait’s `DefId`. (This is a two-phase implementation inside one library.)
+
+Config example:
+
+```toml
+[workspace.metadata.whitaker.lints.advisory_async_trait_clear_misuse]
+mode = "conservative"              # "off" | "conservative" | "aggressive"
+max_suggestions_per_crate = 10
+ignore_traits = ["Tool", "Database"]  # known dyn-backed traits
+```
+
+Diagnostics/messages:
+
+- `async-trait appears migratable: trait '{TraitName}' is not used as dyn
+  Trait in this crate`
+- Notes:
+  - remind about `Send` semantics and object safety (link to internal migration
+    guidance)
+  - recommend verifying with `cargo check` and relevant feature combinations
+    (because feature-gated `dyn` use can exist). [^4]
+
+Autofix feasibility:
+
+- Not safe; too many semantic constraints (object safety, `Send`, return type
+  syntax). The best output is a structured suggestion describing the manual
+  steps, and explicitly marking it advisory.
+
+Test plan:
+
+- Fixtures:
+  - A private trait `#[async_trait] trait Foo { async fn f(&self); }` used only
+    concretely → advisory triggers.
+  - Same trait used as `Box<dyn Foo>` → no advisory.
+  - A public dyn-backed trait listed in `ignore_traits` → no advisory.
+- Include a regression check that the lint does not trigger on known dyn-heavy
+  patterns (consistent with Axinite’s classification). [^4]
+
+## cargo-compile-hygiene design
+
+### Tool shape and why it is a Cargo subcommand
+
+Cargo explicitly supports third-party tooling via custom subcommands, and it
+provides `cargo metadata` for machine-readable workspace structure and
+dependency graphs. [^2]
+
+Therefore, implement as a `cargo` plugin:
+
+- Binary name: `cargo-compile-hygiene`
+- User-facing invocation: `cargo compile-hygiene …`
+- Implementation language: Rust, using the `cargo_metadata` crate to parse
+  `cargo metadata` output. Cargo docs recommend `--format-version`, and the
+  `cargo_metadata` crate is the standard Rust API for parsing the JSON.
+  [^2]
+
+### Commands and CLI UX
+
+Proposed subcommands:
+
+- `cargo compile-hygiene check`  
+  Run all checks and return exit status based on configured severities.
+- `cargo compile-hygiene check --json`  
+  Emit machine-readable JSON report for CI dashboards.
+- `cargo compile-hygiene explain <finding-id>`  
+  Print an expanded explanation and “how to fix” guidance.
+- `cargo compile-hygiene baseline --write`  
+  Record current metrics (test target count, duplicates, heavy deps) into a
+  baseline file for regression detection.
+
+Core flags:
+
+- `--manifest-path …` (pass-through to Cargo conventions)
+- `--features …`, `--all-features`, `--no-default-features` (passed to
+  `cargo metadata` / to `cargo` feature selection, used to model feature-matrix
+  behaviour)
+- `--target …` and `--filter-platform …` where applicable (Cargo supports
+  `--filter-platform` for `cargo metadata`). [^2]
+
+### Inputs and data sources
+
+Primary inputs:
+
+- Workspace `Cargo.toml` (for `[workspace.metadata.whitaker]` and workspace
+  member discovery).
+- `cargo metadata --format-version 1` output (packages, targets, resolved
+  dependency graph). Cargo documents the JSON output and recommends
+  `--format-version`. [^2]
+
+Secondary inputs (optional enhancements; not required for initial MVP):
+
+- `cargo tree -d` for human debugging, but the tool should not shell out; it
+  should compute duplicates directly from metadata. Cargo’s docs explain that
+  duplicates matter for build time and show how `--duplicates` highlights them.
+  [^2]
+
+### Checks
+
+#### `integration_target_budget`
+
+What it checks:
+
+- Count integration test targets per package (targets with kind `"test"` and
+  src paths under `tests/`).
+- Flag packages exceeding `max_integration_tests_per_package` (default example:
+  12), and flag workspaces exceeding `max_integration_tests_total` (default
+  example: 60).
+
+Why it matters:
+
+- Cargo compiles each integration test file as a separate crate/executable, and
+  Cargo notes that many such crates can be inefficient and recommends
+  consolidating into fewer targets split into modules. [^2]
+- Axinite’s measured hot path was “re-links N test binaries,” and its
+  consolidation plan reduces test binaries by grouping modules under fewer
+  harnesses. [^4]
+- Gauss’s consolidation plan shows the organisational vs compile-time
+  trade-off: a naming convention improves discoverability but does not reduce
+  target count, so this check should focus on target counts rather than file
+  naming aesthetics. [^4]
+
+Implementation sketch:
+
+- In `cargo_metadata::Metadata`, iterate `packages[].targets[]` and filter
+  where `kind` contains `"test"` and `src_path` includes `/tests/`.
+- Group by package ID; count.
+
+Config schema example:
+
+```toml
+[workspace.metadata.whitaker.compile_hygiene.integration_target_budget]
+max_integration_tests_per_package = 12
+max_integration_tests_total = 80
+ignore = [
+  { package = "ironclaw", target = "html_to_markdown", reason = "required-features gated" }
+]
+```
+
+Outputs:
+
+- Human report includes top offending packages, counts, and suggested
+  consolidation strategy referencing Cargo’s recommended approach.
+  [^2]
+
+#### `heavy_dependency_not_optional`
+
+What it checks:
+
+- Direct dependencies that have a transitive footprint above a threshold
+  (default example: `transitive_crates >= 100`) and are not optional / not
+  feature-gated according to policy.
+
+Why it matters:
+
+- Axinite identified heavyweight always-compiled dependencies (e.g., wasmtime
+  ecosystem, bollard) and proposed feature gating to make them optional for
+  developers not working on those areas.
+  [^4]
+
+Implementation sketch:
+
+- Build a package dependency graph from `metadata.resolve`.
+- For each workspace member package, evaluate each direct dependency edge in
+  `packages[].dependencies`:
+  - Compute reachable node count from that dependency node (unique package IDs).
+  - Determine whether the dependency is optional:
+    - In manifest: dependency `optional = true` (available via `cargo metadata`
+      packages reproduction of `Cargo.toml` fields), or
+    - In Whitaker policy mapping: heavy deps list with expected feature.
+- Emit finding if “heavy” + “not optional” + “not in allowlist”.
+
+Config schema example:
+
+```toml
+[workspace.metadata.whitaker.compile_hygiene.heavy_dependency_not_optional]
+heavy_threshold_transitive_crates = 100
+heavy_deps = { wasmtime = "wasm", bollard = "docker", pdf_extract = "pdf" }
+allow = [
+  { package = "gauss", dep = "gpui", reason = "app crate" }
+]
+```
+
+Outputs:
+
+- Provide transitive count, and a “how to fix” note: make dep optional + gate
+  behind feature + rerun feature matrix.
+
+#### `duplicate_major_version_hotspots`
+
+What it checks:
+
+- Packages present in multiple versions in the resolved graph (same name,
+  different `semver`), especially major-version duplicates.
+
+Why it matters:
+
+- Cargo’s own docs note that avoiding building a package multiple times can
+  benefit build times and executable sizes, and `cargo tree --duplicates`
+  exists to identify duplicates. [^2]
+- Axinite observed many duplicated core stacks (HTTP/TLS and other ecosystem
+  crates) due to a heavy dependency pulling an older stack.
+  [^4]
+
+Implementation sketch:
+
+- From `metadata.packages`, group by `name`, list distinct versions. Flag if >1.
+- Compute severity score:
+  - Weight by number of distinct major versions.
+  - Weight by “fan-in” (how many nodes depend on each version) using
+    `resolve.nodes` reverse edges.
+- Optionally compute “hotspot explanation” paths (minimal path to root) to help
+  remediation.
+
+Config schema example:
+
+```toml
+[workspace.metadata.whitaker.compile_hygiene.duplicate_major_version_hotspots]
+max_duplicates_per_crate = 1         # allow at most 1 version
+prefer_report_top_n = 25
+ignore = ["hashbrown"]              # example: if ecosystem reality makes it noisy
+```
+
+Outputs:
+
+- Include top N duplications with versions and likely introducers.
+- Provide hints: update the older dependency; align feature flags; consider
+  dependency replacement.
+
+#### `tls_backend_multiplicity`
+
+What it checks:
+
+- Whether both major TLS backend stacks are present in the build graph at once
+  (heuristic: presence of both `rustls`-family packages and
+  `native-tls`/`openssl-sys`).
+
+Why it matters:
+
+- Axinite identified both rustls and native-tls being compiled due to
+  conflicting reqwest feature selections, and noted that native-tls can pull in
+  C compilation (openssl-sys), increasing build time variability and cost.
+  [^4]
+
+Implementation sketch:
+
+- Define backend signatures:
+  - rustls: package names matching `rustls`, `tokio-rustls`, `hyper-rustls`,
+    etc.
+  - native/openssl: `native-tls`, `openssl`, `openssl-sys`, etc.
+- Flag if both non-empty sets appear in the resolved graph for the same feature
+  configuration.
+
+Feature-matrix note:
+
+- `cargo metadata` feature reporting can be tricky in workspaces; the tool
+  should therefore run in each CI feature configuration (default,
+  no-default-features+selected minimal, all-features), mirroring the same
+  invocation patterns used for build/test. (Cargo issues discuss how resolved
+  features may be aggregated across workspace members, so treat
+  per-configuration runs as the unit of truth.) [^2]
+
+Config schema example:
+
+```toml
+[workspace.metadata.whitaker.compile_hygiene.tls_backend_multiplicity]
+deny_if_both_present = true
+rustls_markers = ["rustls", "tokio-rustls"]
+native_markers = ["native-tls", "openssl-sys"]
+```
+
+Outputs:
+
+- “Both TLS stacks detected: rustls (N crates) and native-tls/openssl (M
+  crates).”
+- Show a short list of introducer packages (reverse dependency roots).
+
+#### `package_boundary_purity`
+
+What it checks:
+
+- Package-level “purity” constraints: certain packages must not depend on
+  certain crates, matching architectural boundaries that should be visible at
+  the Cargo graph level (stronger than source-only checks).
+
+Why it matters:
+
+- Gauss’s crate split explicitly requires `gauss-core` and `gauss-svg` to
+  remain GPUI-independent; the split’s value depends on preventing UI deps from
+  re-entering core crates. [^4]
+
+Implementation sketch:
+
+- For each configured package rule, examine its resolved dependencies (direct
+  and/or transitive) and fail if any forbidden package names appear.
+- Provide two modes:
+  - direct-only (fast, less strict)
+  - transitive (stronger, default for “no gpui in core”)
+
+Config schema example:
+
+```toml
+[workspace.metadata.whitaker.compile_hygiene.package_boundary_purity]
+rules = [
+  { package = "gauss-core", forbid = ["gpui", "gpui-component", "accesskit"], transitive = true },
+  { package = "gauss-svg", forbid = ["gpui", "gpui-component", "accesskit"], transitive = true },
+]
+```
+
+Outputs:
+
+- List the forbidden package found and the shortest path
+  (`gauss-core -> … -> gpui`), using metadata graph traversal.
+
+### Output formats and example reports
+
+Human-readable (default):
+
+```text
+cargo-compile-hygiene report (features: default; target: host)
+- integration_target_budget: FAIL
+  ironclaw: 43 integration test targets (budget: 12). Suggest consolidating under fewer harnesses.
+- heavy_dependency_not_optional: WARN
+  ironclaw: wasmtime (≈300 transitive crates) is non-optional. Expected feature gate: wasm.
+- duplicate_major_version_hotspots: WARN
+  rustls: versions 0.22.x, 0.23.x present (major duplicates); likely introduced via libsql stack.
+- tls_backend_multiplicity: FAIL
+  rustls and native-tls/openssl detected concurrently. Investigate reqwest default-features mismatch.
+- package_boundary_purity: PASS
+```
+
+JSON (`--json`):
+
+- A single JSON object containing:
+  - `invocation`: manifest path, feature flags, target/filter platform,
+    timestamp
+  - `findings`: array of typed findings with IDs, severity, summary, details,
+    and suggested remediation
+  - `metrics`: counts (targets, duplicates, heavy deps)
+
+CI integration:
+
+- Exit codes:
+  - 0 if no findings above configured failure threshold.
+  - 1 if any `deny` findings (or configured levels) exist.
+
+This aligns with standard CLI tooling expectations and Cargo subcommand
+ergonomics. [^2]
+
+## Integration, CI, and rollout
+
+### Component interaction and data flow
+
+```mermaid
+flowchart LR
+  Dev[Developer / CI runner] -->|cargo dylint --all| Dylint[cargo-dylint + Dylint driver]
+  Dev -->|cargo compile-hygiene check| CCH[cargo-compile-hygiene]
+
+  Dylint -->|rustc callback registers lints| Rustc[rustc]
+  Rustc -->|HIR/AST/attrs| Whitaker[Whitaker Dylint library]
+
+  CCH -->|cargo metadata --format-version 1| CargoMeta[cargo metadata JSON]
+  CCH -->|read workspace metadata| CargoToml[Cargo.toml workspace.metadata]
+
+  Whitaker -->|read config| CargoToml
+  CCH -->|read config| CargoToml
+
+  Whitaker --> Findings[Diagnostics / lint output]
+  CCH --> Report[Text/JSON report]
+```
+
+Dylint runs lints from dynamic libraries by registering them with `rustc` via a
+driver; its architecture mirrors the “driver wraps rustc” model used by Clippy,
+and it shares compilation work across lints compiled for the same toolchain.
+[^1]
+
+Cargo-compile-hygiene uses Cargo’s external tool facilities: custom subcommands
+plus `cargo metadata` JSON. Cargo recommends passing `--format-version` because
+output can evolve. [^2]
+
+### Invocation patterns and feature-matrix handling
+
+Because both code-level and graph-level findings can vary with features,
+enforce under a feature matrix aligned with existing project practices:
+
+- **default features** (baseline developer experience)
+- **no-default-features + minimal feature set** (ensures optional heavy
+  subsystems are truly optional)
+- **all-features** (ensures full product surface still compiles)
+
+This mirrors Axinite’s gating plans and is a necessary companion to feature
+islands. [^4]
+
+Example CI (pseudo-commands):
+
+```bash
+# Whitaker lints across all targets
+cargo dylint --all -- --all-targets
+
+cargo dylint --all -- --all-targets --no-default-features --features "libsql,test-helpers"
+cargo dylint --all -- --all-targets --all-features --features "test-helpers"
+
+# Graph hygiene checks (same matrix)
+cargo compile-hygiene check
+cargo compile-hygiene check --no-default-features --features "libsql,test-helpers"
+cargo compile-hygiene check --all-features --features "test-helpers"
+```
+
+Cargo’s own documentation explains integration targets and `tests/` behaviour;
+running with `--all-targets` ensures non-default targets
+(examples/tests/benches) are included, matching the practical locations where
+boundary violations often hide. [^2][^3]
+
+### Comparison table: what belongs where
+
+| Check / policy | Whitaker (Dylint) | cargo-compile-hygiene | Repo-specific checker | Rationale |
+| --- | ---: | ---: | ---: | --- |
+| `forbidden_external_crate_in_layer` | ✅ | ❌ | ❌ | Needs per-use resolution and file/layer mapping inside rustc; best expressed as a lint. [^3] |
+| `public_api_leaks_optional_dep` | ✅ | ❌ | ❌ | Requires type-level inspection of exported signatures; late lint. [^3] |
+| `feature_island_breach` | ✅ | ❌ | ❌ | Needs source location + cfg context; best enforced in lint passes. [^1] |
+| `ui_test_macro_outside_app` | ✅ | ❌ | ❌ | Detects attribute macro usage; requires pre-expansion linting. [^1] |
+| `hexagonal_layer_boundary` | ✅ | ❌ | ❌ | Architectural boundary rule-set; Dylint improves Wildside’s lexical approach via resolution. [^4][^3] |
+| `async_trait_clear_misuse` (advisory) | ✅ | ❌ | ❌ | Code-level advisory; whole-workspace audit excluded. [^4] |
+| `integration_target_budget` | ❌ | ✅ | ❌ | Depends on targets and package graph; Cargo metadata. [^2] |
+| `heavy_dependency_not_optional` | ❌ | ✅ | ❌ | Depends on resolved dependency graph + optionality. [^2] |
+| `duplicate_major_version_hotspots` | ❌ | ✅ | ❌ | Graph-level duplicate analysis; matches `cargo tree --duplicates` intent. [^2] |
+| `tls_backend_multiplicity` | ❌ | ✅ | ❌ | Graph-level presence of TLS stacks; depends on resolved deps per feature config. [^4] |
+| `package_boundary_purity` | ❌ | ✅ | ❌ | Package dependency purity is a Cargo graph property; complements Whitaker. [^4] |
+| Redundant `make` pipelines (e.g., `check` + `clippy`) | ❌ | ❌ | ✅ | Not a Rust/Cargo semantic issue; a repo build orchestration issue. [^4] |
+
+### Rollout timeline
+
+```mermaid
+gantt
+  title Whitaker + cargo-compile-hygiene rollout
+  dateFormat  YYYY-MM-DD
+  axisFormat  %d %b
+
+  section Foundation
+  Define shared config schema (workspace.metadata.whitaker) :a1, 2026-03-25, 7d
+  Wire Dylint library loading via workspace.metadata.dylint :a2, 2026-03-25, 7d
+  Implement cargo-compile-hygiene skeleton + metadata parsing :a3, 2026-03-25, 10d
+
+  section Whitaker MVP lints
+  arch_hexagonal_layer_boundary (port Wildside) :b1, 2026-04-01, 14d
+  hygiene_public_api_leaks_optional_dep :b2, 2026-04-05, 14d
+  tests_ui_test_macro_outside_app (pre-expansion) :b3, 2026-04-08, 10d
+
+  section cargo-compile-hygiene MVP checks
+  integration_target_budget :c1, 2026-04-01, 7d
+  duplicate_major_version_hotspots :c2, 2026-04-03, 7d
+  heavy_dependency_not_optional :c3, 2026-04-05, 10d
+  tls_backend_multiplicity :c4, 2026-04-10, 7d
+  package_boundary_purity :c5, 2026-04-10, 7d
+
+  section Stabilization
+  CI feature matrix integration + baseline reports :d1, 2026-04-15, 10d
+  Developer docs + suppression guidance :d2, 2026-04-15, 7d
+  Promote selected lints from warn to deny :d3, 2026-04-22, 7d
+```
+
+The emphasis is to land hard-boundary lints early (architectural contracts) and
+keep compile-time hygiene checks initially as warning/reporting, then promote
+once noise is understood. This matches the risk profile implied by Rust lint
+levels and the desire to avoid warning fatigue. [^3]
+
+## Migration guidance for Axinite and Gauss
+
+### Axinite migration steps (concrete)
+
+Axinite’s build-time investigation identifies: many integration test binaries;
+always-compiled heavy dependencies intended to be optional (wasmtime, bollard,
+pdf); duplicate dependency stacks; and TLS backend multiplicity.
+[^4]
+
+A practical migration sequence:
+
+1. **Introduce `cargo-compile-hygiene` in “report-only” mode**  
+   Configure budgets and heavy deps list but do not fail CI immediately. Record
+   a baseline report for default features and the minimal feature set. (Cargo
+   supports external tools and versioned metadata output; use
+   `--format-version 1`.) [^2]
+
+2. **Enforce `integration_target_budget`**  
+   Set a target budget that reflects post-consolidation expectations. Axinite
+   already has a plan that reduced test binaries substantially by grouping into
+   fewer harnesses. Make the budget slightly above the achieved count to allow
+   small growth. [^4]
+
+   Example config:
+
+   ```toml
+   [workspace.metadata.whitaker.compile_hygiene.integration_target_budget]
+   max_integration_tests_per_package = 12
+   ```
+
+3. **Adopt feature islands** (`wasm`, `docker`, `pdf`, `cli`) and enforce with
+   Whitaker  
+   Axinite has explicit feature-gating plans for wasmtime (`wasm`) and bollard
+   (`docker`). Implement the Cargo feature gates, then add Whitaker’s
+   `feature_island_breach` and `public_api_leaks_optional_dep` to prevent
+   regressions. [^4]
+
+   Example islands config:
+
+   ```toml
+   [workspace.metadata.whitaker.lints.hygiene_feature_island_breach]
+   islands = [
+     { name = "wasm", feature = "wasm", crate_roots = [
+       "wasmtime", "wasmtime_wasi", "wasmparser",
+     ], allowed_paths = ["src/tools/wasm/", "src/channels/wasm/"] },
+     { name = "docker", feature = "docker", crate_roots = ["bollard"],
+       allowed_paths = ["src/sandbox/", "src/orchestrator/"] },
+   ]
+   ```
+
+4. **Enable `tls_backend_multiplicity`**  
+   Once feature sets stabilise, make that check a failure in CI for default
+   features if the project intends to standardise on one TLS backend. Axinite
+   explicitly observed dual stacks due to conflicting reqwest defaults.
+   [^4]
+
+5. **Track duplicates as hotspots, not “must fix”**  
+   Axinite’s duplicate stacks are partly upstream (libsql pulling older
+   ecosystems). Use `duplicate_major_version_hotspots` to surface and rank
+   them, but keep failures off unless you have a realistic remediation path.
+   Cargo’s docs frame duplicates as something to identify and investigate; they
+   do not guarantee easy resolution. [^2][^4]
+
+6. **Keep async-trait migration lint advisory**  
+   Axinite’s own audit shows most async-trait uses are blocked by trait-object
+   patterns; enforce neither a deny lint nor a cargo-level audit (excluded).
+   Only ship `async_trait_clear_misuse` as advisory with a conservative mode.
+   [^4]
+
+### Gauss migration steps (concrete)
+
+Gauss’s crate split is complete and establishes a clear graph: `gauss` (app)
+depends on `gauss-core` and `gauss-svg`, and `gauss-svg` depends on
+`gauss-core`, with the goal that core/SVG do not compile GPUI.
+[^4]
+
+A Gauss-focused migration sequence:
+
+1. **Lock package boundary purity in cargo-compile-hygiene**  
+   Immediately set `package_boundary_purity` rules for `gauss-core` and
+   `gauss-svg` to forbid `gpui`, `gpui-component`, and `accesskit`
+   transitively. This preserves the primary benefit of the split.
+   [^4]
+
+2. **Add Whitaker UI test macro confinement**  
+   Enforce `ui_test_macro_outside_app` so `#[gpui::test]` can never appear
+   outside the app crate, consistent with planned test relocation and crate
+   purity. [^4]
+
+3. **Treat integration test target budgets cautiously**  
+   Gauss’s integration-test consolidation plan ended up preserving target
+   counts for pragmatic reasons (naming convention instead of module
+   consolidation). If you later decide build-time reductions matter more than
+   isolation, set budgets that reflect a desired future state and use the
+   tool’s reporting to drive an incremental consolidation project.
+   [^4]
+
+4. **Add architectural lints only where architecture is explicit**  
+   If Gauss has explicit layer boundaries akin to Wildside’s
+   domain/inbound/outbound model, adopt `hexagonal_layer_boundary`. Otherwise,
+   keep Whitaker’s layering rules focused on “GPUI must not leak into core/SVG”
+   and on optional heavy features (if any). Wildside’s success rests on
+   path-based layer inference and explicit forbidden root lists.
+   [^4]
+
+### Example combined config snippets
+
+Gauss (workspace root):
+
+```toml
+[workspace.metadata.dylint]
+libraries = [{ path = "tools/whitaker" }]
+
+[workspace.metadata.whitaker.compile_hygiene.package_boundary_purity]
+rules = [
+  { package = "gauss-core", forbid = ["gpui", "gpui-component", "accesskit"], transitive = true },
+  { package = "gauss-svg", forbid = ["gpui", "gpui-component", "accesskit"], transitive = true },
+]
+
+[workspace.metadata.whitaker.lints.tests_ui_test_macro_outside_app]
+app_packages = ["gauss"]
+forbid_attributes = ["gpui::test"]
+```
+
+Axinite (workspace root), illustrative additions:
+
+```toml
+[workspace.metadata.whitaker.compile_hygiene.integration_target_budget]
+max_integration_tests_per_package = 12
+
+[workspace.metadata.whitaker.compile_hygiene.heavy_dependency_not_optional]
+heavy_threshold_transitive_crates = 100
+heavy_deps = { wasmtime = "wasm", bollard = "docker" }
+
+[workspace.metadata.whitaker.compile_hygiene.tls_backend_multiplicity]
+deny_if_both_present = true
+rustls_markers = ["rustls"]
+native_markers = ["native-tls", "openssl-sys"]
+```
+
+These examples deliberately leave numeric thresholds adjustable; they
+illustrate the default shape rather than asserting a single “correct” budget.
+Cargo’s manifest metadata mechanism exists precisely to support that sort of
+tool configuration. [^2]
+
+## References
+
+[^1]: Dylint references covering the execution model, `rustc_private` coupling,
+      configuration, conditional compilation, pre-expansion lints, and
+      `dylint_linting` support.
+      <https://blog.trailofbits.com/2021/11/09/write-rust-lints-without-forking-clippy/>
+      <https://github.com/trailofbits/dylint>
+      <https://docs.rs/crate/dylint_linting/latest>
+      <https://docs.rs/dylint_uitesting>
+[^2]: Cargo documentation covering external tools, `cargo metadata`, target
+      structure, manifest metadata, duplicate-tree inspection, and per-feature
+      graph analysis.
+      <https://doc.rust-lang.org/cargo/reference/external-tools.html>
+      <https://doc.rust-lang.org/cargo/commands/cargo-metadata.html>
+      <https://doc.rust-lang.org/cargo/reference/cargo-targets.html?utm_source=chatgpt.com>
+      <https://doc.rust-lang.org/cargo/reference/manifest.html>
+      <https://dev-doc.rust-lang.org/beta/cargo/commands/cargo-tree.html>
+[^3]: Rust compiler and Clippy development references covering tool-lint
+      registration, lint stores, lint levels, late versus early passes, and
+      type-checking context.
+      <https://doc.rust-lang.org/beta/nightly-rustc/rustc_session/macro.declare_tool_lint.html>
+      <https://github.com/rust-lang/rustc-dev-guide/blob/main/src/diagnostics/lintstore.md?plain=1>
+      <https://doc.rust-lang.org/rustc/lints/levels.html>
+      <https://doc.rust-lang.org/stable/clippy/development/lint_passes.html?utm_source=chatgpt.com>
+      <https://docs.adacore.com/live/wave/rust/html/rust_ug/_static/clippy/development/type_checking.html?utm_source=chatgpt.com>
+      <https://github.com/rust-lang/rust-clippy>
+[^4]: Repository evidence from Wildside, Axinite, and Gauss used to motivate
+      the lint split, package-boundary rules, feature islands, and advisory
+      `async-trait` hygiene.
+      <https://github.com/leynos/wildside/blob/main/docs/rfcs/0001-wildside-architecture-boundary-lint.md>
+      <https://github.com/leynos/wildside/blob/main/src/architecture_boundary.rs>
+      <https://github.com/leynos/axinite/blob/main/docs/execplans/compile-time-hygiene.md>
+      <https://github.com/leynos/axinite/blob/main/docs/execplans/consolidate-test-binaries.md>
+      <https://github.com/leynos/axinite/blob/main/docs/execplans/wasm-feature-island.md>
+      <https://github.com/leynos/axinite/blob/main/docs/execplans/docker-feature-island.md>
+      <https://github.com/leynos/axinite/blob/main/docs/execplans/async-trait-audit.md>
+      <https://github.com/leynos/gauss/blob/main/docs/crate-split.md>
+      <https://github.com/leynos/gauss/blob/main/docs/integration-test-layout.md>
+      <https://github.com/leynos/gauss/blob/main/docs/svg-core-boundary.md>

--- a/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
+++ b/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
@@ -18,7 +18,7 @@ duplicate version hotspots, TLS backend multiplicity, and package boundary
 purity). [^2][^1]
 
 Both tools share configuration via `Cargo.toml` workspace metadata (and
-optionally `dylint.toml`/`dylint.toml`-style tables for Dylint), enabling a
+optionally `dylint.toml`/`whitaker.toml`-style tables for Dylint), enabling a
 single policy source of truth (layer definitions, forbidden dependencies,
 feature “islands”, thresholds). Cargo explicitly supports third-party tooling
 via (a) `cargo metadata`, (b) stable JSON message formats, and (c) custom
@@ -1291,7 +1291,7 @@ tool configuration. [^2]
       graph analysis.
       <https://doc.rust-lang.org/cargo/reference/external-tools.html>
       <https://doc.rust-lang.org/cargo/commands/cargo-metadata.html>
-      <https://doc.rust-lang.org/cargo/reference/cargo-targets.html?utm_source=chatgpt.com>
+      <https://doc.rust-lang.org/cargo/reference/cargo-targets.html>
       <https://doc.rust-lang.org/cargo/reference/manifest.html>
       <https://dev-doc.rust-lang.org/beta/cargo/commands/cargo-tree.html>
 [^3]: Rust compiler and Clippy development references covering tool-lint
@@ -1300,8 +1300,8 @@ tool configuration. [^2]
       <https://doc.rust-lang.org/beta/nightly-rustc/rustc_session/macro.declare_tool_lint.html>
       <https://github.com/rust-lang/rustc-dev-guide/blob/main/src/diagnostics/lintstore.md?plain=1>
       <https://doc.rust-lang.org/rustc/lints/levels.html>
-      <https://doc.rust-lang.org/stable/clippy/development/lint_passes.html?utm_source=chatgpt.com>
-      <https://docs.adacore.com/live/wave/rust/html/rust_ug/_static/clippy/development/type_checking.html?utm_source=chatgpt.com>
+      <https://doc.rust-lang.org/stable/clippy/development/lint_passes.html>
+      <https://docs.adacore.com/live/wave/rust/html/rust_ug/_static/clippy/development/type_checking.html>
       <https://github.com/rust-lang/rust-clippy>
 [^4]: Repository evidence from Wildside, Axinite, and Gauss used to motivate
       the lint split, package-boundary rules, feature islands, and advisory

--- a/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
+++ b/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
@@ -28,8 +28,7 @@ tools. [^2]
 The design is driven by the concrete failures seen in Axinite and Gauss:
 repeated link/compile work due to many integration test crates, always-compiled
 heavy optional dependencies, duplicate dependency stacks, and package boundary
-contamination (notably UI dependencies leaking into “core” layers).
-[^4]
+contamination (notably UI dependencies leaking into “core” layers). [^4]
 
 Non-goals: debuginfo/profile tuning (explicitly out of scope), UI feature
 auditing, and whole-workspace async-trait migration auditing (both explicitly
@@ -67,15 +66,13 @@ The goals therefore separate cleanly into two enforcement planes:
   optional deps; feature-gated “islands” remain bounded; UI test harness macros
   do not appear in non-app crates). This is Whitaker’s remit, implemented as
   Dylint lints. Dylint runs lints loaded from dynamic libraries, and—like
-  Clippy—operates by registering lint passes with `rustc`.
-  [^1]
+  Clippy—operates by registering lint passes with `rustc`. [^1]
 
 - **Plane B (workspace graph / Cargo metadata):** enforce packaging-and-graph
   constraints (how many test targets; duplicate versions; heavy dependency
   “optionality”; TLS backend multiplicity; package boundary purity). This is
   `cargo-compile-hygiene`’s remit, implemented using `cargo metadata`’s JSON.
-  Cargo recommends using `--format-version` to stabilise expectations.
-  [^2]
+  Cargo recommends using `--format-version` to stabilise expectations. [^2]
 
 A critical design constraint: Dylint’s lints rely on `rustc` internal APIs (as
 Clippy does), so Whitaker must be versioned and maintained with the Rust
@@ -109,8 +106,7 @@ Whitaker should therefore adopt a two-tier configuration model:
   `[workspace.metadata.whitaker.lints.<lint>]`, or (b) expose a Dylint-native
   `dylint.toml` configuration table keyed by library name, as Dylint supports
   configurable libraries. For multi-lint libraries, Dylint’s `dylint_linting`
-  utilities require an explicit `register_lints` and `init_config` call.
-  [^1]
+  utilities require an explicit `register_lints` and `init_config` call. [^1]
 
 ### Whitaker lint namespaces and naming conventions
 
@@ -138,8 +134,7 @@ Discovery/navigation guidance:
   model described in the compiler dev guide.) [^3]
 - Default “developer local” guidance: enable `whitaker::arch_*` and
   `whitaker::hygiene_*` at `warn` locally, escalate in CI. Rust supports
-  multiple lint levels and configuration via attributes and CLI flags.
-  [^3]
+  multiple lint levels and configuration via attributes and CLI flags. [^3]
 
 ### Severity levels and build gating
 
@@ -152,8 +147,7 @@ levels):
 
 - **hard policy (default `deny`):** architectural boundary violations that
   should never ship (e.g., a “domain” layer importing infrastructure crates, or
-  `gauss-core` importing `gpui`). These should fail CI by default.
-  [^3][^4]
+  `gauss-core` importing `gpui`). These should fail CI by default. [^3][^4]
 - **soft policy (default `warn`):** compile-time hygiene issues that merit
   action but may have local exceptions (e.g., a public API uses an optional dep
   type in a non-critical surface; a feature-island rule triggers in
@@ -164,8 +158,7 @@ levels):
 
 This separation aligns with the Rust community’s broader warning-fatigue
 concerns: warnings should remain meaningful and not drown developers; hard
-failures should be reserved for clear architectural contracts.
-[^3]
+failures should be reserved for clear architectural contracts. [^3]
 
 ### Feature-matrix and “unknown lint” ergonomics
 
@@ -197,8 +190,7 @@ Whitaker is a **single Dylint library** named `whitaker` (crate name
 `whitaker_lints` or similar), exporting multiple lints. Because Dylint’s macro
 helpers vary between single-lint libraries and multi-lint libraries, Whitaker
 should implement an explicit `register_lints(sess, lint_store)` and call
-`dylint_linting::init_config(sess)` before reading configuration.
-[^1]
+`dylint_linting::init_config(sess)` before reading configuration. [^1]
 
 Whitaker will implement a mixture of:
 
@@ -208,8 +200,7 @@ Whitaker will implement a mixture of:
   where resolution suffices.
 - **Pre-expansion lints** for rules that must observe attribute-macro syntax
   prior to expansion. Dylint’s tooling explicitly supports
-  `declare_pre_expansion_lint!` / `impl_pre_expansion_lint!`.
-  [^1][^3]
+  `declare_pre_expansion_lint!` / `impl_pre_expansion_lint!`. [^1][^3]
 
 Rustc/Clippy guidance: a `LateLintPass` has access to type and symbol
 information that an `EarlyLintPass` does not. Most “semantic” lints should be
@@ -257,8 +248,7 @@ islands = [
 app_packages = ["gauss"] # only the app crate may contain gpui::test
 ```
 
-This uses Cargo’s manifest metadata facility for tool configuration.
-[^2]
+This uses Cargo’s manifest metadata facility for tool configuration. [^2]
 
 Where per-lint tunables need a Dylint-native `dylint.toml`, Whitaker can also
 expose:
@@ -271,8 +261,7 @@ policy_version = 1
 ```
 
 Dylint supports configurable libraries via `dylint.toml` keyed by library name,
-and `dylint_linting` provides config parsing helpers.
-[^1]
+and `dylint_linting` provides config parsing helpers. [^1]
 
 ### Lint designs
 
@@ -284,8 +273,7 @@ needs, config examples, diagnostics, autofix feasibility, and test plan.
 Purpose: enforce that specific layers (defined by package + path prefix) do not
 reference specific external crates. This is the “external-crate half” of
 Wildside’s architecture lint, and it is also useful for compile-time hygiene
-(“heavy deps should not be imported by most of the codebase”).
-[^4]
+(“heavy deps should not be imported by most of the codebase”). [^4]
 
 Scope: counts *resolved* uses of external crates in paths (`use`, type paths,
 expression paths), within files that Whitaker maps into a configured layer.
@@ -305,8 +293,7 @@ False-positive risks:
 Phase and type info:
 
 - Recommended: **Late lint** to use HIR and resolution. Late lints run on HIR
-  and have full type/symbol information; early lints do not.
-  [^3]
+  and have full type/symbol information; early lints do not. [^3]
 - HIR needs: path resolution (`Res::Def` / crate root), span-to-file mapping
   for layer inference.
 
@@ -432,8 +419,7 @@ Purpose: enforce that “heavy optional” subsystems remain confined to configu
 **feature islands**: code that depends on a heavy crate (or its transitive
 surface) must live under specific paths/modules and be guarded by
 `#[cfg(feature="…")]` as required. This operationalises Axinite’s `wasm`
-(wasmtime) and `docker` (bollard) feature-gating plans.
-[^4]
+(wasmtime) and `docker` (bollard) feature-gating plans. [^4]
 
 Scope:
 
@@ -480,11 +466,10 @@ cfg_allow_patterns = [
 Diagnostics/messages:
 
 - If outside allowed paths:
-  `feature-island '{island}' dependency '{crate}' used outside allowed paths
-  (expected under: …)`
+  `feature-island '{island}' dependency '{crate}' used outside allowed paths`
+  plus the configured expected path prefixes.
 - If missing cfg:
-  `feature-island '{island}' dependency '{crate}' used without
-  cfg(feature = "{feature}") guard`
+  `feature-island '{island}' dependency '{crate}' missing feature guard`
 - Include actionable hint: “wrap the module/function in `#[cfg(feature="…")]`
   or move this code under {allowed_paths[0]}”.
 
@@ -515,8 +500,7 @@ Purpose: enforce that UI integration testing harnesses (specifically
 `#[gpui::test]`) remain confined to app crates, preventing UI dependencies from
 creeping into pure crates and forcing expensive UI compilation during
 logic-only work. This supports Gauss’s package split goals and test relocation
-goals, where core/SVG crates must not pull GPUI.
-[^4]
+goals, where core/SVG crates must not pull GPUI. [^4]
 
 Scope:
 
@@ -578,8 +562,7 @@ inside Whitaker/Dylint:
 - forbid **external framework/infrastructure crates** per layer (e.g., domain
   must not depend on `diesel`, `utoipa`, `actix_web`, etc.)
 - infer layer membership from file path under a configured root, mirroring
-  Wildside’s `backend/src/{domain,inbound,outbound}/…` convention.
-  [^4]
+  Wildside’s `backend/src/{domain,inbound,outbound}/…` convention. [^4]
 
 This lint is the primary “architectural boundary” mechanism;
 `forbidden_external_crate_in_layer` is effectively its external-only subset and
@@ -597,8 +580,7 @@ Wildside baseline behaviour:
   indicates an internal module root (`crate::domain`, `backend::outbound`,
   etc.) or an external crate root (first segment not
   `crate/self/super/backend`). It then compares against per-layer forbidden
-  roots and emits one violation per file per unique message.
-  [^4]
+  roots and emits one violation per file per unique message. [^4]
 - It infers layer from the first path component under `backend/src` and errors
   if it cannot infer. [^4]
 - Its unit tests demonstrate both internal and external violations.
@@ -671,8 +653,7 @@ Purpose: provide low-confidence, non-blocking guidance where `#[async_trait]`
 usage is locally migratable to native async traits, without attempting
 whole-workspace auditing (explicitly excluded). The Axinite audit found that
 native async traits are not object-safe and that most uses are blocked by
-`dyn Trait` call sites; only a small subset was verified migratable.
-[^4]
+`dyn Trait` call sites; only a small subset was verified migratable. [^4]
 
 Scope:
 
@@ -690,8 +671,7 @@ False-positive risks:
   must remain advisory and conservative. [^4]
 - `async-trait` imposes a default `Send` bound behaviour; native async traits
   do not automatically impose equivalent bounds, so naive migration guidance
-  can be wrong. The migration plan explicitly calls this out as a risk.
-  [^4]
+  can be wrong. The migration plan explicitly calls this out as a risk. [^4]
 
 Phase and type info:
 
@@ -752,8 +732,7 @@ Therefore, implement as a `cargo` plugin:
 - User-facing invocation: `cargo compile-hygiene …`
 - Implementation language: Rust, using the `cargo_metadata` crate to parse
   `cargo metadata` output. Cargo docs recommend `--format-version`, and the
-  `cargo_metadata` crate is the standard Rust API for parsing the JSON.
-  [^2]
+  `cargo_metadata` crate is the standard Rust API for parsing the JSON. [^2]
 
 ### Commands and CLI UX
 
@@ -840,8 +819,7 @@ ignore = [
 Outputs:
 
 - Human report includes top offending packages, counts, and suggested
-  consolidation strategy referencing Cargo’s recommended approach.
-  [^2]
+  consolidation strategy referencing Cargo’s recommended approach. [^2]
 
 #### `heavy_dependency_not_optional`
 
@@ -855,8 +833,7 @@ Why it matters:
 
 - Axinite identified heavyweight always-compiled dependencies (e.g., wasmtime
   ecosystem, bollard) and proposed feature gating to make them optional for
-  developers not working on those areas.
-  [^4]
+  developers not working on those areas. [^4]
 
 Implementation sketch:
 
@@ -899,8 +876,7 @@ Why it matters:
   benefit build times and executable sizes, and `cargo tree --duplicates`
   exists to identify duplicates. [^2]
 - Axinite observed many duplicated core stacks (HTTP/TLS and other ecosystem
-  crates) due to a heavy dependency pulling an older stack.
-  [^4]
+  crates) due to a heavy dependency pulling an older stack. [^4]
 
 Implementation sketch:
 
@@ -939,8 +915,7 @@ Why it matters:
 
 - Axinite identified both rustls and native-tls being compiled due to
   conflicting reqwest feature selections, and noted that native-tls can pull in
-  C compilation (openssl-sys), increasing build time variability and cost.
-  [^4]
+  C compilation (openssl-sys), increasing build time variability and cost. [^4]
 
 Implementation sketch:
 
@@ -1113,20 +1088,20 @@ boundary violations often hide. [^2][^3]
 
 ### Comparison table: what belongs where
 
-| Check / policy | Whitaker (Dylint) | cargo-compile-hygiene | Repo-specific checker | Rationale |
-| --- | ---: | ---: | ---: | --- |
-| `forbidden_external_crate_in_layer` | ✅ | ❌ | ❌ | Needs per-use resolution and file/layer mapping inside rustc; best expressed as a lint. [^3] |
-| `public_api_leaks_optional_dep` | ✅ | ❌ | ❌ | Requires type-level inspection of exported signatures; late lint. [^3] |
-| `feature_island_breach` | ✅ | ❌ | ❌ | Needs source location + cfg context; best enforced in lint passes. [^1] |
-| `ui_test_macro_outside_app` | ✅ | ❌ | ❌ | Detects attribute macro usage; requires pre-expansion linting. [^1] |
-| `hexagonal_layer_boundary` | ✅ | ❌ | ❌ | Architectural boundary rule-set; Dylint improves Wildside’s lexical approach via resolution. [^4][^3] |
-| `async_trait_clear_misuse` (advisory) | ✅ | ❌ | ❌ | Code-level advisory; whole-workspace audit excluded. [^4] |
-| `integration_target_budget` | ❌ | ✅ | ❌ | Depends on targets and package graph; Cargo metadata. [^2] |
-| `heavy_dependency_not_optional` | ❌ | ✅ | ❌ | Depends on resolved dependency graph + optionality. [^2] |
-| `duplicate_major_version_hotspots` | ❌ | ✅ | ❌ | Graph-level duplicate analysis; matches `cargo tree --duplicates` intent. [^2] |
-| `tls_backend_multiplicity` | ❌ | ✅ | ❌ | Graph-level presence of TLS stacks; depends on resolved deps per feature config. [^4] |
-| `package_boundary_purity` | ❌ | ✅ | ❌ | Package dependency purity is a Cargo graph property; complements Whitaker. [^4] |
-| Redundant `make` pipelines (e.g., `check` + `clippy`) | ❌ | ❌ | ✅ | Not a Rust/Cargo semantic issue; a repo build orchestration issue. [^4] |
+| Check / policy                                        | Whitaker (Dylint) | cargo-compile-hygiene | Repo-specific checker | Rationale                                                                                               |
+| ----------------------------------------------------- | ----------------- | --------------------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
+| `forbidden_external_crate_in_layer`                   | Yes               | No                    | No                    | Needs per-use resolution and file/layer mapping inside rustc; best expressed as a lint. [^3]            |
+| `public_api_leaks_optional_dep`                       | Yes               | No                    | No                    | Requires type-level inspection of exported signatures; late lint. [^3]                                  |
+| `feature_island_breach`                               | Yes               | No                    | No                    | Needs source location + cfg context; best enforced in lint passes. [^1]                                 |
+| `ui_test_macro_outside_app`                           | Yes               | No                    | No                    | Detects attribute macro usage; requires pre-expansion linting. [^1]                                     |
+| `hexagonal_layer_boundary`                            | Yes               | No                    | No                    | Architectural boundary rule-set; Dylint improves Wildside’s lexical approach via resolution. [^4][^3]   |
+| `async_trait_clear_misuse` (advisory)                 | Yes               | No                    | No                    | Code-level advisory; whole-workspace audit excluded. [^4]                                               |
+| `integration_target_budget`                           | No                | Yes                   | No                    | Depends on targets and package graph; Cargo metadata. [^2]                                              |
+| `heavy_dependency_not_optional`                       | No                | Yes                   | No                    | Depends on resolved dependency graph + optionality. [^2]                                                |
+| `duplicate_major_version_hotspots`                    | No                | Yes                   | No                    | Graph-level duplicate analysis; matches `cargo tree --duplicates` intent. [^2]                          |
+| `tls_backend_multiplicity`                            | No                | Yes                   | No                    | Graph-level presence of TLS stacks; depends on resolved deps per feature config. [^4]                   |
+| `package_boundary_purity`                             | No                | Yes                   | No                    | Package dependency purity is a Cargo graph property; complements Whitaker. [^4]                         |
+| Redundant `make` pipelines (e.g., `check` + `clippy`) | No                | No                    | Yes                   | Not a Rust/Cargo semantic issue; a repo build orchestration issue. [^4]                                 |
 
 ### Rollout timeline
 
@@ -1170,8 +1145,7 @@ levels and the desire to avoid warning fatigue. [^3]
 
 Axinite’s build-time investigation identifies: many integration test binaries;
 always-compiled heavy dependencies intended to be optional (wasmtime, bollard,
-pdf); duplicate dependency stacks; and TLS backend multiplicity.
-[^4]
+pdf); duplicate dependency stacks; and TLS backend multiplicity. [^4]
 
 A practical migration sequence:
 
@@ -1195,9 +1169,8 @@ A practical migration sequence:
    ```
 
 3. **Adopt feature islands** (`wasm`, `docker`, `pdf`, `cli`) and enforce with
-   Whitaker  
-   Axinite has explicit feature-gating plans for wasmtime (`wasm`) and bollard
-   (`docker`). Implement the Cargo feature gates, then add Whitaker’s
+   Whitaker Axinite has explicit feature-gating plans for wasmtime (`wasm`) and
+   bollard (`docker`). Implement the Cargo feature gates, then add Whitaker’s
    `feature_island_breach` and `public_api_leaks_optional_dep` to prevent
    regressions. [^4]
 
@@ -1217,8 +1190,7 @@ A practical migration sequence:
 4. **Enable `tls_backend_multiplicity`**  
    Once feature sets stabilise, make that check a failure in CI for default
    features if the project intends to standardise on one TLS backend. Axinite
-   explicitly observed dual stacks due to conflicting reqwest defaults.
-   [^4]
+   explicitly observed dual stacks due to conflicting reqwest defaults. [^4]
 
 5. **Track duplicates as hotspots, not “must fix”**  
    Axinite’s duplicate stacks are partly upstream (libsql pulling older
@@ -1237,16 +1209,14 @@ A practical migration sequence:
 
 Gauss’s crate split is complete and establishes a clear graph: `gauss` (app)
 depends on `gauss-core` and `gauss-svg`, and `gauss-svg` depends on
-`gauss-core`, with the goal that core/SVG do not compile GPUI.
-[^4]
+`gauss-core`, with the goal that core/SVG do not compile GPUI. [^4]
 
 A Gauss-focused migration sequence:
 
 1. **Lock package boundary purity in cargo-compile-hygiene**  
    Immediately set `package_boundary_purity` rules for `gauss-core` and
    `gauss-svg` to forbid `gpui`, `gpui-component`, and `accesskit`
-   transitively. This preserves the primary benefit of the split.
-   [^4]
+   transitively. This preserves the primary benefit of the split. [^4]
 
 2. **Add Whitaker UI test macro confinement**  
    Enforce `ui_test_macro_outside_app` so `#[gpui::test]` can never appear
@@ -1258,16 +1228,14 @@ A Gauss-focused migration sequence:
    counts for pragmatic reasons (naming convention instead of module
    consolidation). If you later decide build-time reductions matter more than
    isolation, set budgets that reflect a desired future state and use the
-   tool’s reporting to drive an incremental consolidation project.
-   [^4]
+   tool’s reporting to drive an incremental consolidation project. [^4]
 
 4. **Add architectural lints only where architecture is explicit**  
    If Gauss has explicit layer boundaries akin to Wildside’s
    domain/inbound/outbound model, adopt `hexagonal_layer_boundary`. Otherwise,
    keep Whitaker’s layering rules focused on “GPUI must not leak into core/SVG”
    and on optional heavy features (if any). Wildside’s success rests on
-   path-based layer inference and explicit forbidden root lists.
-   [^4]
+   path-based layer inference and explicit forbidden root lists. [^4]
 
 ### Example combined config snippets
 

--- a/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
+++ b/docs/whitaker-and-cargo-compile-hygiene-technical-design.md
@@ -1,5 +1,14 @@
 # Whitaker and cargo-compile-hygiene Technical Design
 
+- Status: Proposed
+- Scope: Whitaker lint and Cargo-subcommand enforcement for architecture and
+  compile-time hygiene across Rust workspaces.
+- Primary audience: Whitaker contributors, lint authors, and workspace
+  maintainers.
+- Precedence documents: `docs/whitaker-dylint-suite-design.md`,
+  `docs/whitaker-cli-design.md`, and any later ADRs or roadmap decisions that
+  supersede this design.
+
 ## Executive summary
 
 This design proposes a two-part enforcement system for Rust workspaces:
@@ -1026,6 +1035,9 @@ ergonomics. [^2]
 
 ### Component interaction and data flow
 
+This diagram describes how Dylint-based Whitaker checks and the
+`cargo-compile-hygiene` subcommand consume workspace data and emit findings.
+
 ```mermaid
 flowchart LR
   Dev[Developer / CI runner] -->|cargo dylint --all| Dylint[cargo-dylint + Dylint driver]
@@ -1043,6 +1055,8 @@ flowchart LR
   Whitaker --> Findings[Diagnostics / lint output]
   CCH --> Report[Text/JSON report]
 ```
+
+Caption: Toolchain flow for Whitaker Dylint checks and `cargo-compile-hygiene`.
 
 Dylint runs lints from dynamic libraries by registering them with `rustc` via a
 driver; its architecture mirrors the “driver wraps rustc” model used by Clippy,
@@ -1105,34 +1119,49 @@ boundary violations often hide. [^2][^3]
 
 ### Rollout timeline
 
+This diagram shows the delivery sequence and measurable completion criteria for
+the foundation, MVP, and stabilization workstreams.
+
 ```mermaid
-gantt
-  title Whitaker + cargo-compile-hygiene rollout
-  dateFormat  YYYY-MM-DD
-  axisFormat  %d %b
+flowchart TB
+  subgraph Foundation
+    a1["a1 Define shared config schema\n(workspace.metadata.whitaker)\nAccept: schema PR merged and parsing tests pass"]
+    a2["a2 Wire Dylint library loading via\nworkspace.metadata.dylint\nAccept: CI smoke tests load shared config"]
+    a3["a3 Implement cargo-compile-hygiene skeleton\n+ metadata parsing\nAccept: CLI reads metadata and fixture tests pass"]
+    a1 --> a2 --> a3
+  end
 
-  section Foundation
-  Define shared config schema (workspace.metadata.whitaker) :a1, 2026-03-25, 7d
-  Wire Dylint library loading via workspace.metadata.dylint :a2, 2026-03-25, 7d
-  Implement cargo-compile-hygiene skeleton + metadata parsing :a3, 2026-03-25, 10d
+  subgraph "Whitaker MVP lints"
+    b1["b1 arch_hexagonal_layer_boundary\n(port Wildside)\nAccept: Wildside-style regression fixtures pass in UI tests"]
+    b2["b2 hygiene_public_api_leaks_optional_dep\nAccept: exported-signature cases pass with optional-dependency diagnostics"]
+    b3["b3 tests_ui_test_macro_outside_app\n(pre-expansion)\nAccept: fixtures catch misuse and stay quiet on valid code"]
+    b1 --> b2 --> b3
+  end
 
-  section Whitaker MVP lints
-  arch_hexagonal_layer_boundary (port Wildside) :b1, 2026-04-01, 14d
-  hygiene_public_api_leaks_optional_dep :b2, 2026-04-05, 14d
-  tests_ui_test_macro_outside_app (pre-expansion) :b3, 2026-04-08, 10d
+  subgraph "cargo-compile-hygiene MVP checks"
+    c1["c1 integration_target_budget\nAccept: target-budget findings and thresholds appear in text and JSON reports"]
+    c2["c2 duplicate_major_version_hotspots\nAccept: hotspot reports identify duplicate stacks and explanation paths"]
+    c3["c3 heavy_dependency_not_optional\nAccept: optionality breaches are detected across the feature matrix"]
+    c4["c4 tls_backend_multiplicity\nAccept: reports distinguish parallel TLS stacks per configuration"]
+    c5["c5 package_boundary_purity\nAccept: package-boundary violations are reported from cargo metadata analysis"]
+    c1 --> c2 --> c3 --> c4 --> c5
+  end
 
-  section cargo-compile-hygiene MVP checks
-  integration_target_budget :c1, 2026-04-01, 7d
-  duplicate_major_version_hotspots :c2, 2026-04-03, 7d
-  heavy_dependency_not_optional :c3, 2026-04-05, 10d
-  tls_backend_multiplicity :c4, 2026-04-10, 7d
-  package_boundary_purity :c5, 2026-04-10, 7d
+  subgraph Stabilization
+    d1["d1 CI feature matrix integration + baseline reports\nAccept: baseline reports stay stable across the feature matrix"]
+    d2["d2 Developer docs + suppression guidance\nAccept: guide updates land with suppression examples"]
+    d3["d3 Promote selected lints from warn to deny\nAccept: promotion criteria are met and CI gates stay green"]
+    d1 --> d2 --> d3
+  end
 
-  section Stabilization
-  CI feature matrix integration + baseline reports :d1, 2026-04-15, 10d
-  Developer docs + suppression guidance :d2, 2026-04-15, 7d
-  Promote selected lints from warn to deny :d3, 2026-04-22, 7d
+  a3 --> b1
+  a3 --> c1
+  b3 --> d1
+  c5 --> d1
 ```
+
+Caption: Delivery sequence for foundation work, Whitaker MVP lints,
+`cargo-compile-hygiene` MVP checks, and stabilization criteria.
 
 The emphasis is to land hard-boundary lints early (architectural contracts) and
 keep compile-time hygiene checks initially as warning/reporting, then promote

--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -6,8 +6,14 @@
 > [brain trust lints design](brain-trust-lints-design.md), the
 > [clone detector design](whitaker-clone-detector-design.md), the
 > [rstest fixture and test hygiene lints](lints-for-rstest-fixtures-and-test-hygiene.md),
+> [ownership shape lints design](ownership-shape-lints-design.md), the
+> [async-trait architecture hygiene Dylint suite design](async-trait-architecture-hygiene-dylint-suite-design-for-whitaker.md),
+> the
+> [test-support dead-code and masked-expectations design](technical-design-for-test-support-dead-code-and-masked-dead-code-expectations.md),
 > and the
-> [ownership shape lints design](ownership-shape-lints-design.md).
+> [Whitaker and cargo-compile-hygiene technical design](whitaker-and-cargo-compile-hygiene-technical-design.md).
+> Use this document for the foundational suite conventions and those
+> companion documents for later phase-specific architecture and rollout work.
 
 This single document consolidates the workspace design, the seven core lints
 (with the **revised conditional rule**), the separate `no_unwrap_or_else_panic`
@@ -1294,6 +1300,13 @@ function and is suitable as a stable Dylint rule in the default suite.
 - [ ] CI workflows.
 
 ## 15) Phased roadmap (small, nested tasks)
+
+> [!NOTE]
+> The historical phased outline below captures the original suite-delivery
+> sequence. Active follow-on planning for the later specialist phases now lives
+> in [docs/roadmap.md](roadmap.md), with detailed architecture in the companion
+> design documents for ownership-shape lints, async-trait hygiene,
+> test-support dead-code analysis, and cargo-compile-hygiene.
 
 ### Phase 0 — Repo scaffolding
 

--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -1,5 +1,14 @@
 # Whitaker Rust Dylint Workspace — Lint Suite Design and Roadmap
 
+> [!NOTE]
+> Follow-on design work now lives in focused companion documents for newer
+> phases, including the
+> [brain trust lints design](brain-trust-lints-design.md), the
+> [clone detector design](whitaker-clone-detector-design.md), the
+> [rstest fixture and test hygiene lints](lints-for-rstest-fixtures-and-test-hygiene.md),
+> and the
+> [ownership shape lints design](ownership-shape-lints-design.md).
+
 This single document consolidates the workspace design, the seven core lints
 (with the **revised conditional rule**), the separate `no_unwrap_or_else_panic`
 lint crate, a feasibility study for a **Bumpy Road** detector, and a phased

--- a/installer/tests/behaviour_dependency_binaries.rs
+++ b/installer/tests/behaviour_dependency_binaries.rs
@@ -206,19 +206,19 @@ fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
             },
         )
     };
-    world.install_result = Some(
-        if tool == "dylint-link" && !world.expect_missing_dylint_link {
-            let _guard = env_test_guard();
+    world.install_result = Some(if tool == "dylint-link" {
+        let _guard = env_test_guard();
+        if !world.expect_missing_dylint_link {
             #[cfg(windows)]
             let dylint_link_path = bin_dir.join("dylint-link.cmd");
             #[cfg(not(windows))]
             let dylint_link_path = bin_dir.join("dylint-link");
             write_fake_binary(&dylint_link_path, true);
-            with_var("PATH", Some(&bin_dir), run_install)
-        } else {
-            run_install()
-        },
-    );
+        }
+        with_var("PATH", Some(&bin_dir), run_install)
+    } else {
+        run_install()
+    });
     executor.assert_finished();
 }
 

--- a/installer/tests/behaviour_dependency_binaries.rs
+++ b/installer/tests/behaviour_dependency_binaries.rs
@@ -2,6 +2,7 @@
 
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
+use std::path::Path;
 use std::path::PathBuf;
 use temp_env::with_var;
 use whitaker_installer::dependency_binaries::{
@@ -166,6 +167,22 @@ fn build_stub_executor(world: &DependencyBinaryWorld, tool: &str) -> StubExecuto
     ))
 }
 
+fn run_install_with_dylint_link_on_path(
+    expect_missing_dylint_link: bool,
+    bin_dir: &Path,
+    run_install: impl FnOnce() -> std::result::Result<(), whitaker_installer::error::InstallerError>,
+) -> std::result::Result<(), whitaker_installer::error::InstallerError> {
+    let _guard = env_test_guard();
+    if !expect_missing_dylint_link {
+        #[cfg(windows)]
+        let dylint_link_path = bin_dir.join("dylint-link.cmd");
+        #[cfg(not(windows))]
+        let dylint_link_path = bin_dir.join("dylint-link");
+        write_fake_binary(&dylint_link_path, true);
+    }
+    with_var("PATH", Some(bin_dir), run_install)
+}
+
 #[when("dependency installation runs")]
 fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
     let tool = world
@@ -207,15 +224,11 @@ fn when_dependency_installation_runs(world: &mut DependencyBinaryWorld) {
         )
     };
     world.install_result = Some(if tool == "dylint-link" {
-        let _guard = env_test_guard();
-        if !world.expect_missing_dylint_link {
-            #[cfg(windows)]
-            let dylint_link_path = bin_dir.join("dylint-link.cmd");
-            #[cfg(not(windows))]
-            let dylint_link_path = bin_dir.join("dylint-link");
-            write_fake_binary(&dylint_link_path, true);
-        }
-        with_var("PATH", Some(&bin_dir), run_install)
+        run_install_with_dylint_link_on_path(
+            world.expect_missing_dylint_link,
+            &bin_dir,
+            run_install,
+        )
     } else {
         run_install()
     });


### PR DESCRIPTION
## Summary by Sourcery

Expand and refine Whitaker’s roadmap and technical documentation for upcoming lint suites and tooling, while making small adjustments to CI tooling, tests, and ignore patterns.

CI:
- Update the CI workflow to install the Nixie tool via the new `nixie-cli` package name.

Documentation:
- Extend the roadmap with phases covering ownership-shape lints, async-trait architecture hygiene lints, test-support dead-code analysis, and architecture/compile-hygiene enforcement, linked to new design documents.
- Add detailed technical design documents for ownership-shape lints, async-trait architecture hygiene Dylint suite, test-support dead-code and masked-dead-code expectations, and Whitaker plus cargo-compile-hygiene, and wire them into the documentation contents and suite design.
- Clarify and deconflict the documentation style guide around canonical filenames, contents files, and design/ADR/RFC roles, fixing a merge artifact, and refine cross-links in the suite design and CLI docs.

Tests:
- Adjust installer dependency-binary tests so `dylint-link` test setup consistently injects a fake binary on the PATH before running installs.

Chores:
- Add new architecture/compile-hygiene technical design file to the repository and update `.gitignore` to reflect new documentation or tooling outputs.