### PR TITLE
Bridge lemma for FragmentId ordering; Verus proof for CandidatePair::new (7.2.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Check Verus FragmentId bridge
+        run: scripts/check-verus-fragment-id-bridge.sh
+
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
 

--- a/crates/whitaker_clones_core/src/index/fragment_id.rs
+++ b/crates/whitaker_clones_core/src/index/fragment_id.rs
@@ -1,0 +1,69 @@
+//! Fragment identifier newtype for clone-detector candidate generation.
+
+use std::fmt;
+
+/// Opaque fragment identifier used by candidate generation.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FragmentId(String);
+
+impl FragmentId {
+    /// Creates a new fragment identifier.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use whitaker_clones_core::FragmentId;
+    ///
+    /// let id = FragmentId::new("src/lib.rs:10..20");
+    /// assert_eq!(id.as_str(), "src/lib.rs:10..20");
+    /// ```
+    #[must_use]
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Returns the fragment identifier as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Consumes the identifier and returns the owned string.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use whitaker_clones_core::FragmentId;
+    ///
+    /// let id = FragmentId::from("fragment-a");
+    /// assert_eq!(id.into_inner(), "fragment-a".to_owned());
+    /// ```
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl From<&str> for FragmentId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for FragmentId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for FragmentId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for FragmentId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}

--- a/crates/whitaker_clones_core/src/index/mod.rs
+++ b/crates/whitaker_clones_core/src/index/mod.rs
@@ -1,6 +1,7 @@
 //! MinHash and LSH indexing for token-pass candidate generation.
 
 mod error;
+mod fragment_id;
 #[cfg(kani)]
 mod kani;
 mod lsh;
@@ -8,9 +9,10 @@ mod minhash;
 mod types;
 
 pub use error::{IndexError, IndexResult};
+pub use fragment_id::FragmentId;
 pub use lsh::LshIndex;
 pub use minhash::MinHasher;
-pub use types::{CandidatePair, FragmentId, LshConfig, MINHASH_SIZE, MinHashSignature};
+pub use types::{CandidatePair, LshConfig, MINHASH_SIZE, MinHashSignature};
 
 #[cfg(test)]
 mod tests;

--- a/crates/whitaker_clones_core/src/index/tests.rs
+++ b/crates/whitaker_clones_core/src/index/tests.rs
@@ -65,6 +65,31 @@ fn fragment_ids() -> FragmentIds {
     }
 }
 
+fn pair_members(pair: &CandidatePair) -> (&str, &str) {
+    (pair.left().as_str(), pair.right().as_str())
+}
+
+#[rstest]
+#[case(("alpha", "beta", ("alpha", "beta")))]
+#[case(("beta", "alpha", ("alpha", "beta")))]
+#[case(("fragment-2", "fragment-10", ("fragment-10", "fragment-2")))]
+fn candidate_pair_orders_distinct_inputs(#[case] case: (&str, &str, (&str, &str))) {
+    let (left, right, expected) = case;
+
+    let pair = CandidatePair::new(FragmentId::from(left), FragmentId::from(right))
+        .expect("distinct fragment IDs should form a canonical pair");
+
+    assert_eq!(pair_members(&pair), expected);
+}
+
+#[test]
+fn candidate_pair_suppresses_self_pairs() {
+    assert_eq!(
+        CandidatePair::new(FragmentId::from("alpha"), FragmentId::from("alpha")),
+        None
+    );
+}
+
 #[rstest]
 #[case(((0, 4), IndexError::ZeroBands))]
 #[case(((4, 0), IndexError::ZeroRows))]

--- a/crates/whitaker_clones_core/src/index/types.rs
+++ b/crates/whitaker_clones_core/src/index/types.rs
@@ -1,77 +1,11 @@
 //! Shared MinHash and LSH index types.
 
-use std::{fmt, num::NonZeroUsize, slice::ChunksExact};
+use std::{num::NonZeroUsize, slice::ChunksExact};
 
-use super::{IndexError, IndexResult};
+use super::{FragmentId, IndexError, IndexResult};
 
 /// The fixed MinHash sketch width for roadmap item 7.2.2.
 pub const MINHASH_SIZE: usize = 128;
-
-/// Opaque fragment identifier used by candidate generation.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FragmentId(String);
-
-impl FragmentId {
-    /// Creates a new fragment identifier.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use whitaker_clones_core::FragmentId;
-    ///
-    /// let id = FragmentId::new("src/lib.rs:10..20");
-    /// assert_eq!(id.as_str(), "src/lib.rs:10..20");
-    /// ```
-    #[must_use]
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-
-    /// Returns the fragment identifier as a string slice.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
-    /// Consumes the identifier and returns the owned string.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use whitaker_clones_core::FragmentId;
-    ///
-    /// let id = FragmentId::from("fragment-a");
-    /// assert_eq!(id.into_inner(), "fragment-a".to_owned());
-    /// ```
-    #[must_use]
-    pub fn into_inner(self) -> String {
-        self.0
-    }
-}
-
-impl From<&str> for FragmentId {
-    fn from(value: &str) -> Self {
-        Self::new(value)
-    }
-}
-
-impl From<String> for FragmentId {
-    fn from(value: String) -> Self {
-        Self::new(value)
-    }
-}
-
-impl AsRef<str> for FragmentId {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl fmt::Display for FragmentId {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(self.as_str())
-    }
-}
 
 /// A canonical fragment pair emitted by the LSH candidate filter.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/whitaker_clones_core/tests/candidate_pair_behaviour.rs
+++ b/crates/whitaker_clones_core/tests/candidate_pair_behaviour.rs
@@ -1,0 +1,87 @@
+//! Behaviour-driven coverage for `CandidatePair::new`.
+//!
+//! Keep this harness in sync with `tests/features/candidate_pair.feature`.
+
+use std::cell::RefCell;
+
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use whitaker_clones_core::{CandidatePair, FragmentId};
+
+#[derive(Debug, Default)]
+struct CandidatePairWorld {
+    left: RefCell<Option<String>>,
+    right: RefCell<Option<String>>,
+    pair: RefCell<Option<CandidatePair>>,
+}
+
+#[fixture]
+fn world() -> CandidatePairWorld {
+    CandidatePairWorld::default()
+}
+
+fn with_pair(world: &CandidatePairWorld, assert_fn: impl FnOnce(&CandidatePair)) {
+    let pair = world.pair.borrow();
+    match pair.as_ref() {
+        Some(pair) => assert_fn(pair),
+        None => panic!("candidate pair must be present before running assertions"),
+    }
+}
+
+#[given("input fragment IDs {left} and {right}")]
+fn given_input_fragment_ids(world: &CandidatePairWorld, left: String, right: String) {
+    *world.left.borrow_mut() = Some(left);
+    *world.right.borrow_mut() = Some(right);
+}
+
+#[when("the candidate pair constructor is called")]
+fn when_candidate_pair_constructor_is_called(world: &CandidatePairWorld) -> Result<(), String> {
+    let left = world
+        .left
+        .borrow()
+        .clone()
+        .ok_or_else(|| "left fragment ID must be set before construction".to_owned())?;
+    let right = world
+        .right
+        .borrow()
+        .clone()
+        .ok_or_else(|| "right fragment ID must be set before construction".to_owned())?;
+
+    *world.pair.borrow_mut() = CandidatePair::new(FragmentId::from(left), FragmentId::from(right));
+    Ok(())
+}
+
+#[then("the canonical pair is {left} and {right}")]
+fn then_the_canonical_pair_is(world: &CandidatePairWorld, left: String, right: String) {
+    with_pair(world, |pair| {
+        assert_eq!(
+            (pair.left().as_str(), pair.right().as_str()),
+            (left.as_str(), right.as_str())
+        );
+    });
+}
+
+#[then("no candidate pair is returned")]
+fn then_no_candidate_pair_is_returned(world: &CandidatePairWorld) {
+    assert!(world.pair.borrow().is_none());
+}
+
+#[scenario(path = "tests/features/candidate_pair.feature", index = 0)]
+fn scenario_ordered_distinct_ids(world: CandidatePairWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/candidate_pair.feature", index = 1)]
+fn scenario_reversed_distinct_ids(world: CandidatePairWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/candidate_pair.feature", index = 2)]
+fn scenario_identical_ids(world: CandidatePairWorld) {
+    let _ = world;
+}
+
+#[scenario(path = "tests/features/candidate_pair.feature", index = 3)]
+fn scenario_lexical_order_edge_case(world: CandidatePairWorld) {
+    let _ = world;
+}

--- a/crates/whitaker_clones_core/tests/candidate_pair_behaviour.rs
+++ b/crates/whitaker_clones_core/tests/candidate_pair_behaviour.rs
@@ -10,8 +10,8 @@ use whitaker_clones_core::{CandidatePair, FragmentId};
 
 #[derive(Debug, Default)]
 struct CandidatePairWorld {
-    left: RefCell<Option<String>>,
-    right: RefCell<Option<String>>,
+    left: RefCell<Option<FragmentId>>,
+    right: RefCell<Option<FragmentId>>,
     pair: RefCell<Option<CandidatePair>>,
 }
 
@@ -30,8 +30,8 @@ fn with_pair(world: &CandidatePairWorld, assert_fn: impl FnOnce(&CandidatePair))
 
 #[given("input fragment IDs {left} and {right}")]
 fn given_input_fragment_ids(world: &CandidatePairWorld, left: String, right: String) {
-    *world.left.borrow_mut() = Some(left);
-    *world.right.borrow_mut() = Some(right);
+    *world.left.borrow_mut() = Some(FragmentId::from(left));
+    *world.right.borrow_mut() = Some(FragmentId::from(right));
 }
 
 #[when("the candidate pair constructor is called")]
@@ -47,7 +47,7 @@ fn when_candidate_pair_constructor_is_called(world: &CandidatePairWorld) -> Resu
         .clone()
         .ok_or_else(|| "right fragment ID must be set before construction".to_owned())?;
 
-    *world.pair.borrow_mut() = CandidatePair::new(FragmentId::from(left), FragmentId::from(right));
+    *world.pair.borrow_mut() = CandidatePair::new(left, right);
     Ok(())
 }
 

--- a/crates/whitaker_clones_core/tests/features/candidate_pair.feature
+++ b/crates/whitaker_clones_core/tests/features/candidate_pair.feature
@@ -1,0 +1,23 @@
+Feature: Candidate pair canonicalization
+  CandidatePair::new should suppress self-pairs and emit distinct pairs in
+  canonical lexical order.
+
+  Scenario: Distinct IDs already in canonical order stay unchanged
+    Given input fragment IDs alpha and beta
+    When the candidate pair constructor is called
+    Then the canonical pair is alpha and beta
+
+  Scenario: Reversed distinct IDs are canonicalized
+    Given input fragment IDs beta and alpha
+    When the candidate pair constructor is called
+    Then the canonical pair is alpha and beta
+
+  Scenario: Identical IDs are suppressed
+    Given input fragment IDs alpha and alpha
+    When the candidate pair constructor is called
+    Then no candidate pair is returned
+
+  Scenario: Similar IDs follow lexical order rather than numeric order
+    Given input fragment IDs fragment-2 and fragment-10
+    When the candidate pair constructor is called
+    Then the canonical pair is fragment-10 and fragment-2

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -256,14 +256,15 @@ honour an existing environment value if set before invoking make, allowing
 per-developer overrides without modifying the Makefile.
 
 `make verus` currently runs both decomposition-advice proofs and the
-clone-detector `LshConfig::new` proof. `make kani` runs the decomposition
-adjacency harnesses and the clone-detector harness group in one pass.
+clone-detector proofs for `LshConfig::new` and `CandidatePair::new`.
+`make kani` runs the decomposition adjacency harnesses and the clone-detector
+harness group in one pass.
 
 ### Verus scope and trust boundary
 
-The clone-detector Verus file is intentionally an implementation-shaped model
-of `LshConfig::new` and `validate_product`, not a direct proof of the compiled
-Rust body in `crates/whitaker_clones_core`.
+The clone-detector Verus files are intentionally implementation-shaped models
+of `LshConfig::new`, `validate_product`, and `CandidatePair::new`, not direct
+proofs of the compiled Rust bodies in `crates/whitaker_clones_core`.
 
 This distinction matters. In the current sidecar setup, Verus can describe the
 contract of an external Rust function with mechanisms such as
@@ -273,14 +274,19 @@ implementation itself. The repository therefore keeps the Verus proof honest:
 it mirrors the real branch order and `checked_mul` overflow behaviour, while
 Kani calls the actual constructor and checks its runtime behaviour directly.
 
-For `LshConfig::new`, the split is:
+For the current clone-detector constructors, the split is:
 
-- Verus proves the constructor model rejects zero bands, rejects zero rows,
-  accepts only exact products of `MINHASH_SIZE`, and rejects overflowing
-  products via the same `checked_mul` semantics as the runtime code.
+- Verus proves the `LshConfig::new` constructor model rejects zero bands,
+  rejects zero rows, accepts only exact products of `MINHASH_SIZE`, and rejects
+  overflowing products via the same `checked_mul` semantics as the runtime code.
+- Verus proves the `CandidatePair::new` constructor model suppresses equal
+  inputs, preserves already ordered distinct inputs, and swaps reversed
+  distinct inputs into canonical order for an ordered identifier domain.
 - Kani executes the real constructor with one concrete acceptance harness, one
   bounded symbolic harness over `[0, 128]²`, and one overflow harness that
   forces the `checked_mul(None)` branch.
+- Ordinary unit tests and `rstest-bdd` scenarios pin the concrete lexical
+  `FragmentId` ordering contract that the `CandidatePair` proof models.
 
 ### Tooling scripts
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -281,10 +281,10 @@ For the current clone-detector constructors, the split is:
   overflowing products via the same `checked_mul` semantics as the runtime code.
 - Verus proves the `CandidatePair::new` constructor model suppresses equal
   inputs, preserves already ordered distinct inputs, and swaps reversed
-  distinct inputs into canonical order. The sidecar now states that proof over
-  a trusted `FragmentId` bridge lemma: `FragmentId::partial_cmp` is modelled as
-  a strict total order via a ghost `nat` ranking, rather than being left as an
-  implicit assumption.
+  distinct inputs into canonical order. The sidecar now formulates that proof
+  over a trusted `FragmentId` bridge lemma: `FragmentId::partial_cmp` is
+  modelled as a strict total order via a ghost `nat` ranking, rather than being
+  left as an implicit assumption.
 - Kani executes the real constructor with one concrete acceptance harness, one
   bounded symbolic harness over `[0, 128]²`, and one overflow harness that
   forces the `checked_mul(None)` branch.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -226,7 +226,6 @@ Whitaker now ships repository-managed proof tooling for the formal verification
 work introduced around decomposition advice and the clone-detector pipeline.
 Run these commands from the workspace root.
 
-
 ### Clone-detector index structure
 
 The clone-detector index code is grouped under

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -226,6 +226,49 @@ Whitaker now ships repository-managed proof tooling for the formal verification
 work introduced around decomposition advice and the clone-detector pipeline.
 Run these commands from the workspace root.
 
+
+### Clone-detector index structure
+
+The clone-detector index code is grouped under
+`crates/whitaker_clones_core/src/index/` by the candidate-generation feature it
+serves. The module split keeps the public constructor contracts small enough to
+test and verify directly:
+
+- `fragment_id.rs` owns the `FragmentId` newtype. It is intentionally separate
+  from the LSH and pair types because its lexical ordering is a contract that
+  unit tests, BDD scenarios, and the Verus sidecar all rely on.
+- `types.rs` owns `CandidatePair`, `LshConfig`, and the fixed MinHash
+  signature types. `CandidatePair::new` consumes already validated `FragmentId`
+  values, suppresses self-pairs, and canonicalizes distinct pairs by the
+  ordering supplied by `FragmentId`.
+- `lsh.rs` and `minhash.rs` own the indexing and sketching algorithms that use
+  those small domain types, while `error.rs` keeps the index error contract out
+  of the algorithm modules.
+- `mod.rs` re-exports the public index surface so callers import
+  `FragmentId`, `CandidatePair`, `LshConfig`, `LshIndex`, and `MinHasher`
+  through `whitaker_clones_core` rather than depending on the internal module
+  layout.
+
+The `FragmentId` reorganization was done to remove a type-ownership tangle in
+`types.rs`. Keeping the identifier newtype in its own module makes the trusted
+ordering bridge in `verus/clone_detector_candidate_pair.rs` easy to audit:
+Verus trusts the derived production ordering for `FragmentId`, while ordinary
+tests pin the concrete string-backed behaviour.
+
+The direct `CandidatePair::new` coverage lives in the clone-core crate:
+
+- Unit tests in `crates/whitaker_clones_core/src/index/tests.rs` cover
+  self-pair suppression, already ordered inputs, reversed inputs, and the
+  lexical edge case `fragment-10 < fragment-2`.
+- The BDD harness in
+  `crates/whitaker_clones_core/tests/candidate_pair_behaviour.rs` exercises the
+  same public constructor through `rstest-bdd` steps.
+- The feature file is
+  `crates/whitaker_clones_core/tests/features/candidate_pair.feature`.
+- The test dependencies are declared in
+  `crates/whitaker_clones_core/Cargo.toml` as `rstest`, `rstest-bdd`, and
+  `rstest-bdd-macros`.
+
 ### Make targets
 
 Use the Makefile targets for normal proof runs:

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -281,12 +281,16 @@ For the current clone-detector constructors, the split is:
   overflowing products via the same `checked_mul` semantics as the runtime code.
 - Verus proves the `CandidatePair::new` constructor model suppresses equal
   inputs, preserves already ordered distinct inputs, and swaps reversed
-  distinct inputs into canonical order for an ordered identifier domain.
+  distinct inputs into canonical order. The sidecar now states that proof over
+  a trusted `FragmentId` bridge lemma: `FragmentId::partial_cmp` is modelled as
+  a strict total order via a ghost `nat` ranking, rather than being left as an
+  implicit assumption.
 - Kani executes the real constructor with one concrete acceptance harness, one
   bounded symbolic harness over `[0, 128]²`, and one overflow harness that
   forces the `checked_mul(None)` branch.
 - Ordinary unit tests and `rstest-bdd` scenarios pin the concrete lexical
-  `FragmentId` ordering contract that the `CandidatePair` proof models.
+  `FragmentId` ordering contract that the `CandidatePair` proof's bridge still
+  trusts rather than proving from `String` internals.
 
 ### Tooling scripts
 

--- a/docs/execplans/7-2-6-verus-proofs-for-candidate-pair-new-canonicalization.md
+++ b/docs/execplans/7-2-6-verus-proofs-for-candidate-pair-new-canonicalization.md
@@ -4,11 +4,9 @@ This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
 `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
 `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 This document must be maintained in accordance with `AGENTS.md`.
-
-Implementation must not begin until the user explicitly approves this plan.
 
 ## Purpose / big picture
 
@@ -172,21 +170,23 @@ Relevant skills for the implementation turn:
 
 - [x] Stage A: Gather repository context, inspect the current proof workflow,
   and draft this ExecPlan (2026-04-21).
-- [ ] Stage B: Add failing direct unit tests for `CandidatePair::new` happy,
-  unhappy, and edge-case behaviour.
-- [ ] Stage C: Add failing `rstest-bdd` v0.5.0 scenarios for direct
-  `CandidatePair::new` behaviour.
-- [ ] Stage D: Add a dedicated Verus sidecar proof for `CandidatePair::new`
-  and wire it into `scripts/run-verus.sh`.
-- [ ] Stage E: Make the targeted tests and proof green, refactoring only as
-  needed to keep files small and readable.
-- [ ] Stage F: Update `docs/whitaker-clone-detector-design.md`,
-  `docs/developers-guide.md`, and `docs/users-guide.md` if user-visible
-  behaviour actually changed.
-- [ ] Stage G: Mark roadmap item 7.2.6 done in `docs/roadmap.md`.
-- [ ] Stage H: Run documentation, proof, lint, and test gates successfully.
-- [ ] Stage I: Finalize the living sections in this ExecPlan after the
-  implementation turn.
+- [x] Stage B: Add direct unit tests for `CandidatePair::new` happy, unhappy,
+  and edge-case behaviour (2026-04-22).
+- [x] Stage C: Add `rstest-bdd` v0.5.0 scenarios for direct
+  `CandidatePair::new` behaviour (2026-04-22).
+- [x] Stage D: Add a dedicated Verus sidecar proof for `CandidatePair::new`
+  and wire it into `scripts/run-verus.sh` (2026-04-22).
+- [x] Stage E: Make the targeted tests and proof green without a runtime
+  refactor (2026-04-22).
+- [x] Stage F: Update `docs/whitaker-clone-detector-design.md` and
+  `docs/developers-guide.md`, and confirm `docs/users-guide.md` needs no change
+  because this work is not user-visible (2026-04-22).
+- [x] Stage G: Mark roadmap item 7.2.6 done in `docs/roadmap.md`
+  (2026-04-22).
+- [x] Stage H: Run documentation, proof, lint, and test gates successfully
+  (2026-04-22).
+- [x] Stage I: Finalize the living sections in this ExecPlan after the
+  implementation turn (2026-04-22).
 
 ## Surprises & Discoveries
 
@@ -208,6 +208,12 @@ Relevant skills for the implementation turn:
   are emitted in lexical `FragmentId` order and that self-pairs are suppressed.
   The 7.2.6 work therefore proves an existing documented invariant rather than
   inventing a new one.
+- The implementation did not need any production-code refactor in
+  `index/types.rs`; direct tests and the new sidecar proof were sufficient to
+  pin the contract.
+- The Verus proof is simplest and clearest when it models an ordered
+  identifier domain with `nat` values, while runtime tests cover the concrete
+  lexical-string behaviour of `FragmentId`.
 
 ## Decision Log
 
@@ -228,6 +234,14 @@ Relevant skills for the implementation turn:
   automatic edit. Rationale: this roadmap slice is proof and developer-guidance
   work unless implementation exposes a new user-facing behaviour. Date/Author:
   2026-04-21 / Codex.
+- Decision: keep the runtime constructor body unchanged and prove/document the
+  existing behaviour instead of extracting a proof helper. Rationale: the
+  constructor is already small, direct, and readable, so a helper would add
+  surface area without reducing drift. Date/Author: 2026-04-22 / Codex.
+- Decision: model proof identifiers as `nat` values in Verus and rely on
+  direct runtime tests to pin lexical `FragmentId` semantics. Rationale: this
+  proves the constructor's ordering control flow without pretending to verify
+  Rust `String` internals. Date/Author: 2026-04-22 / Codex.
 
 ## Context and orientation
 
@@ -439,6 +453,46 @@ Expected success signals:
 
 ## Outcomes & Retrospective
 
-Pending implementation. After approval and delivery, replace this section with
-the actual results, the final proof and test counts, any deviations from the
-draft, and the lessons worth carrying into roadmap items 7.2.7 and 7.2.8.
+Delivered roadmap item 7.2.6 without changing the production constructor body.
+`CandidatePair::new` remains the same small three-branch runtime function, and
+the work landed as proof, test, and documentation hardening around that seam.
+
+Final shipped pieces:
+
+- Direct unit coverage in `crates/whitaker_clones_core/src/index/tests.rs` for
+  preserved canonical order, reversed-input canonicalization, self-pair
+  suppression, and the lexical-order edge case `"fragment-10" < "fragment-2"`.
+- Dedicated BDD coverage in
+  `crates/whitaker_clones_core/tests/candidate_pair_behaviour.rs` and
+  `tests/features/candidate_pair.feature` with four constructor-level scenarios.
+- New Verus sidecar `verus/clone_detector_candidate_pair.rs`.
+- Updated `scripts/run-verus.sh` so `clone-detector` and `all` include the new
+  proof file.
+- Updated `docs/whitaker-clone-detector-design.md`,
+  `docs/developers-guide.md`, and `docs/roadmap.md`.
+- Left `docs/users-guide.md` unchanged because the work did not alter any
+  public feature or user-visible workflow.
+
+Validation evidence:
+
+- `make fmt`
+- `make markdownlint`
+- `make nixie`
+- `make check-fmt`
+- `make lint`
+- `make test` -> `Summary [ 126.157s] 1348 tests run: 1348 passed, 2 skipped`
+- `make verus-clone-detector` -> `9 verified, 0 errors` for
+  `clone_detector_lsh_config.rs` and `7 verified, 0 errors` for
+  `clone_detector_candidate_pair.rs`
+- `make verus` -> `5 verified, 0 errors`, `8 verified, 0 errors`,
+  `9 verified, 0 errors`, and `7 verified, 0 errors` across the full Verus
+  proof set
+
+Lessons worth carrying into 7.2.7 and 7.2.8:
+
+- Keep constructor proofs separate and small; they are easiest to maintain
+  when one proof file maps to one runtime seam.
+- For ordering proofs, model the control flow over an ordered identifier
+  domain in Verus and let runtime tests pin the concrete string semantics.
+- Direct constructor-level tests reduce proof drift more effectively than
+  relying on indirect coverage through later pipeline stages.

--- a/docs/execplans/7-2-6-verus-proofs-for-candidate-pair-new-canonicalization.md
+++ b/docs/execplans/7-2-6-verus-proofs-for-candidate-pair-new-canonicalization.md
@@ -1,0 +1,444 @@
+# Prove `CandidatePair::new` canonicalization and self-pair suppression with Verus (roadmap 7.2.6)
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+This document must be maintained in accordance with `AGENTS.md`.
+
+Implementation must not begin until the user explicitly approves this plan.
+
+## Purpose / big picture
+
+Roadmap item 7.2.6 adds a machine-checked Verus proof for
+`crates/whitaker_clones_core/src/index/types.rs::CandidatePair::new`. Verus is
+the repository's theorem prover for small semantic invariants. This change must
+show two things clearly and repeatedly:
+
+1. Distinct fragment identifiers are returned in canonical lexical order,
+   regardless of the order passed to `CandidatePair::new`.
+2. Identical fragment identifiers are suppressed by returning `None`, so the
+   token-pass candidate pipeline never admits self-pairs through this
+   constructor seam.
+
+This matters because roadmap item 7.2.2 made `CandidatePair` the stable output
+of MinHash plus locality-sensitive hashing (LSH) candidate generation, and
+roadmap item 7.2.3 already depends on the left-hand side of that canonical pair
+to choose the primary Static Analysis Results Interchange Format (SARIF)
+location. If the constructor contract drifts, later stages inherit unstable
+ordering, duplicate emissions, or accidental self-matches.
+
+Observable outcome:
+
+1. The clone-detector Verus group contains a dedicated proof for
+   `CandidatePair::new`, and `make verus-clone-detector` reports that both the
+   existing `LshConfig::new` proof and the new `CandidatePair::new` proof pass.
+2. Unit tests in `crates/whitaker_clones_core/src/index/tests.rs` cover happy
+   paths, unhappy paths, and edge cases for direct `CandidatePair::new`
+   construction, rather than relying only on indirect `LshIndex` coverage.
+3. Behaviour-driven development (BDD) coverage using workspace-pinned
+   `rstest-bdd` v0.5.0 exercises canonical order preservation, reversal
+   canonicalization, self-pair suppression, and at least one lexical-order edge
+   case through a dedicated behaviour harness.
+4. `docs/whitaker-clone-detector-design.md` records the final 7.2.6 decisions,
+   especially the exact ordering contract and the Verus trust boundary.
+5. `docs/developers-guide.md` explains how the clone-detector Verus workflow
+   now covers both constructor proofs, and why the sidecar proof models the
+   constructor instead of proving the compiled Rust body directly.
+6. `docs/users-guide.md` is updated only if implementation changes a public
+   tooling behaviour or surfaced feature. If no user-visible behaviour changes,
+   the implementation notes that explicitly and leaves the guide unchanged.
+7. `docs/roadmap.md` marks 7.2.6 done only after the proof, tests, and all
+   required gates succeed.
+8. The implementation turn ends with successful runs of `make fmt`,
+   `make markdownlint`, `make nixie`, `make check-fmt`, `make lint`,
+   `make test`, `make verus-clone-detector`, and `make verus`.
+
+## Relevant docs and skills
+
+Use these repository documents during implementation:
+
+- `docs/roadmap.md` for the exact 7.2.6 scope and dependency on 7.2.4.
+- `docs/adr-003-formal-proof-strategy-for-clone-detector-pipeline.md` for the
+  Verus-versus-Kani proof split.
+- `docs/whitaker-clone-detector-design.md` for the published MinHash, LSH,
+  `CandidatePair`, and SARIF contracts.
+- `docs/developers-guide.md` for the proof workflow and trust-boundary wording
+  already established by 7.2.4 and 7.2.5.
+- `docs/rstest-bdd-users-guide.md` and
+  `docs/rust-testing-with-rstest-fixtures.md` for fixture-backed BDD structure
+  and `rstest` composition.
+- `docs/rust-doctest-dry-guide.md` for any Rustdoc examples added or revised in
+  public APIs.
+- `docs/complexity-antipatterns-and-refactoring-strategies.md` and
+  `docs/whitaker-dylint-suite-design.md` for the repository's preference for
+  small helpers, files under 400 lines, and BDD coverage with `rstest-bdd`
+  v0.5.0.
+
+Relevant skills for the implementation turn:
+
+- `execplans` to keep this document current while work proceeds.
+- `rust-router` to route Rust-specific questions to the smallest useful skill.
+- `rust-types-and-apis` if constructor seams or ordering helpers need careful
+  API-boundary decisions.
+- `nextest` when interpreting or debugging repository test runs.
+- `en-gb-oxendict-style` for any documentation updates.
+
+## Constraints
+
+- Scope only roadmap item 7.2.6. Do not pull 7.2.7 or 7.2.8 forward, and do
+  not widen this task into new Kani work.
+- Keep proof tooling in sidecar files and scripts. Normal Cargo builds and the
+  default `make test` path must remain independent of Verus.
+- Preserve the existing runtime behaviour of `CandidatePair::new` unless a
+  tiny refactor is required to improve clarity without changing the contract.
+- Do not widen the public API of `whitaker_clones_core` solely for proof
+  convenience. A crate-private helper is acceptable only if it reduces drift
+  and stays narrower than the current public surface.
+- Keep each Rust source file below 400 lines. Add focused sibling modules or a
+  dedicated behaviour harness instead of overloading existing files.
+- Every new Rust module must begin with a `//!` module-level comment.
+- Every new or newly public API must carry Rustdoc comments with examples that
+  follow the guidance in `docs/rust-doctest-dry-guide.md`.
+- Use workspace-pinned `rstest`, `rstest-bdd`, and `rstest-bdd-macros`
+  (`0.5.0`) for unit and behavioural coverage.
+- Behaviour tests must stay within the workspace Clippy argument-count limit:
+  `world` plus at most three parsed values per step.
+- Integration tests under `crates/whitaker_clones_core/tests/` should avoid
+  `unwrap()` and `expect()` in new code, following the repository's preferred
+  BDD world-helper style.
+- Keep the ordering contract explicit: canonicalization is lexical
+  `FragmentId` ordering, not insertion order, numeric ordering, or span order.
+- Update `docs/whitaker-clone-detector-design.md` with final 7.2.6 decisions.
+- Update `docs/developers-guide.md` with any significant developer-facing proof
+  workflow or trust-boundary guidance introduced by this change.
+- Only update `docs/users-guide.md` if the implementation changes a public
+  feature, interface, or observable tool behaviour.
+- Do not mark roadmap item 7.2.6 done until implementation, proof runs, tests,
+  and all requested quality gates succeed.
+- Run long validation commands through `tee` with `set -o pipefail`, because
+  the environment truncates direct output.
+- Keep this plan in `DRAFT` status until approval is received.
+
+## Tolerances
+
+- Proof-model tolerance: if the Verus proof cannot stay a small
+  implementation-shaped model and starts needing trusted assumptions about the
+  compiled `FragmentId` or `String` implementation, stop and escalate before
+  weakening the claim silently.
+- Scope tolerance: if proving 7.2.6 appears to require new Kani harnesses,
+  `LshIndex` redesign, or SARIF emission changes, stop and ask whether the
+  roadmap scope should be widened deliberately.
+- API tolerance: if the only practical route is to expose a new public helper
+  from `index/types.rs`, stop and ask before widening the public API.
+- Validation tolerance: if `make check-fmt`, `make lint`, or `make test` still
+  fail after three focused fix iterations, stop and escalate with saved log
+  paths.
+- File-size tolerance: if the implementation would push a Rust file over 400
+  lines or touch more than 10 files, stop and split the work more cleanly
+  before continuing.
+- Semantics tolerance: if the proof or direct tests reveal ambiguity over what
+  "lexical order" means for `FragmentId`, stop and ask whether the project
+  wants bytewise string order, locale-aware order, or a different domain rule.
+- Documentation tolerance: if `docs/users-guide.md` starts needing substantive
+  updates, pause and confirm that the change is truly user-facing rather than
+  maintainer-facing.
+
+## Risks
+
+- Drift risk: a sidecar proof can drift from the runtime constructor logic.
+  Mitigation: mirror the real branch order exactly and add direct runtime unit
+  and BDD tests around the concrete Rust implementation.
+- Ordering-semantics risk: `FragmentId` is a string-backed newtype with derived
+  `Ord`, so future maintainers may misread the contract as natural-number or
+  span-based ordering. Mitigation: add one edge-case test that proves the
+  contract is lexical string order and document that decision in the design
+  document.
+- Indirect-coverage risk: the repository already tests pair behaviour through
+  `LshIndex` and SARIF flows, but those tests do not isolate the constructor.
+  Mitigation: add direct constructor tests and a dedicated behaviour harness.
+- Workflow-wiring risk: `scripts/run-verus.sh` currently lists only
+  `verus/clone_detector_lsh_config.rs` for the clone-detector group.
+  Mitigation: add the new proof file explicitly to both the `clone-detector`
+  and `all` groups, then validate both `make verus-clone-detector` and
+  `make verus`.
+- Documentation-scope risk: proof-only work often tempts unnecessary user-guide
+  edits. Mitigation: check explicitly for user-visible behaviour changes before
+  touching `docs/users-guide.md`.
+
+## Progress
+
+- [x] Stage A: Gather repository context, inspect the current proof workflow,
+  and draft this ExecPlan (2026-04-21).
+- [ ] Stage B: Add failing direct unit tests for `CandidatePair::new` happy,
+  unhappy, and edge-case behaviour.
+- [ ] Stage C: Add failing `rstest-bdd` v0.5.0 scenarios for direct
+  `CandidatePair::new` behaviour.
+- [ ] Stage D: Add a dedicated Verus sidecar proof for `CandidatePair::new`
+  and wire it into `scripts/run-verus.sh`.
+- [ ] Stage E: Make the targeted tests and proof green, refactoring only as
+  needed to keep files small and readable.
+- [ ] Stage F: Update `docs/whitaker-clone-detector-design.md`,
+  `docs/developers-guide.md`, and `docs/users-guide.md` if user-visible
+  behaviour actually changed.
+- [ ] Stage G: Mark roadmap item 7.2.6 done in `docs/roadmap.md`.
+- [ ] Stage H: Run documentation, proof, lint, and test gates successfully.
+- [ ] Stage I: Finalize the living sections in this ExecPlan after the
+  implementation turn.
+
+## Surprises & Discoveries
+
+- `CandidatePair::new` already exists in
+  `crates/whitaker_clones_core/src/index/types.rs` and already has the exact
+  branch structure the roadmap item wants proved: equality returns `None`,
+  ordered distinct inputs are preserved, and reversed distinct inputs are
+  swapped.
+- The existing `src/index/tests.rs` file covers self-pair suppression and
+  canonical ordering only indirectly through `LshIndex`, not through isolated
+  constructor tests.
+- The existing clone-detector Verus runner knows about only one proof file,
+  `verus/clone_detector_lsh_config.rs`, so 7.2.6 must extend the runner rather
+  than only dropping in a new proof file.
+- `docs/developers-guide.md` already contains trust-boundary language for the
+  `LshConfig::new` proof. Reusing that wording pattern will keep 7.2.6 aligned
+  with the established proof model.
+- `docs/whitaker-clone-detector-design.md` already states that candidate pairs
+  are emitted in lexical `FragmentId` order and that self-pairs are suppressed.
+  The 7.2.6 work therefore proves an existing documented invariant rather than
+  inventing a new one.
+
+## Decision Log
+
+- Decision: implement 7.2.6 as a dedicated proof file,
+  `verus/clone_detector_candidate_pair.rs`, instead of extending
+  `verus/clone_detector_lsh_config.rs`. Rationale: one roadmap item maps
+  cleanly to one proof artefact, and `scripts/run-verus.sh` output stays
+  explicit. Date/Author: 2026-04-21 / Codex.
+- Decision: add direct unit and BDD coverage for `CandidatePair::new` instead
+  of treating existing `LshIndex` tests as sufficient. Rationale: roadmap item
+  7.2.6 is about the constructor seam itself, and direct tests reduce proof
+  drift. Date/Author: 2026-04-21 / Codex.
+- Decision: keep the ordering contract lexical and string-based, matching the
+  current `FragmentId` derived ordering, and document that explicitly.
+  Rationale: later SARIF and deduplication stages already depend on that
+  concrete contract. Date/Author: 2026-04-21 / Codex.
+- Decision: treat `docs/users-guide.md` as "update only if needed", not as an
+  automatic edit. Rationale: this roadmap slice is proof and developer-guidance
+  work unless implementation exposes a new user-facing behaviour. Date/Author:
+  2026-04-21 / Codex.
+
+## Context and orientation
+
+### Repository state
+
+The code under proof lives in `crates/whitaker_clones_core/src/index/types.rs`.
+The current constructor is:
+
+```rust
+pub fn new(left: FragmentId, right: FragmentId) -> Option<Self> {
+    if left == right {
+        return None;
+    }
+    if left < right {
+        return Some(Self { left, right });
+    }
+    Some(Self {
+        left: right,
+        right: left,
+    })
+}
+```
+
+The clone-detector proof workflow already exists:
+
+- `make verus-clone-detector` delegates to `./scripts/run-verus.sh
+  clone-detector`.
+- `scripts/run-verus.sh` currently includes only
+  `verus/clone_detector_lsh_config.rs` for the clone-detector group.
+- `make verus` delegates to the same runner's `all` group.
+
+The direct upstream and downstream dependencies that matter are:
+
+- `crates/whitaker_clones_core/src/index/lsh.rs`, where `CandidatePair::new` is
+  used while emitting deduplicated candidate pairs from band buckets.
+- `crates/whitaker_clones_core/src/run0/types.rs` and
+  `crates/whitaker_clones_core/tests/run0_sarif_behaviour.rs`, where the
+  canonical left fragment already drives downstream observable behaviour.
+- `docs/whitaker-clone-detector-design.md`, which already documents lexical
+  pair ordering and self-pair suppression as part of the shipped 7.2.2 design.
+
+### Proof shape to preserve
+
+ADR 003 assigns small canonicalization invariants to Verus and bounded
+collection-heavy behaviour to Kani. That means 7.2.6 should stay intentionally
+small:
+
+- Verus proves the constructor model for an ordered identifier domain.
+- Unit tests and BDD scenarios pin the concrete runtime semantics of the
+  `String`-backed `FragmentId`.
+- No new Kani harness is needed for this roadmap item.
+
+### Testing shape to preserve
+
+The repository already uses:
+
+- `rstest` fixtures for unit-level setup reuse.
+- `rstest-bdd` v0.5.0 for behaviour tests under
+  `crates/whitaker_clones_core/tests/`.
+- Indexed `#[scenario]` bindings plus a small world struct, as documented in
+  `docs/whitaker-clone-detector-design.md`.
+
+7.2.6 should follow that existing shape rather than inventing a second testing
+style.
+
+## Proposed implementation shape
+
+Implement the feature in four small slices.
+
+1. Add direct constructor tests in
+   `crates/whitaker_clones_core/src/index/tests.rs`. These tests should prove:
+   - already-canonical distinct inputs are preserved,
+   - reversed distinct inputs are swapped,
+   - identical inputs return `None`,
+   - an edge case such as `"fragment-10"` versus `"fragment-2"` follows lexical
+     string ordering rather than natural-number ordering.
+2. Add a dedicated behaviour harness,
+   `crates/whitaker_clones_core/tests/candidate_pair_behaviour.rs`, plus
+   `crates/whitaker_clones_core/tests/features/candidate_pair.feature`. The
+   world only needs to store the attempted input IDs and the resulting
+   `Option<CandidatePair>`.
+3. Add `verus/clone_detector_candidate_pair.rs`.
+   The proof should mirror the constructor's three-way branch structure and
+   establish:
+   - equal inputs are suppressed,
+   - distinct inputs always yield a pair,
+   - the returned pair is ordered so that `left < right`,
+   - if the inputs are already ordered, the constructor preserves that order,
+   - if the inputs are reversed, the constructor swaps them exactly once.
+4. Update `scripts/run-verus.sh` so the `clone-detector` and `all` groups
+   include the new proof file. Then update
+   `docs/whitaker-clone-detector-design.md` and `docs/developers-guide.md` to
+   record the final proof scope and wording.
+
+Prefer no runtime refactor. If constructor tests become awkward to read, small
+test-local helpers are acceptable. A new runtime helper inside `index/types.rs`
+should be added only if it materially improves clarity without widening the
+public API.
+
+## Detailed work plan
+
+### Stage B: make the constructor contract fail loudly in tests first
+
+Add direct unit tests to `crates/whitaker_clones_core/src/index/tests.rs`
+before touching the proof runner. The new tests should fail if:
+
+- `CandidatePair::new` stops returning `None` for equal IDs,
+- canonical order stops being preserved,
+- reversed inputs stop being normalized,
+- lexical string order changes unexpectedly for similar-looking IDs.
+
+These tests isolate the constructor contract so later proof work has a runtime
+anchor.
+
+### Stage C: add behaviour-level coverage
+
+Create a dedicated BDD harness for `CandidatePair::new` instead of extending
+`min_hash_lsh_behaviour.rs`. The behaviour file should stay tightly focused on
+the public constructor API and avoid pulling MinHash or LSH setup into the
+world.
+
+Use four scenarios:
+
+1. Already-canonical distinct IDs return the same ordered pair.
+2. Reversed distinct IDs are normalized into canonical order.
+3. Identical IDs produce no pair.
+4. Similar identifiers demonstrate lexical ordering explicitly.
+
+Keep every step to `world` plus at most three parsed values. Use `match`-based
+world helpers instead of `expect()` in the integration test.
+
+### Stage D: add the Verus proof
+
+Create `verus/clone_detector_candidate_pair.rs` as an implementation-shaped
+model of the constructor. The cleanest proof shape is to model identifiers as
+an abstract totally ordered value domain in Verus and prove the constructor
+logic over that domain.
+
+That proof does not need to model Rust `String` internals. Instead:
+
+- Verus establishes the control-flow theorem for any ordered IDs.
+- Runtime unit and BDD tests establish that `FragmentId` uses lexical string
+  ordering concretely.
+
+Document that split clearly in the proof file header and in
+`docs/developers-guide.md`, following the existing `LshConfig::new` wording.
+
+### Stage E: wire the proof into the repository workflow
+
+Update `scripts/run-verus.sh` so:
+
+- `clone-detector` runs both `verus/clone_detector_lsh_config.rs` and
+  `verus/clone_detector_candidate_pair.rs`,
+- `all` runs the new proof as well.
+
+Do not change `Makefile` targets unless the existing targets cannot discover
+the new file through the script.
+
+### Stage F: update design and developer documentation
+
+Update `docs/whitaker-clone-detector-design.md` with a new
+`## Implementation decisions (7.2.6)` section. Record at least:
+
+- that `CandidatePair::new` is now covered by a Verus sidecar proof,
+- that the ordering contract is lexical `FragmentId` order,
+- that self-pair suppression remains a constructor-level invariant,
+- that the proof stays implementation-shaped and does not directly verify the
+  compiled Rust body.
+
+Update `docs/developers-guide.md` so the proof-workflow section explains that
+the clone-detector Verus group now covers both constructor proofs.
+
+Inspect `docs/users-guide.md`. If no public tooling behaviour changed, leave it
+unchanged and say so in the implementation notes. If a user-visible behaviour
+or feature description needs clarification, update it narrowly.
+
+### Stage G: mark the roadmap item done
+
+After all proofs and tests pass, change the 7.2.6 entry in `docs/roadmap.md`
+from `[ ]` to `[x]`.
+
+## Validation and evidence
+
+Run every long command with `tee` and `set -o pipefail`. Save logs in `/tmp/`
+using stable names so failures are easy to inspect and report.
+
+Recommended command sequence for the implementation turn:
+
+```sh
+set -o pipefail && make fmt 2>&1 | tee /tmp/7-2-6-fmt.log
+set -o pipefail && make markdownlint 2>&1 | tee /tmp/7-2-6-markdownlint.log
+set -o pipefail && make nixie 2>&1 | tee /tmp/7-2-6-nixie.log
+set -o pipefail && make check-fmt 2>&1 | tee /tmp/7-2-6-check-fmt.log
+set -o pipefail && make lint 2>&1 | tee /tmp/7-2-6-lint.log
+set -o pipefail && make test 2>&1 | tee /tmp/7-2-6-test.log
+set -o pipefail && make verus-clone-detector 2>&1 | tee /tmp/7-2-6-verus-clone-detector.log
+set -o pipefail && make verus 2>&1 | tee /tmp/7-2-6-verus.log
+```
+
+Expected success signals:
+
+- `make test` reports the new direct constructor tests and the new BDD
+  scenarios passing.
+- `make verus-clone-detector` reports both clone-detector proof files passing.
+- `make verus` reports the full Verus proof set passing, including the new
+  clone-detector proof.
+- `docs/roadmap.md` shows 7.2.6 marked done only after the commands above are
+  green.
+
+## Outcomes & Retrospective
+
+Pending implementation. After approval and delivery, replace this section with
+the actual results, the final proof and test counts, any deviations from the
+draft, and the lessons worth carrying into roadmap items 7.2.7 and 7.2.8.

--- a/docs/execplans/7-2-6-verus-proofs-for-candidate-pair-new-canonicalization.md
+++ b/docs/execplans/7-2-6-verus-proofs-for-candidate-pair-new-canonicalization.md
@@ -208,11 +208,11 @@ Relevant skills for the implementation turn:
   are emitted in lexical `FragmentId` order and that self-pairs are suppressed.
   The 7.2.6 work therefore proves an existing documented invariant rather than
   inventing a new one.
-- The implementation did not need any production-code refactor in
-  `index/types.rs`; direct tests and the new sidecar proof were sufficient to
-  pin the contract.
-- The Verus proof is simplest and clearest when it models an ordered
-  identifier domain with `nat` values, while runtime tests cover the concrete
+- The strengthening pass extracted `FragmentId` into
+  `src/index/fragment_id.rs` so the sidecar can import the real source
+  definition instead of a hand-copied stand-in.
+- The Verus proof now keeps the `nat` model as a ghost ranking behind an
+  explicit `FragmentId` bridge lemma, while runtime tests cover the concrete
   lexical-string behaviour of `FragmentId`.
 
 ## Decision Log
@@ -238,10 +238,11 @@ Relevant skills for the implementation turn:
   existing behaviour instead of extracting a proof helper. Rationale: the
   constructor is already small, direct, and readable, so a helper would add
   surface area without reducing drift. Date/Author: 2026-04-22 / Codex.
-- Decision: model proof identifiers as `nat` values in Verus and rely on
-  direct runtime tests to pin lexical `FragmentId` semantics. Rationale: this
-  proves the constructor's ordering control flow without pretending to verify
-  Rust `String` internals. Date/Author: 2026-04-22 / Codex.
+- Decision: strengthen the proof with an explicit `FragmentId` bridge lemma and
+  keep the `nat` model behind a ghost ranking rather than as the public proof
+  surface. Rationale: this makes the strict-total-order assumption visible in
+  machine-checked form without pretending to verify Rust `String` internals.
+  Date/Author: 2026-04-23 / Codex.
 
 ## Context and orientation
 
@@ -382,7 +383,11 @@ logic over that domain.
 
 That proof does not need to model Rust `String` internals. Instead:
 
-- Verus establishes the control-flow theorem for any ordered IDs.
+- Verus establishes the control-flow theorem for any identifier type whose
+  `partial_cmp` satisfies the strict-total-order axioms used by the constructor
+  proof.
+- A dedicated bridge lemma makes that assumption explicit for `FragmentId` via
+  a ghost `nat` ranking.
 - Runtime unit and BDD tests establish that `FragmentId` uses lexical string
   ordering concretely.
 

--- a/docs/execplans/7-2-6-verus-proofs-for-candidate-pair-new-canonicalization.md
+++ b/docs/execplans/7-2-6-verus-proofs-for-candidate-pair-new-canonicalization.md
@@ -118,7 +118,8 @@ Relevant skills for the implementation turn:
   and all requested quality gates succeed.
 - Run long validation commands through `tee` with `set -o pipefail`, because
   the environment truncates direct output.
-- Keep this plan in `DRAFT` status until approval is received.
+- Keep this plan in `COMPLETE` status unless later review reopens roadmap item
+  7.2.6 with new implementation work.
 
 ## Tolerances
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -382,7 +382,7 @@
   `rows`, and enforces `bands * rows == MINHASH_SIZE`. Requires 7.2.4. See
   [ADR 003](adr-003-formal-proof-strategy-for-clone-detector-pipeline.md) and
   [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.
-- [ ] 7.2.6. Use Verus to prove `CandidatePair::new` canonicalizes fragment
+- [x] 7.2.6. Use Verus to prove `CandidatePair::new` canonicalizes fragment
   ordering and suppresses self-pairs. Requires 7.2.4. See
   [ADR 003](adr-003-formal-proof-strategy-for-clone-detector-pipeline.md) and
   [clone detector design](whitaker-clone-detector-design.md) §MinHash and LSH.

--- a/docs/whitaker-clone-detector-design.md
+++ b/docs/whitaker-clone-detector-design.md
@@ -557,6 +557,31 @@ cargo whitaker clones report --in target/whitaker/clones.refined.sarif --html
    `usize::MAX` with `rows = 2` return `IndexError::InvalidBandRowProduct`
    rather than panicking or widening the public API with proof-specific helpers.
 
+## Implementation decisions (7.2.6)
+
+1. **`CandidatePair::new` now has direct constructor coverage.** The runtime
+   contract is pinned with unit tests in `src/index/tests.rs` and a dedicated
+   `rstest-bdd` harness in `tests/candidate_pair_behaviour.rs`, rather than
+   relying only on indirect `LshIndex` coverage.
+
+2. **Canonical order is lexical `FragmentId` order.** `FragmentId` remains a
+   string-backed newtype with derived ordering, so `CandidatePair::new`
+   canonicalizes using lexical string order. The direct tests include a
+   similar-looking pair (`"fragment-2"` and `"fragment-10"`) to make clear that
+   the contract is lexical rather than natural-number ordering.
+
+3. **Self-pair suppression remains a constructor-level invariant.** Equal
+   fragment IDs still return `None` from `CandidatePair::new`, which keeps
+   downstream candidate generation and SARIF emission free from accidental
+   self-matches.
+
+4. **The Verus proof stays implementation-shaped and order-modelled.** The
+   sidecar proof for `CandidatePair::new` mirrors the runtime three-way branch
+   structure over an ordered identifier model rather than claiming to verify
+   Rust `String` internals or the compiled `FragmentId` body directly. Runtime
+   tests pin the concrete lexical-string semantics, while Verus proves the
+   canonicalization control flow.
+
 ## Minimal code skeletons (selected)
 
 ### Token to fingerprints to candidates

--- a/docs/whitaker-clone-detector-design.md
+++ b/docs/whitaker-clone-detector-design.md
@@ -575,12 +575,14 @@ cargo whitaker clones report --in target/whitaker/clones.refined.sarif --html
    downstream candidate generation and SARIF emission free from accidental
    self-matches.
 
-4. **The Verus proof stays implementation-shaped and order-modelled.** The
-   sidecar proof for `CandidatePair::new` mirrors the runtime three-way branch
-   structure over an ordered identifier model rather than claiming to verify
-   Rust `String` internals or the compiled `FragmentId` body directly. Runtime
-   tests pin the concrete lexical-string semantics, while Verus proves the
-   canonicalization control flow.
+4. **The Verus proof now names the `FragmentId` ordering trust boundary
+   explicitly.** The sidecar still mirrors the runtime three-way branch
+   structure, but it now imports the real `FragmentId` source definition,
+   introduces a trusted bridge lemma stating that `FragmentId::partial_cmp`
+   satisfies the strict-total-order axioms via a ghost `nat` ranking, and then
+   proves the constructor contract generically over that ordered domain.
+   Runtime tests still pin the concrete lexical-string semantics; the proof
+   does not verify Rust `String` internals directly.
 
 ## Minimal code skeletons (selected)
 

--- a/scripts/check-verus-fragment-id-bridge.sh
+++ b/scripts/check-verus-fragment-id-bridge.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)
+SIDECAR="${REPO_ROOT}/verus/clone_detector_candidate_pair.rs"
+EXPECTED_PATH="../crates/whitaker_clones_core/src/index/fragment_id.rs"
+EXPECTED_SYMBOL="FragmentId"
+RUNTIME_FILE="${REPO_ROOT}/verus/${EXPECTED_PATH}"
+
+if ! grep -F "#[path = \"${EXPECTED_PATH}\"]" "${SIDECAR}" >/dev/null; then
+    printf 'missing expected Verus bridge path in %s: #[path = "%s"]\n' \
+        "${SIDECAR}" "${EXPECTED_PATH}" >&2
+    exit 1
+fi
+
+if ! grep -F "use fragment_id_runtime::${EXPECTED_SYMBOL};" "${SIDECAR}" >/dev/null; then
+    printf 'missing expected Verus bridge symbol import in %s: %s\n' \
+        "${SIDECAR}" "${EXPECTED_SYMBOL}" >&2
+    exit 1
+fi
+
+if [ ! -f "${RUNTIME_FILE}" ]; then
+    printf 'Verus bridge runtime file does not exist: %s\n' "${RUNTIME_FILE}" >&2
+    exit 1
+fi
+
+if ! grep -Eq "(^|[[:space:]])pub[[:space:]]+struct[[:space:]]+${EXPECTED_SYMBOL}($|[[:space:]<(])" \
+    "${RUNTIME_FILE}"; then
+    printf 'Verus bridge runtime file does not declare expected type: %s\n' \
+        "${EXPECTED_SYMBOL}" >&2
+    exit 1
+fi

--- a/scripts/run-verus.sh
+++ b/scripts/run-verus.sh
@@ -15,13 +15,15 @@ proof_files_for_group() {
             ;;
         clone-detector)
             printf '%s\n' \
-                "${REPO_ROOT}/verus/clone_detector_lsh_config.rs"
+                "${REPO_ROOT}/verus/clone_detector_lsh_config.rs" \
+                "${REPO_ROOT}/verus/clone_detector_candidate_pair.rs"
             ;;
         all)
             printf '%s\n' \
                 "${REPO_ROOT}/verus/decomposition_cosine_threshold.rs" \
                 "${REPO_ROOT}/verus/decomposition_vector_algebra.rs" \
-                "${REPO_ROOT}/verus/clone_detector_lsh_config.rs"
+                "${REPO_ROOT}/verus/clone_detector_lsh_config.rs" \
+                "${REPO_ROOT}/verus/clone_detector_candidate_pair.rs"
             ;;
         *)
             printf 'unknown Verus proof group: %s\n' "$1" >&2

--- a/verus/clone_detector_candidate_pair.rs
+++ b/verus/clone_detector_candidate_pair.rs
@@ -1,57 +1,218 @@
 //! Verus proof for the `CandidatePair::new` constructor contract.
 //!
-//! This sidecar mirrors the runtime three-way branch structure exactly:
+//! This sidecar still mirrors the runtime three-way branch structure exactly:
 //! identical IDs are rejected first, already ordered distinct IDs are
 //! preserved second, and reversed distinct IDs are swapped last.
 //!
-//! The proof models fragment identifiers as natural numbers standing in for an
-//! ordered identifier domain. That keeps the proof focused on constructor
-//! control flow instead of claiming to verify Rust `String` internals or the
-//! compiled `FragmentId` implementation directly. Runtime unit and behaviour
-//! tests pin the concrete lexical-string ordering contract.
+//! The difference from the initial proof is that the ordered-ID model is now
+//! made explicit as a trusted bridge over the real `FragmentId` source
+//! definition. The proof does not verify Rust `String` internals or prove that
+//! the derived `FragmentId::partial_cmp` implementation is lexicographic from
+//! first principles. Instead, it introduces a ghost `nat` ranking for
+//! `FragmentId`, uses that ranking to state the strict-total-order axioms
+//! required by the constructor proof, and makes the trust boundary explicit in
+//! one bridge lemma rather than leaving it only in prose.
+
+use core::cmp::Ordering;
 
 use vstd::prelude::*;
+use vstd::std_specs::cmp::{PartialEqSpec, PartialOrdSpec};
+
+#[path = "../crates/whitaker_clones_core/src/index/fragment_id.rs"]
+mod fragment_id_runtime;
+
+use fragment_id_runtime::FragmentId;
 
 verus! {
 
-enum CandidatePairOutcome {
+#[verifier::external_type_specification]
+#[verifier::external_body]
+pub struct ExFragmentId(FragmentId);
+
+enum CandidatePairOutcome<Id> {
     NoPair,
-    Pair(nat, nat),
+    Pair(Id, Id),
 }
 
-spec fn candidate_pair_new_result(left: nat, right: nat) -> CandidatePairOutcome {
-    if left == right {
+pub uninterp spec fn fragment_id_rank(id: &FragmentId) -> nat;
+
+pub open spec fn fragment_id_partial_cmp_model(
+    left: &FragmentId,
+    right: &FragmentId,
+) -> Option<Ordering> {
+    if fragment_id_rank(left) < fragment_id_rank(right) {
+        Some(Ordering::Less)
+    } else if fragment_id_rank(left) > fragment_id_rank(right) {
+        Some(Ordering::Greater)
+    } else {
+        Some(Ordering::Equal)
+    }
+}
+
+impl vstd::std_specs::cmp::PartialEqSpecImpl for FragmentId {
+    open spec fn obeys_eq_spec() -> bool {
+        true
+    }
+
+    open spec fn eq_spec(&self, other: &FragmentId) -> bool {
+        fragment_id_rank(self) == fragment_id_rank(other)
+    }
+}
+
+impl vstd::std_specs::cmp::PartialOrdSpecImpl for FragmentId {
+    open spec fn obeys_partial_cmp_spec() -> bool {
+        true
+    }
+
+    open spec fn partial_cmp_spec(&self, other: &FragmentId) -> Option<Ordering> {
+        fragment_id_partial_cmp_model(self, other)
+    }
+}
+
+pub assume_specification[ <FragmentId as PartialEq<FragmentId>>::eq ](
+    left: &FragmentId,
+    right: &FragmentId,
+) -> bool;
+
+pub assume_specification[ <FragmentId as PartialOrd<FragmentId>>::partial_cmp ](
+    left: &FragmentId,
+    right: &FragmentId,
+) -> Option<Ordering>;
+
+pub open spec fn strict_total_order_axioms<Id: PartialOrd>() -> bool {
+    &&& forall|id: Id| #[trigger] id.eq_spec(&id)
+    &&& forall|left: Id, right: Id| #[trigger] left.partial_cmp_spec(&right)
+        != None::<Ordering>
+    &&& forall|left: Id, right: Id| #[trigger]
+        left.partial_cmp_spec(&right) == Some(Ordering::Equal) <==> left.eq_spec(&right)
+    &&& forall|left: Id, right: Id| #[trigger]
+        left.partial_cmp_spec(&right) == Some(Ordering::Less) <==> right.partial_cmp_spec(&left)
+            == Some(Ordering::Greater)
+    &&& forall|left: Id, right: Id| #[trigger]
+        left.partial_cmp_spec(&right) == Some(Ordering::Greater) <==> right.partial_cmp_spec(
+            &left,
+        ) == Some(Ordering::Less)
+    &&& forall|left: Id, middle: Id, right: Id|
+        left.partial_cmp_spec(&middle) == Some(Ordering::Less) && #[trigger]
+            middle.partial_cmp_spec(&right) == Some(Ordering::Less) ==> #[trigger]
+            left.partial_cmp_spec(&right) == Some(Ordering::Less)
+}
+
+proof fn lemma_fragment_id_partial_cmp_obeys_strict_total_order()
+    ensures
+        strict_total_order_axioms::<FragmentId>(),
+{
+    assert forall|id: FragmentId| #[trigger] id.eq_spec(&id) by {
+        assert(fragment_id_rank(&id) == fragment_id_rank(&id));
+    };
+
+    assert forall|left: FragmentId, right: FragmentId| #[trigger]
+        left.partial_cmp_spec(&right) != None::<Ordering> by {
+        if fragment_id_rank(&left) < fragment_id_rank(&right) {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Less));
+        } else if fragment_id_rank(&left) > fragment_id_rank(&right) {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Greater));
+        } else {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Equal));
+        }
+    };
+
+    assert forall|left: FragmentId, right: FragmentId| #[trigger]
+        left.partial_cmp_spec(&right) == Some(Ordering::Equal) <==> left.eq_spec(&right) by {
+        if fragment_id_rank(&left) < fragment_id_rank(&right) {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Less));
+            assert(!left.eq_spec(&right));
+        } else if fragment_id_rank(&left) > fragment_id_rank(&right) {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Greater));
+            assert(!left.eq_spec(&right));
+        } else {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Equal));
+            assert(left.eq_spec(&right));
+        }
+    };
+
+    assert forall|left: FragmentId, right: FragmentId| #[trigger]
+        left.partial_cmp_spec(&right) == Some(Ordering::Less) <==> right.partial_cmp_spec(&left)
+            == Some(Ordering::Greater) by {
+        if fragment_id_rank(&left) < fragment_id_rank(&right) {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Less));
+            assert(right.partial_cmp_spec(&left) == Some(Ordering::Greater));
+        } else if fragment_id_rank(&left) > fragment_id_rank(&right) {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Greater));
+            assert(right.partial_cmp_spec(&left) == Some(Ordering::Less));
+        } else {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Equal));
+            assert(right.partial_cmp_spec(&left) == Some(Ordering::Equal));
+        }
+    };
+
+    assert forall|left: FragmentId, right: FragmentId| #[trigger]
+        left.partial_cmp_spec(&right) == Some(Ordering::Greater) <==> right.partial_cmp_spec(
+            &left,
+        ) == Some(Ordering::Less) by {
+        if fragment_id_rank(&left) < fragment_id_rank(&right) {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Less));
+            assert(right.partial_cmp_spec(&left) == Some(Ordering::Greater));
+        } else if fragment_id_rank(&left) > fragment_id_rank(&right) {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Greater));
+            assert(right.partial_cmp_spec(&left) == Some(Ordering::Less));
+        } else {
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Equal));
+            assert(right.partial_cmp_spec(&left) == Some(Ordering::Equal));
+        }
+    };
+
+    assert forall|left: FragmentId, middle: FragmentId, right: FragmentId|
+        left.partial_cmp_spec(&middle) == Some(Ordering::Less) && #[trigger]
+            middle.partial_cmp_spec(&right) == Some(Ordering::Less) implies #[trigger]
+            left.partial_cmp_spec(&right) == Some(Ordering::Less) by {
+        if left.partial_cmp_spec(&middle) == Some(Ordering::Less)
+            && middle.partial_cmp_spec(&right) == Some(Ordering::Less)
+        {
+            assert(fragment_id_rank(&left) < fragment_id_rank(&middle));
+            assert(fragment_id_rank(&middle) < fragment_id_rank(&right));
+            assert(fragment_id_rank(&left) < fragment_id_rank(&right));
+            assert(left.partial_cmp_spec(&right) == Some(Ordering::Less));
+        }
+    };
+}
+
+spec fn candidate_pair_new_result<Id: PartialOrd>(left: Id, right: Id) -> CandidatePairOutcome<Id> {
+    if left.eq_spec(&right) {
         CandidatePairOutcome::NoPair
-    } else if left < right {
+    } else if left.partial_cmp_spec(&right) == Some(Ordering::Less) {
         CandidatePairOutcome::Pair(left, right)
     } else {
         CandidatePairOutcome::Pair(right, left)
     }
 }
 
-spec fn constructor_accepts(left: nat, right: nat) -> bool {
+spec fn constructor_accepts<Id: PartialOrd>(left: Id, right: Id) -> bool {
     match candidate_pair_new_result(left, right) {
         CandidatePairOutcome::Pair(_, _) => true,
         CandidatePairOutcome::NoPair => false,
     }
 }
 
-spec fn is_canonical_pair(left: nat, right: nat, pair_left: nat, pair_right: nat) -> bool {
-    pair_left < pair_right
-        && ((pair_left == left && pair_right == right)
-            || (pair_left == right && pair_right == left))
+spec fn is_canonical_pair<Id: PartialOrd>(left: Id, right: Id, pair_left: Id, pair_right: Id) -> bool {
+    pair_left.partial_cmp_spec(&pair_right) == Some(Ordering::Less)
+        && ((pair_left.eq_spec(&left) && pair_right.eq_spec(&right))
+            || (pair_left.eq_spec(&right) && pair_right.eq_spec(&left)))
 }
 
-proof fn lemma_equal_inputs_are_suppressed(id: nat)
+proof fn lemma_equal_inputs_are_suppressed<Id: PartialOrd>(id: Id)
+    requires
+        strict_total_order_axioms::<Id>(),
     ensures
-        candidate_pair_new_result(id, id) == CandidatePairOutcome::NoPair,
+        candidate_pair_new_result(id, id) == CandidatePairOutcome::<Id>::NoPair,
         !constructor_accepts(id, id),
 {
 }
 
-proof fn lemma_ordered_inputs_are_preserved(left: nat, right: nat)
+proof fn lemma_ordered_inputs_are_preserved<Id: PartialOrd>(left: Id, right: Id)
     requires
-        left < right,
+        strict_total_order_axioms::<Id>(),
+        left.partial_cmp_spec(&right) == Some(Ordering::Less),
     ensures
         candidate_pair_new_result(left, right) == CandidatePairOutcome::Pair(left, right),
         constructor_accepts(left, right),
@@ -59,20 +220,22 @@ proof fn lemma_ordered_inputs_are_preserved(left: nat, right: nat)
 {
 }
 
-proof fn lemma_reversed_inputs_are_swapped(left: nat, right: nat)
+proof fn lemma_reversed_inputs_are_swapped<Id: PartialOrd>(left: Id, right: Id)
     requires
-        left > right,
+        strict_total_order_axioms::<Id>(),
+        left.partial_cmp_spec(&right) == Some(Ordering::Greater),
     ensures
         candidate_pair_new_result(left, right) == CandidatePairOutcome::Pair(right, left),
         constructor_accepts(left, right),
         is_canonical_pair(left, right, right, left),
 {
-    assert(right < left);
+    assert(right.partial_cmp_spec(&left) == Some(Ordering::Less));
 }
 
-proof fn lemma_distinct_inputs_yield_one_canonical_pair(left: nat, right: nat)
+proof fn lemma_distinct_inputs_yield_one_canonical_pair<Id: PartialOrd>(left: Id, right: Id)
     requires
-        left != right,
+        strict_total_order_axioms::<Id>(),
+        !left.eq_spec(&right),
     ensures
         constructor_accepts(left, right),
         match candidate_pair_new_result(left, right) {
@@ -82,42 +245,56 @@ proof fn lemma_distinct_inputs_yield_one_canonical_pair(left: nat, right: nat)
             CandidatePairOutcome::NoPair => false,
         },
 {
-    if left < right {
-        lemma_ordered_inputs_are_preserved(left, right);
-    } else {
-        lemma_reversed_inputs_are_swapped(left, right);
+    match left.partial_cmp_spec(&right) {
+        Some(Ordering::Less) => {
+            lemma_ordered_inputs_are_preserved(left, right);
+        }
+        Some(Ordering::Equal) => {
+            assert(left.eq_spec(&right));
+            assert(false);
+        }
+        Some(Ordering::Greater) => {
+            lemma_reversed_inputs_are_swapped(left, right);
+        }
+        None => {
+            assert(false);
+        }
     }
 }
 
-proof fn lemma_constructor_contract(left: nat, right: nat)
+proof fn lemma_constructor_contract<Id: PartialOrd>(left: Id, right: Id)
+    requires
+        strict_total_order_axioms::<Id>(),
     ensures
-        !constructor_accepts(left, right) <==> left == right,
-        constructor_accepts(left, right) <==> left != right,
+        !constructor_accepts(left, right) <==> left.eq_spec(&right),
+        constructor_accepts(left, right) <==> !left.eq_spec(&right),
         match candidate_pair_new_result(left, right) {
             CandidatePairOutcome::Pair(pair_left, pair_right) => {
                 is_canonical_pair(left, right, pair_left, pair_right)
             }
-            CandidatePairOutcome::NoPair => left == right,
+            CandidatePairOutcome::NoPair => left.eq_spec(&right),
         },
 {
-    if left == right {
+    if left.eq_spec(&right) {
         lemma_equal_inputs_are_suppressed(left);
     } else {
         lemma_distinct_inputs_yield_one_canonical_pair(left, right);
     }
 }
 
-proof fn lemma_documented_examples()
+proof fn lemma_fragment_id_constructor_contract(left: FragmentId, right: FragmentId)
     ensures
-        candidate_pair_new_result(1, 1) == CandidatePairOutcome::NoPair,
-        candidate_pair_new_result(1, 2) == CandidatePairOutcome::Pair(1, 2),
-        candidate_pair_new_result(2, 1) == CandidatePairOutcome::Pair(1, 2),
-        candidate_pair_new_result(10, 2) == CandidatePairOutcome::Pair(2, 10),
+        !constructor_accepts(left, right) <==> left.eq_spec(&right),
+        constructor_accepts(left, right) <==> !left.eq_spec(&right),
+        match candidate_pair_new_result(left, right) {
+            CandidatePairOutcome::Pair(pair_left, pair_right) => {
+                is_canonical_pair(left, right, pair_left, pair_right)
+            }
+            CandidatePairOutcome::NoPair => left.eq_spec(&right),
+        },
 {
-    lemma_equal_inputs_are_suppressed(1);
-    lemma_ordered_inputs_are_preserved(1, 2);
-    lemma_reversed_inputs_are_swapped(2, 1);
-    lemma_reversed_inputs_are_swapped(10, 2);
+    lemma_fragment_id_partial_cmp_obeys_strict_total_order();
+    lemma_constructor_contract(left, right);
 }
 
 fn main() {

--- a/verus/clone_detector_candidate_pair.rs
+++ b/verus/clone_detector_candidate_pair.rs
@@ -1,0 +1,126 @@
+//! Verus proof for the `CandidatePair::new` constructor contract.
+//!
+//! This sidecar mirrors the runtime three-way branch structure exactly:
+//! identical IDs are rejected first, already ordered distinct IDs are
+//! preserved second, and reversed distinct IDs are swapped last.
+//!
+//! The proof models fragment identifiers as natural numbers standing in for an
+//! ordered identifier domain. That keeps the proof focused on constructor
+//! control flow instead of claiming to verify Rust `String` internals or the
+//! compiled `FragmentId` implementation directly. Runtime unit and behaviour
+//! tests pin the concrete lexical-string ordering contract.
+
+use vstd::prelude::*;
+
+verus! {
+
+enum CandidatePairOutcome {
+    NoPair,
+    Pair(nat, nat),
+}
+
+spec fn candidate_pair_new_result(left: nat, right: nat) -> CandidatePairOutcome {
+    if left == right {
+        CandidatePairOutcome::NoPair
+    } else if left < right {
+        CandidatePairOutcome::Pair(left, right)
+    } else {
+        CandidatePairOutcome::Pair(right, left)
+    }
+}
+
+spec fn constructor_accepts(left: nat, right: nat) -> bool {
+    match candidate_pair_new_result(left, right) {
+        CandidatePairOutcome::Pair(_, _) => true,
+        CandidatePairOutcome::NoPair => false,
+    }
+}
+
+spec fn is_canonical_pair(left: nat, right: nat, pair_left: nat, pair_right: nat) -> bool {
+    pair_left < pair_right
+        && ((pair_left == left && pair_right == right)
+            || (pair_left == right && pair_right == left))
+}
+
+proof fn lemma_equal_inputs_are_suppressed(id: nat)
+    ensures
+        candidate_pair_new_result(id, id) == CandidatePairOutcome::NoPair,
+        !constructor_accepts(id, id),
+{
+}
+
+proof fn lemma_ordered_inputs_are_preserved(left: nat, right: nat)
+    requires
+        left < right,
+    ensures
+        candidate_pair_new_result(left, right) == CandidatePairOutcome::Pair(left, right),
+        constructor_accepts(left, right),
+        is_canonical_pair(left, right, left, right),
+{
+}
+
+proof fn lemma_reversed_inputs_are_swapped(left: nat, right: nat)
+    requires
+        left > right,
+    ensures
+        candidate_pair_new_result(left, right) == CandidatePairOutcome::Pair(right, left),
+        constructor_accepts(left, right),
+        is_canonical_pair(left, right, right, left),
+{
+    assert(right < left);
+}
+
+proof fn lemma_distinct_inputs_yield_one_canonical_pair(left: nat, right: nat)
+    requires
+        left != right,
+    ensures
+        constructor_accepts(left, right),
+        match candidate_pair_new_result(left, right) {
+            CandidatePairOutcome::Pair(pair_left, pair_right) => {
+                is_canonical_pair(left, right, pair_left, pair_right)
+            }
+            CandidatePairOutcome::NoPair => false,
+        },
+{
+    if left < right {
+        lemma_ordered_inputs_are_preserved(left, right);
+    } else {
+        lemma_reversed_inputs_are_swapped(left, right);
+    }
+}
+
+proof fn lemma_constructor_contract(left: nat, right: nat)
+    ensures
+        !constructor_accepts(left, right) <==> left == right,
+        constructor_accepts(left, right) <==> left != right,
+        match candidate_pair_new_result(left, right) {
+            CandidatePairOutcome::Pair(pair_left, pair_right) => {
+                is_canonical_pair(left, right, pair_left, pair_right)
+            }
+            CandidatePairOutcome::NoPair => left == right,
+        },
+{
+    if left == right {
+        lemma_equal_inputs_are_suppressed(left);
+    } else {
+        lemma_distinct_inputs_yield_one_canonical_pair(left, right);
+    }
+}
+
+proof fn lemma_documented_examples()
+    ensures
+        candidate_pair_new_result(1, 1) == CandidatePairOutcome::NoPair,
+        candidate_pair_new_result(1, 2) == CandidatePairOutcome::Pair(1, 2),
+        candidate_pair_new_result(2, 1) == CandidatePairOutcome::Pair(1, 2),
+        candidate_pair_new_result(10, 2) == CandidatePairOutcome::Pair(2, 10),
+{
+    lemma_equal_inputs_are_suppressed(1);
+    lemma_ordered_inputs_are_preserved(1, 2);
+    lemma_reversed_inputs_are_swapped(2, 1);
+    lemma_reversed_inputs_are_swapped(10, 2);
+}
+
+fn main() {
+}
+
+} // verus!

--- a/verus/clone_detector_candidate_pair.rs
+++ b/verus/clone_detector_candidate_pair.rs
@@ -18,6 +18,8 @@ use core::cmp::Ordering;
 use vstd::prelude::*;
 use vstd::std_specs::cmp::{PartialEqSpec, PartialOrdSpec};
 
+// Keep this path in sync with the runtime `FragmentId` source file; CI checks
+// the exact `#[path]` value and imported `FragmentId` symbol below.
 #[path = "../crates/whitaker_clones_core/src/index/fragment_id.rs"]
 mod fragment_id_runtime;
 

--- a/verus/clone_detector_candidate_pair.rs
+++ b/verus/clone_detector_candidate_pair.rs
@@ -262,6 +262,7 @@ proof fn lemma_reversed_inputs_are_swapped(left: FragmentId, right: FragmentId)
 
 proof fn lemma_distinct_ordered_inputs_yield_canonical_pair(left: FragmentId, right: FragmentId)
     requires
+        fragment_id_strict_total_order_axioms(),
         !left.eq_spec(&right),
         left.partial_cmp_spec(&right) == Some(Ordering::Less),
     ensures
@@ -278,6 +279,7 @@ proof fn lemma_distinct_ordered_inputs_yield_canonical_pair(left: FragmentId, ri
 
 proof fn lemma_distinct_reversed_inputs_yield_canonical_pair(left: FragmentId, right: FragmentId)
     requires
+        fragment_id_strict_total_order_axioms(),
         !left.eq_spec(&right),
         left.partial_cmp_spec(&right) == Some(Ordering::Greater),
     ensures

--- a/verus/clone_detector_candidate_pair.rs
+++ b/verus/clone_detector_candidate_pair.rs
@@ -29,24 +29,36 @@ verus! {
 #[verifier::external_body]
 pub struct ExFragmentId(FragmentId);
 
-enum CandidatePairOutcome<Id> {
+enum CandidatePairOutcome {
     NoPair,
-    Pair(Id, Id),
+    Pair(FragmentId, FragmentId),
 }
 
+enum CandidatePairInputRelation {
+    Same,
+    Ordered,
+    Reversed,
+}
+
+// Bridge contract: equal ranks are exactly `eq_spec`, and rank comparison is
+// the trusted model for `FragmentId::partial_cmp` on both sides of the proof.
 pub uninterp spec fn fragment_id_rank(id: &FragmentId) -> nat;
+
+pub open spec fn fragment_id_rank_relation(left: &FragmentId, right: &FragmentId) -> Ordering {
+    if fragment_id_rank(left) < fragment_id_rank(right) {
+        Ordering::Less
+    } else if fragment_id_rank(left) > fragment_id_rank(right) {
+        Ordering::Greater
+    } else {
+        Ordering::Equal
+    }
+}
 
 pub open spec fn fragment_id_partial_cmp_model(
     left: &FragmentId,
     right: &FragmentId,
 ) -> Option<Ordering> {
-    if fragment_id_rank(left) < fragment_id_rank(right) {
-        Some(Ordering::Less)
-    } else if fragment_id_rank(left) > fragment_id_rank(right) {
-        Some(Ordering::Greater)
-    } else {
-        Some(Ordering::Equal)
-    }
+    Some(fragment_id_rank_relation(left, right))
 }
 
 impl vstd::std_specs::cmp::PartialEqSpecImpl for FragmentId {
@@ -79,28 +91,35 @@ pub assume_specification[ <FragmentId as PartialOrd<FragmentId>>::partial_cmp ](
     right: &FragmentId,
 ) -> Option<Ordering>;
 
-pub open spec fn strict_total_order_axioms<Id: PartialOrd>() -> bool {
-    &&& forall|id: Id| #[trigger] id.eq_spec(&id)
-    &&& forall|left: Id, right: Id| #[trigger] left.partial_cmp_spec(&right)
+pub open spec fn fragment_id_strict_total_order_axioms() -> bool {
+    &&& forall|id: FragmentId| #[trigger] id.eq_spec(&id)
+    &&& forall|left: FragmentId, right: FragmentId| #[trigger] left.partial_cmp_spec(&right)
         != None::<Ordering>
-    &&& forall|left: Id, right: Id| #[trigger]
+    &&& forall|left: FragmentId, right: FragmentId| #[trigger]
         left.partial_cmp_spec(&right) == Some(Ordering::Equal) <==> left.eq_spec(&right)
-    &&& forall|left: Id, right: Id| #[trigger]
+    &&& forall|left: FragmentId, right: FragmentId| #[trigger]
         left.partial_cmp_spec(&right) == Some(Ordering::Less) <==> right.partial_cmp_spec(&left)
             == Some(Ordering::Greater)
-    &&& forall|left: Id, right: Id| #[trigger]
+    &&& forall|left: FragmentId, right: FragmentId| #[trigger]
         left.partial_cmp_spec(&right) == Some(Ordering::Greater) <==> right.partial_cmp_spec(
             &left,
         ) == Some(Ordering::Less)
-    &&& forall|left: Id, middle: Id, right: Id|
+    &&& forall|left: FragmentId, middle: FragmentId, right: FragmentId|
         left.partial_cmp_spec(&middle) == Some(Ordering::Less) && #[trigger]
             middle.partial_cmp_spec(&right) == Some(Ordering::Less) ==> #[trigger]
             left.partial_cmp_spec(&right) == Some(Ordering::Less)
 }
 
+proof fn lemma_fragment_id_partial_cmp_matches_rank(left: FragmentId, right: FragmentId)
+    ensures
+        left.partial_cmp_spec(&right) == Some(fragment_id_rank_relation(&left, &right)),
+        right.partial_cmp_spec(&left) == Some(fragment_id_rank_relation(&right, &left)),
+{
+}
+
 proof fn lemma_fragment_id_partial_cmp_obeys_strict_total_order()
     ensures
-        strict_total_order_axioms::<FragmentId>(),
+        fragment_id_strict_total_order_axioms(),
 {
     assert forall|id: FragmentId| #[trigger] id.eq_spec(&id) by {
         assert(fragment_id_rank(&id) == fragment_id_rank(&id));
@@ -108,58 +127,25 @@ proof fn lemma_fragment_id_partial_cmp_obeys_strict_total_order()
 
     assert forall|left: FragmentId, right: FragmentId| #[trigger]
         left.partial_cmp_spec(&right) != None::<Ordering> by {
-        if fragment_id_rank(&left) < fragment_id_rank(&right) {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Less));
-        } else if fragment_id_rank(&left) > fragment_id_rank(&right) {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Greater));
-        } else {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Equal));
-        }
+        lemma_fragment_id_partial_cmp_matches_rank(left, right);
     };
 
     assert forall|left: FragmentId, right: FragmentId| #[trigger]
         left.partial_cmp_spec(&right) == Some(Ordering::Equal) <==> left.eq_spec(&right) by {
-        if fragment_id_rank(&left) < fragment_id_rank(&right) {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Less));
-            assert(!left.eq_spec(&right));
-        } else if fragment_id_rank(&left) > fragment_id_rank(&right) {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Greater));
-            assert(!left.eq_spec(&right));
-        } else {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Equal));
-            assert(left.eq_spec(&right));
-        }
+        lemma_fragment_id_partial_cmp_matches_rank(left, right);
     };
 
     assert forall|left: FragmentId, right: FragmentId| #[trigger]
         left.partial_cmp_spec(&right) == Some(Ordering::Less) <==> right.partial_cmp_spec(&left)
             == Some(Ordering::Greater) by {
-        if fragment_id_rank(&left) < fragment_id_rank(&right) {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Less));
-            assert(right.partial_cmp_spec(&left) == Some(Ordering::Greater));
-        } else if fragment_id_rank(&left) > fragment_id_rank(&right) {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Greater));
-            assert(right.partial_cmp_spec(&left) == Some(Ordering::Less));
-        } else {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Equal));
-            assert(right.partial_cmp_spec(&left) == Some(Ordering::Equal));
-        }
+        lemma_fragment_id_partial_cmp_matches_rank(left, right);
     };
 
     assert forall|left: FragmentId, right: FragmentId| #[trigger]
         left.partial_cmp_spec(&right) == Some(Ordering::Greater) <==> right.partial_cmp_spec(
             &left,
         ) == Some(Ordering::Less) by {
-        if fragment_id_rank(&left) < fragment_id_rank(&right) {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Less));
-            assert(right.partial_cmp_spec(&left) == Some(Ordering::Greater));
-        } else if fragment_id_rank(&left) > fragment_id_rank(&right) {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Greater));
-            assert(right.partial_cmp_spec(&left) == Some(Ordering::Less));
-        } else {
-            assert(left.partial_cmp_spec(&right) == Some(Ordering::Equal));
-            assert(right.partial_cmp_spec(&left) == Some(Ordering::Equal));
-        }
+        lemma_fragment_id_partial_cmp_matches_rank(left, right);
     };
 
     assert forall|left: FragmentId, middle: FragmentId, right: FragmentId|
@@ -177,41 +163,57 @@ proof fn lemma_fragment_id_partial_cmp_obeys_strict_total_order()
     };
 }
 
-spec fn candidate_pair_new_result<Id: PartialOrd>(left: Id, right: Id) -> CandidatePairOutcome<Id> {
+spec fn candidate_pair_input_relation(
+    left: FragmentId,
+    right: FragmentId,
+) -> CandidatePairInputRelation {
     if left.eq_spec(&right) {
-        CandidatePairOutcome::NoPair
+        CandidatePairInputRelation::Same
     } else if left.partial_cmp_spec(&right) == Some(Ordering::Less) {
-        CandidatePairOutcome::Pair(left, right)
+        CandidatePairInputRelation::Ordered
     } else {
-        CandidatePairOutcome::Pair(right, left)
+        CandidatePairInputRelation::Reversed
     }
 }
 
-spec fn constructor_accepts<Id: PartialOrd>(left: Id, right: Id) -> bool {
+spec fn candidate_pair_new_result(left: FragmentId, right: FragmentId) -> CandidatePairOutcome {
+    match candidate_pair_input_relation(left, right) {
+        CandidatePairInputRelation::Same => CandidatePairOutcome::NoPair,
+        CandidatePairInputRelation::Ordered => CandidatePairOutcome::Pair(left, right),
+        CandidatePairInputRelation::Reversed => CandidatePairOutcome::Pair(right, left),
+    }
+}
+
+spec fn constructor_accepts(left: FragmentId, right: FragmentId) -> bool {
     match candidate_pair_new_result(left, right) {
         CandidatePairOutcome::Pair(_, _) => true,
         CandidatePairOutcome::NoPair => false,
     }
 }
 
-spec fn is_canonical_pair<Id: PartialOrd>(left: Id, right: Id, pair_left: Id, pair_right: Id) -> bool {
+spec fn is_canonical_pair(
+    left: FragmentId,
+    right: FragmentId,
+    pair_left: FragmentId,
+    pair_right: FragmentId,
+) -> bool {
     pair_left.partial_cmp_spec(&pair_right) == Some(Ordering::Less)
         && ((pair_left.eq_spec(&left) && pair_right.eq_spec(&right))
             || (pair_left.eq_spec(&right) && pair_right.eq_spec(&left)))
 }
 
-proof fn lemma_equal_inputs_are_suppressed<Id: PartialOrd>(id: Id)
+proof fn lemma_equal_inputs_are_suppressed(id: FragmentId)
     requires
-        strict_total_order_axioms::<Id>(),
+        fragment_id_strict_total_order_axioms(),
     ensures
-        candidate_pair_new_result(id, id) == CandidatePairOutcome::<Id>::NoPair,
+        candidate_pair_new_result(id, id) == CandidatePairOutcome::NoPair,
         !constructor_accepts(id, id),
 {
 }
 
-proof fn lemma_ordered_inputs_are_preserved<Id: PartialOrd>(left: Id, right: Id)
+proof fn lemma_ordered_inputs_are_preserved(left: FragmentId, right: FragmentId)
     requires
-        strict_total_order_axioms::<Id>(),
+        fragment_id_strict_total_order_axioms(),
         left.partial_cmp_spec(&right) == Some(Ordering::Less),
     ensures
         candidate_pair_new_result(left, right) == CandidatePairOutcome::Pair(left, right),
@@ -220,9 +222,9 @@ proof fn lemma_ordered_inputs_are_preserved<Id: PartialOrd>(left: Id, right: Id)
 {
 }
 
-proof fn lemma_reversed_inputs_are_swapped<Id: PartialOrd>(left: Id, right: Id)
+proof fn lemma_reversed_inputs_are_swapped(left: FragmentId, right: FragmentId)
     requires
-        strict_total_order_axioms::<Id>(),
+        fragment_id_strict_total_order_axioms(),
         left.partial_cmp_spec(&right) == Some(Ordering::Greater),
     ensures
         candidate_pair_new_result(left, right) == CandidatePairOutcome::Pair(right, left),
@@ -232,9 +234,41 @@ proof fn lemma_reversed_inputs_are_swapped<Id: PartialOrd>(left: Id, right: Id)
     assert(right.partial_cmp_spec(&left) == Some(Ordering::Less));
 }
 
-proof fn lemma_distinct_inputs_yield_one_canonical_pair<Id: PartialOrd>(left: Id, right: Id)
+proof fn lemma_distinct_ordered_inputs_yield_canonical_pair(left: FragmentId, right: FragmentId)
     requires
-        strict_total_order_axioms::<Id>(),
+        !left.eq_spec(&right),
+        left.partial_cmp_spec(&right) == Some(Ordering::Less),
+    ensures
+        constructor_accepts(left, right),
+        match candidate_pair_new_result(left, right) {
+            CandidatePairOutcome::Pair(pair_left, pair_right) => {
+                is_canonical_pair(left, right, pair_left, pair_right)
+            }
+            CandidatePairOutcome::NoPair => false,
+        },
+{
+    lemma_ordered_inputs_are_preserved(left, right);
+}
+
+proof fn lemma_distinct_reversed_inputs_yield_canonical_pair(left: FragmentId, right: FragmentId)
+    requires
+        !left.eq_spec(&right),
+        left.partial_cmp_spec(&right) == Some(Ordering::Greater),
+    ensures
+        constructor_accepts(left, right),
+        match candidate_pair_new_result(left, right) {
+            CandidatePairOutcome::Pair(pair_left, pair_right) => {
+                is_canonical_pair(left, right, pair_left, pair_right)
+            }
+            CandidatePairOutcome::NoPair => false,
+        },
+{
+    lemma_reversed_inputs_are_swapped(left, right);
+}
+
+proof fn lemma_distinct_inputs_yield_one_canonical_pair(left: FragmentId, right: FragmentId)
+    requires
+        fragment_id_strict_total_order_axioms(),
         !left.eq_spec(&right),
     ensures
         constructor_accepts(left, right),
@@ -245,40 +279,11 @@ proof fn lemma_distinct_inputs_yield_one_canonical_pair<Id: PartialOrd>(left: Id
             CandidatePairOutcome::NoPair => false,
         },
 {
-    match left.partial_cmp_spec(&right) {
-        Some(Ordering::Less) => {
-            lemma_ordered_inputs_are_preserved(left, right);
-        }
-        Some(Ordering::Equal) => {
-            assert(left.eq_spec(&right));
-            assert(false);
-        }
-        Some(Ordering::Greater) => {
-            lemma_reversed_inputs_are_swapped(left, right);
-        }
-        None => {
-            assert(false);
-        }
-    }
-}
-
-proof fn lemma_constructor_contract<Id: PartialOrd>(left: Id, right: Id)
-    requires
-        strict_total_order_axioms::<Id>(),
-    ensures
-        !constructor_accepts(left, right) <==> left.eq_spec(&right),
-        constructor_accepts(left, right) <==> !left.eq_spec(&right),
-        match candidate_pair_new_result(left, right) {
-            CandidatePairOutcome::Pair(pair_left, pair_right) => {
-                is_canonical_pair(left, right, pair_left, pair_right)
-            }
-            CandidatePairOutcome::NoPair => left.eq_spec(&right),
-        },
-{
-    if left.eq_spec(&right) {
-        lemma_equal_inputs_are_suppressed(left);
+    if left.partial_cmp_spec(&right) == Some(Ordering::Less) {
+        lemma_distinct_ordered_inputs_yield_canonical_pair(left, right);
     } else {
-        lemma_distinct_inputs_yield_one_canonical_pair(left, right);
+        assert(left.partial_cmp_spec(&right) == Some(Ordering::Greater));
+        lemma_distinct_reversed_inputs_yield_canonical_pair(left, right);
     }
 }
 
@@ -294,7 +299,11 @@ proof fn lemma_fragment_id_constructor_contract(left: FragmentId, right: Fragmen
         },
 {
     lemma_fragment_id_partial_cmp_obeys_strict_total_order();
-    lemma_constructor_contract(left, right);
+    if left.eq_spec(&right) {
+        lemma_equal_inputs_are_suppressed(left);
+    } else {
+        lemma_distinct_inputs_yield_one_canonical_pair(left, right);
+    }
 }
 
 fn main() {

--- a/verus/clone_detector_candidate_pair.rs
+++ b/verus/clone_detector_candidate_pair.rs
@@ -25,6 +25,7 @@ use fragment_id_runtime::FragmentId;
 
 verus! {
 
+/// Verus external type witness for the production `FragmentId` newtype.
 #[verifier::external_type_specification]
 #[verifier::external_body]
 pub struct ExFragmentId(FragmentId);
@@ -40,10 +41,13 @@ enum CandidatePairInputRelation {
     Reversed,
 }
 
-// Bridge contract: equal ranks are exactly `eq_spec`, and rank comparison is
-// the trusted model for `FragmentId::partial_cmp` on both sides of the proof.
+/// Trusted ghost rank used to bridge production `FragmentId` ordering.
+///
+/// Equal ranks are exactly `eq_spec`, and rank comparison is the trusted model
+/// for `FragmentId::partial_cmp` on both sides of the proof.
 pub uninterp spec fn fragment_id_rank(id: &FragmentId) -> nat;
 
+/// Classifies two fragment IDs by their trusted ghost ranks.
 pub open spec fn fragment_id_rank_relation(left: &FragmentId, right: &FragmentId) -> Ordering {
     if fragment_id_rank(left) < fragment_id_rank(right) {
         Ordering::Less
@@ -54,6 +58,7 @@ pub open spec fn fragment_id_rank_relation(left: &FragmentId, right: &FragmentId
     }
 }
 
+/// Models `FragmentId::partial_cmp` as a total comparison over ghost ranks.
 pub open spec fn fragment_id_partial_cmp_model(
     left: &FragmentId,
     right: &FragmentId,
@@ -81,16 +86,19 @@ impl vstd::std_specs::cmp::PartialOrdSpecImpl for FragmentId {
     }
 }
 
+/// Trusts the production `PartialEq` implementation to match `eq_spec`.
 pub assume_specification[ <FragmentId as PartialEq<FragmentId>>::eq ](
     left: &FragmentId,
     right: &FragmentId,
 ) -> bool;
 
+/// Trusts the production `PartialOrd` implementation to match the rank model.
 pub assume_specification[ <FragmentId as PartialOrd<FragmentId>>::partial_cmp ](
     left: &FragmentId,
     right: &FragmentId,
 ) -> Option<Ordering>;
 
+/// States the strict-total-order properties required by `CandidatePair::new`.
 pub open spec fn fragment_id_strict_total_order_axioms() -> bool {
     &&& forall|id: FragmentId| #[trigger] id.eq_spec(&id)
     &&& forall|left: FragmentId, right: FragmentId| #[trigger] left.partial_cmp_spec(&right)

--- a/verus/clone_detector_candidate_pair.rs
+++ b/verus/clone_detector_candidate_pair.rs
@@ -86,13 +86,29 @@ impl vstd::std_specs::cmp::PartialOrdSpecImpl for FragmentId {
     }
 }
 
-/// Trusts the production `PartialEq` implementation to match `eq_spec`.
+/// Trusts the production `PartialEq<FragmentId>` implementation for
+/// `FragmentId::eq` to match its `eq_spec` counterpart.
+///
+/// This declaration is a trust boundary: the proof assumes the runtime
+/// equality implementation and the Verus equality model describe the same
+/// relation.
+///
+/// Runtime unit tests and BDD scenarios ground this assumption in concrete
+/// lexical-string behaviour.
 pub assume_specification[ <FragmentId as PartialEq<FragmentId>>::eq ](
     left: &FragmentId,
     right: &FragmentId,
 ) -> bool;
 
-/// Trusts the production `PartialOrd` implementation to match the rank model.
+/// Trusts the production `PartialOrd<FragmentId>` implementation for
+/// `FragmentId::partial_cmp` to match its `partial_cmp_spec` counterpart.
+///
+/// This declaration is a trust boundary: the proof assumes the runtime
+/// ordering implementation and the Verus ordering model describe the same
+/// relation.
+///
+/// Runtime unit tests and BDD scenarios ground this assumption in concrete
+/// lexical-string behaviour.
 pub assume_specification[ <FragmentId as PartialOrd<FragmentId>>::partial_cmp ](
     left: &FragmentId,
     right: &FragmentId,


### PR DESCRIPTION
## Summary
- Introduces a Verus bridge lemma for FragmentId ordering and wires it into a dedicated Verus proof for CandidatePair::new canonicalization. Extracts FragmentId into its own module to model ordering independently from String internals. Adds unit tests and behaviour-driven tests for the constructor seam, plus a Verus sidecar proof and runner wiring. Documentation and roadmap updates accompany the changes.

## Changes
- New/updated files:
  - crates/whitaker_clones_core/src/index/fragment_id.rs
  - crates/whitaker_clones_core/src/index/mod.rs
  - crates/whitaker_clones_core/src/index/types.rs
  - crates/whitaker_clones_core/src/index/tests.rs
  - crates/whitaker_clones_core/tests/candidate_pair_behaviour.rs
  - crates/whitaker_clones_core/tests/features/candidate_pair.feature
  - verus/clone_detector_candidate_pair.rs
  - scripts/run-verus.sh (wired in the new proof file)
  - docs/execplans/7-2-6-verus-proofs-for-candidate-pair-new-canonicalization.md
  - docs/whitaker-clone-detector-design.md (updated with 7.2.6 decisions)
  - docs/developers-guide.md (updated to reflect Verus workflow for 7.2.6)
  - docs/roadmap.md (7.2.6 marked done)

## Rationale
- Documents and enforces two core invariants for CandidatePair::new:
  1) Distinct fragment identifiers are returned in canonical lexical order regardless of input order.
  2) Identical fragment identifiers yield None, suppressing self-pairs at the constructor seam.
- Establishes a formal bridge to a lexically ordered FragmentId domain via a Verus proof, keeping proof-shape aligned with ADR003 and existing clone-detector proof patterns.
- Introduces a dedicated FragmentId bridge lemma so the Verus proof does not rely on internal String semantics, while runtime tests pin the concrete lexical behavior.

## Implementation plan (status)
- Stage B: Direct unit tests for CandidatePair::new (happy/unhappy/edge cases) – implemented in tests.rs.
- Stage C: Behaviour-driven tests (rstest-bdd) for constructor semantics – implemented in candidate_pair_behaviour.rs and candidate_pair.feature.
- Stage D: Dedicated Verus sidecar proof file wired into the verifier workflow – implemented in verus/clone_detector_candidate_pair.rs.
- Stage E: Wire the new proof into the repository’s verus runner so clone-detector and all groups run it – wired in scripts/run-verus.sh.
- Stage F: Update design/developer docs to reflect 7.2.6 decisions – reflected in updated docs.
- Stage G: Mark 7.2.6 done in docs/roadmap.md after gates pass – updated.
- Stage H: Validate via fmt, lint, tests, and Verus runs; logs captured with pipefail – validated via repository tests and verus runs.

## Validation plan
- Run the repository’s full validation sequence as guided in the ExecPlan:
  - make fmt, make markdownlint, make nixie, make check-fmt, make lint, make test
  - make verus-clone-detector, and make verus
- Expect direct CandidatePair::new tests and BDD scenarios to pass, with Verus proofs succeeding alongside existing clone-detector proofs.
- Update docs/roadmap.md to reflect 7.2.6 completion once gates succeed.

## Documentation impact
- The new ExecPlan documents the final proof scope, ordering contract, and trust boundary for the clone-detector proofs.
- No public API changes or user-facing behavior are introduced by this documentation alone.

## Review guidance
- Focus on scope adherence to 7.2.6 and the clarity of the stated invariants.
- Ensure the plan aligns with ADR 003 and existing clone-detector proof patterns.
- Confirm that the staged approach minimizes drift and keeps changes modular.

> Generated by DevBoxer; task reference: d830efa2-6dc2-4e41-806e-b81a271753bb

📎 **Task**: https://www.devboxer.com/task/d830efa2-6dc2-4e41-806e-b81a271753bb


📎 **Task**: https://www.devboxer.com/task/316de405-a8f6-4f96-99aa-72c5e69a2865

## Summary by Sourcery

Document and formally verify the `CandidatePair::new` constructor contract, including canonical fragment ordering and self-pair suppression, while extracting `FragmentId` into its own module and wiring the new Verus proof into the existing proof workflow.

New Features:
- Add a dedicated Verus sidecar proof for the `CandidatePair::new` constructor and integrate it into the clone-detector and full Verus proof groups.
- Introduce a behaviour-driven test harness and feature file to describe `CandidatePair::new` canonicalization and self-pair suppression scenarios.

Enhancements:
- Extract `FragmentId` into its own module and re-export it from the index module to decouple its definition from other index types.
- Add unit tests that directly cover `CandidatePair::new` ordering behaviour and self-pair suppression, including a lexical ordering edge case.
- Clarify design and developer documentation around clone-detector constructor proofs, the `FragmentId` ordering contract, and the Verus trust boundary, and mark roadmap item 7.2.6 as complete.

Documentation:
- Add an execution plan documenting the scope, rationale, and outcomes for the `CandidatePair::new` Verus proof and related tests.
- Update clone-detector design and developer guides to reflect the new constructor proof, ordering contract, and proof workflow, and mark roadmap item 7.2.6 as done.

Tests:
- Add focused unit tests and BDD scenarios for `CandidatePair::new` to validate canonical ordering and self-pair suppression at the constructor seam.