### PR TITLE
Document no_expect test harness helpers and fix context detection

### DIFF
--- a/crates/no_expect_outside_tests/src/context.rs
+++ b/crates/no_expect_outside_tests/src/context.rs
@@ -21,6 +21,32 @@ pub(crate) struct ContextSummary {
     pub(crate) function_name: Option<String>,
 }
 
+/// Collects simplified context entries for the ancestors of a HIR node.
+///
+/// Walks the ancestor chain for `hir_id`, records any context-bearing nodes as
+/// `ContextEntry` values, and tracks whether any ancestor establishes test
+/// context through `cfg(test)` or a recognized test attribute.
+///
+/// # Parameters
+///
+/// - `cx`: Lint context used to walk the HIR and inspect ancestor attributes.
+/// - `hir_id`: The HIR node whose ancestor chain should be summarized.
+/// - `additional_test_attributes`: Extra user-configured attribute paths that
+///   should be treated as test markers alongside Whitaker's built-in list.
+///
+/// # Returns
+///
+/// Returns `(entries, has_test_context_ancestry)`, where `entries` is the
+/// ordered list of simplified ancestor contexts and the boolean records whether
+/// any ancestor already established test-only ancestry.
+///
+/// # Examples
+///
+/// ```ignore
+/// let (entries, has_test_context_ancestry) =
+///     collect_context(cx, expr.hir_id, additional_test_attributes);
+/// assert!(!entries.is_empty() || !has_test_context_ancestry);
+/// ```
 pub(crate) fn collect_context<'tcx>(
     cx: &LateContext<'tcx>,
     hir_id: hir::HirId,
@@ -37,7 +63,7 @@ pub(crate) fn collect_context<'tcx>(
         has_test_context_ancestry = has_test_ancestry(
             has_test_context_ancestry,
             attrs,
-            &node,
+            matches!(node, Node::Item(item) if matches!(item.kind, hir::ItemKind::Fn { .. })),
             additional_test_attributes,
         );
 
@@ -52,15 +78,46 @@ pub(crate) fn collect_context<'tcx>(
 fn has_test_ancestry(
     has_test_context_ancestry: bool,
     attrs: &[hir::Attribute],
-    node: &Node<'_>,
+    is_function_item: bool,
     additional_test_attributes: &[AttributePath],
 ) -> bool {
     has_test_context_ancestry
         || attrs.iter().any(is_cfg_test_attribute)
-        || (matches!(node, Node::Item(item) if matches!(item.kind, hir::ItemKind::Fn { .. }))
-            && has_test_like_hir_attributes(attrs, additional_test_attributes))
+        || (is_function_item && has_test_like_hir_attributes(attrs, additional_test_attributes))
 }
 
+/// Summarizes collected ancestor context into the lint's final test decision.
+///
+/// Combines the pre-computed ancestor entries with the carried
+/// `has_test_context_ancestry` flag so the lint can determine whether the
+/// current call site should be treated as test-only code.
+///
+/// # Parameters
+///
+/// - `entries`: Simplified ancestor contexts produced by `collect_context`.
+/// - `has_test_context_ancestry`: Whether any ancestor already established
+///   test-only ancestry via propagation, `cfg(test)`, or a recognized
+///   test-marker attribute.
+/// - `additional_test_attributes`: Extra user-configured attribute paths that
+///   should be considered test markers during the final summary check.
+///
+/// # Returns
+///
+/// Returns a `ContextSummary` describing the derived test-context status and
+/// the innermost enclosing function name, if one was found.
+///
+/// # Examples
+///
+/// ```ignore
+/// let summary = summarise_context(
+///     &entries,
+///     has_test_context_ancestry,
+///     additional_test_attributes,
+/// );
+/// if summary.is_test {
+///     // `.expect()` is allowed in this context.
+/// }
+/// ```
 pub(crate) fn summarise_context(
     entries: &[ContextEntry],
     has_test_context_ancestry: bool,
@@ -167,6 +224,27 @@ where
     })
 }
 
+/// Returns whether a HIR attribute enables `cfg(test)` semantics.
+///
+/// Recognizes both direct `cfg(test)` attributes and `cfg_attr(.., cfg(test))`
+/// forms so callers can treat such ancestors as test-only context.
+///
+/// # Parameters
+///
+/// - `attr`: The HIR attribute to inspect.
+///
+/// # Returns
+///
+/// Returns `true` when the attribute is a `cfg(test)`-style marker and `false`
+/// otherwise.
+///
+/// # Examples
+///
+/// ```ignore
+/// if attrs.iter().any(is_cfg_test_attribute) {
+///     // The enclosing item participates in test-only compilation.
+/// }
+/// ```
 pub(crate) fn is_cfg_test_attribute(attr: &hir::Attribute) -> bool {
     // Parsed attributes (like #[must_use]) are not cfg-related; skip them to
     // avoid panics when calling path() on arbitrary parsed attributes.

--- a/crates/no_expect_outside_tests/src/context.rs
+++ b/crates/no_expect_outside_tests/src/context.rs
@@ -27,32 +27,47 @@ pub(crate) fn collect_context<'tcx>(
     additional_test_attributes: &[AttributePath],
 ) -> (Vec<ContextEntry>, bool) {
     let mut entries = Vec::new();
-    let mut has_cfg_test = false;
+    let mut has_test_context_ancestry = false;
 
     let mut ancestors: Vec<_> = cx.tcx.hir_parent_iter(hir_id).collect();
     ancestors.reverse();
 
     for (ancestor_id, node) in ancestors {
         let attrs = cx.tcx.hir_attrs(ancestor_id);
-        has_cfg_test = has_cfg_test
-            || attrs.iter().any(is_cfg_test_attribute)
-            || (matches!(node, Node::Item(item) if matches!(item.kind, hir::ItemKind::Fn { .. }))
-                && has_test_like_hir_attributes(attrs, additional_test_attributes));
+        has_test_context_ancestry = has_test_ancestry(
+            has_test_context_ancestry,
+            attrs,
+            &node,
+            additional_test_attributes,
+        );
 
         if let Some(entry) = context_entry_for(node, attrs) {
             entries.push(entry);
         }
     }
 
-    (entries, has_cfg_test)
+    (entries, has_test_context_ancestry)
+}
+
+fn has_test_ancestry(
+    has_test_context_ancestry: bool,
+    attrs: &[hir::Attribute],
+    node: &Node<'_>,
+    additional_test_attributes: &[AttributePath],
+) -> bool {
+    has_test_context_ancestry
+        || attrs.iter().any(is_cfg_test_attribute)
+        || (matches!(node, Node::Item(item) if matches!(item.kind, hir::ItemKind::Fn { .. }))
+            && has_test_like_hir_attributes(attrs, additional_test_attributes))
 }
 
 pub(crate) fn summarise_context(
     entries: &[ContextEntry],
-    has_cfg_test: bool,
+    has_test_context_ancestry: bool,
     additional_test_attributes: &[AttributePath],
 ) -> ContextSummary {
-    let is_test = has_cfg_test || in_test_like_context_with(entries, additional_test_attributes);
+    let is_test =
+        has_test_context_ancestry || in_test_like_context_with(entries, additional_test_attributes);
     let function_name = entries.iter().rev().find_map(|entry| {
         entry
             .kind()

--- a/crates/no_expect_outside_tests/src/context.rs
+++ b/crates/no_expect_outside_tests/src/context.rs
@@ -34,8 +34,10 @@ pub(crate) fn collect_context<'tcx>(
 
     for (ancestor_id, node) in ancestors {
         let attrs = cx.tcx.hir_attrs(ancestor_id);
-        has_cfg_test =
-            has_cfg_test || ancestor_marks_test_context(node, attrs, additional_test_attributes);
+        has_cfg_test = has_cfg_test
+            || attrs.iter().any(is_cfg_test_attribute)
+            || (matches!(node, Node::Item(item) if matches!(item.kind, hir::ItemKind::Fn { .. }))
+                && has_test_like_hir_attributes(attrs, additional_test_attributes));
 
         if let Some(entry) = context_entry_for(node, attrs) {
             entries.push(entry);
@@ -43,16 +45,6 @@ pub(crate) fn collect_context<'tcx>(
     }
 
     (entries, has_cfg_test)
-}
-
-fn ancestor_marks_test_context(
-    node: Node<'_>,
-    attrs: &[hir::Attribute],
-    additional_test_attributes: &[AttributePath],
-) -> bool {
-    attrs.iter().any(is_cfg_test_attribute)
-        || (matches!(node, Node::Item(item) if matches!(item.kind, hir::ItemKind::Fn { .. }))
-            && has_test_like_hir_attributes(attrs, additional_test_attributes))
 }
 
 pub(crate) fn summarise_context(

--- a/crates/no_expect_outside_tests/src/context/tests.rs
+++ b/crates/no_expect_outside_tests/src/context/tests.rs
@@ -4,11 +4,15 @@
 //! detection for both parsed and unparsed attribute variants.
 
 #[cfg(feature = "dylint-driver")]
-use super::{convert_attribute, is_cfg_test_attribute, meta_contains_test_cfg};
+use super::{convert_attribute, has_test_ancestry, is_cfg_test_attribute, meta_contains_test_cfg};
 #[cfg(feature = "dylint-driver")]
 use rstest::rstest;
 #[cfg(feature = "dylint-driver")]
-use rustc_ast::ast::{MetaItem, MetaItemInner, MetaItemKind, Path, PathSegment, Safety};
+use rustc_ast::ast::{DelimArgs, MetaItem, MetaItemInner, MetaItemKind, Path, PathSegment, Safety};
+#[cfg(feature = "dylint-driver")]
+use rustc_ast::token::{Delimiter, IdentIsRaw, TokenKind};
+#[cfg(feature = "dylint-driver")]
+use rustc_ast::tokenstream::{DelimSpan, TokenStream, TokenTree};
 #[cfg(feature = "dylint-driver")]
 use rustc_hir as hir;
 #[cfg(feature = "dylint-driver")]
@@ -18,7 +22,7 @@ use rustc_span::symbol::Ident;
 #[cfg(feature = "dylint-driver")]
 use rustc_span::{AttrId, DUMMY_SP, create_default_session_globals_then};
 #[cfg(feature = "dylint-driver")]
-use whitaker_common::{AttributeKind, PARSED_ATTRIBUTE_PLACEHOLDER};
+use whitaker_common::{AttributeKind, AttributePath, PARSED_ATTRIBUTE_PLACEHOLDER};
 
 /// Type-safe wrapper for AST path segments.
 #[cfg(feature = "dylint-driver")]
@@ -37,6 +41,27 @@ impl AsRef<[&'static str]> for PathSegments {
     fn as_ref(&self) -> &[&'static str] {
         self.0
     }
+}
+
+#[cfg(feature = "dylint-driver")]
+#[derive(Clone, Copy, Debug)]
+enum AttributeFixture {
+    None,
+    Allow,
+    CfgTest,
+    BuiltInTest,
+    CustomTest,
+    CfgAndBuiltInTest,
+}
+
+#[cfg(feature = "dylint-driver")]
+#[derive(Clone, Copy, Debug)]
+struct HasTestAncestryCase {
+    has_test_context_ancestry: bool,
+    attr_fixture: AttributeFixture,
+    is_function_item: bool,
+    include_custom_attribute: bool,
+    expected: bool,
 }
 
 // Common path constants
@@ -93,6 +118,31 @@ fn hir_attribute_from_segments(segments: PathSegments) -> hir::Attribute {
         args: hir::AttrArgs::Empty,
         id: hir::HashIgnoredAttrId {
             attr_id: AttrId::from_u32(0),
+        },
+        style: rustc_ast::AttrStyle::Outer,
+        span: DUMMY_SP,
+    };
+
+    hir::Attribute::Unparsed(Box::new(attr_item))
+}
+
+#[cfg(feature = "dylint-driver")]
+fn hir_cfg_test_attribute() -> hir::Attribute {
+    let attr_item = hir::AttrItem {
+        path: hir::AttrPath {
+            segments: vec![Ident::from_str("cfg")].into_boxed_slice(),
+            span: DUMMY_SP,
+        },
+        args: hir::AttrArgs::Delimited(DelimArgs {
+            dspan: DelimSpan::from_single(DUMMY_SP),
+            delim: Delimiter::Parenthesis,
+            tokens: TokenStream::new(vec![TokenTree::token_alone(
+                TokenKind::Ident(rustc_span::sym::test, IdentIsRaw::No),
+                DUMMY_SP,
+            )]),
+        }),
+        id: hir::HashIgnoredAttrId {
+            attr_id: AttrId::from_u32(1),
         },
         style: rustc_ast::AttrStyle::Outer,
         span: DUMMY_SP,
@@ -248,6 +298,101 @@ fn assert_converts_path(segments: PathSegments) {
         .map(String::as_str)
         .collect::<Vec<_>>();
     assert_eq!(converted_segments.as_slice(), segments.as_ref());
+}
+
+#[cfg(feature = "dylint-driver")]
+fn build_test_attrs(fixture: AttributeFixture) -> Vec<hir::Attribute> {
+    match fixture {
+        AttributeFixture::None => Vec::new(),
+        AttributeFixture::Allow => {
+            vec![hir_attribute_from_segments(PathSegments::new(&["allow"]))]
+        }
+        AttributeFixture::CfgTest => vec![hir_cfg_test_attribute()],
+        AttributeFixture::BuiltInTest => vec![hir_attribute_from_segments(PATH_TEST)],
+        AttributeFixture::CustomTest => vec![hir_attribute_from_segments(PathSegments::new(&[
+            "my_framework",
+            "test",
+        ]))],
+        AttributeFixture::CfgAndBuiltInTest => {
+            vec![
+                hir_cfg_test_attribute(),
+                hir_attribute_from_segments(PATH_TEST),
+            ]
+        }
+    }
+}
+
+#[cfg(feature = "dylint-driver")]
+fn build_additional_test_attributes(include_custom: bool) -> Vec<AttributePath> {
+    if include_custom {
+        vec![AttributePath::from("my_framework::test")]
+    } else {
+        Vec::new()
+    }
+}
+
+/// Verify `has_test_ancestry` for propagation, `cfg(test)`, and function-item
+/// marker detection.
+#[cfg(feature = "dylint-driver")]
+#[rstest]
+#[case::prior_detection_carries_forward(HasTestAncestryCase {
+    has_test_context_ancestry: true,
+    attr_fixture: AttributeFixture::None,
+    is_function_item: false,
+    include_custom_attribute: false,
+    expected: true,
+})]
+#[case::cfg_test_attribute_detected(HasTestAncestryCase {
+    has_test_context_ancestry: false,
+    attr_fixture: AttributeFixture::CfgTest,
+    is_function_item: false,
+    include_custom_attribute: false,
+    expected: true,
+})]
+#[case::built_in_test_attribute_on_function_item(HasTestAncestryCase {
+    has_test_context_ancestry: false,
+    attr_fixture: AttributeFixture::BuiltInTest,
+    is_function_item: true,
+    include_custom_attribute: false,
+    expected: true,
+})]
+#[case::configured_test_attribute_on_function_item(HasTestAncestryCase {
+    has_test_context_ancestry: false,
+    attr_fixture: AttributeFixture::CustomTest,
+    is_function_item: true,
+    include_custom_attribute: true,
+    expected: true,
+})]
+#[case::all_detection_paths_together(HasTestAncestryCase {
+    has_test_context_ancestry: true,
+    attr_fixture: AttributeFixture::CfgAndBuiltInTest,
+    is_function_item: true,
+    include_custom_attribute: true,
+    expected: true,
+})]
+#[case::negative_case(HasTestAncestryCase {
+    has_test_context_ancestry: false,
+    attr_fixture: AttributeFixture::Allow,
+    is_function_item: false,
+    include_custom_attribute: false,
+    expected: false,
+})]
+fn has_test_ancestry_detects_test_context(#[case] case: HasTestAncestryCase) {
+    create_default_session_globals_then(|| {
+        let attrs = build_test_attrs(case.attr_fixture);
+        let additional_test_attributes =
+            build_additional_test_attributes(case.include_custom_attribute);
+
+        assert_eq!(
+            has_test_ancestry(
+                case.has_test_context_ancestry,
+                &attrs,
+                case.is_function_item,
+                &additional_test_attributes,
+            ),
+            case.expected,
+        );
+    });
 }
 
 /// Verify `cfg(any(test, doctest))` is detected as a test context.

--- a/crates/no_expect_outside_tests/src/dependency_rlib_tests.rs
+++ b/crates/no_expect_outside_tests/src/dependency_rlib_tests.rs
@@ -92,6 +92,19 @@ fn dependency_rlib_selects_expected_artifact(
     assert_eq!(selection.selected, selection.expected);
 }
 
+#[rstest]
+fn dependency_rlib_returns_err_when_no_matching_rlib_present(
+    selection_directory: TemporaryDirectory,
+) {
+    let error = dependency_rlib(selection_directory.path(), "tokio")
+        .expect_err("missing Tokio artefacts should fail to resolve");
+
+    assert!(
+        error.contains("failed to locate `tokio` rlib in dependency directory"),
+        "unexpected error message, got: {error}",
+    );
+}
+
 impl TemporaryDirectory {
     /// Creates a new uniquely named temporary directory under the system temp
     /// path.

--- a/crates/no_expect_outside_tests/src/dependency_rlib_tests.rs
+++ b/crates/no_expect_outside_tests/src/dependency_rlib_tests.rs
@@ -6,9 +6,12 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
+/// A temporary directory that is removed automatically when dropped.
 #[derive(Debug)]
 struct TemporaryDirectory(PathBuf);
 
+/// Describes a single fixture artefact: its filename and the
+/// seconds-since-Unix-epoch modification timestamp to assign to it.
 #[derive(Clone, Copy, Debug)]
 struct ArtifactSpec<'a> {
     file_name: &'a str,
@@ -16,6 +19,7 @@ struct ArtifactSpec<'a> {
 }
 
 impl<'a> ArtifactSpec<'a> {
+    /// Creates a new spec with the given filename and modification timestamp.
     const fn new(file_name: &'a str, seconds_since_epoch: u64) -> Self {
         Self {
             file_name,
@@ -24,6 +28,9 @@ impl<'a> ArtifactSpec<'a> {
     }
 }
 
+/// Holds the outcome of a `dependency_rlib` selection exercise: the directory
+/// (kept alive so it is not dropped early), the path that was expected to be
+/// chosen, and the path that `dependency_rlib` actually selected.
 #[derive(Debug)]
 struct DependencyRlibSelection {
     _directory: TemporaryDirectory,
@@ -40,11 +47,16 @@ const TIED_ARTIFACTS: [ArtifactSpec<'static>; 2] = [
     ArtifactSpec::new("libtokio-zulu.rlib", 30),
 ];
 
+/// rstest fixture that creates a uniquely named temporary directory for a
+/// selection test.
 #[fixture]
 fn selection_directory() -> TemporaryDirectory {
     TemporaryDirectory::new("selection")
 }
 
+/// Creates `artifacts` inside `directory`, sets their modification times, then
+/// invokes `dependency_rlib` and returns both the expected and selected paths
+/// for the caller to compare.
 fn resolve_dependency_rlib_selection(
     directory: TemporaryDirectory,
     artifacts: &[ArtifactSpec<'_>],
@@ -81,6 +93,8 @@ fn dependency_rlib_selects_expected_artifact(
 }
 
 impl TemporaryDirectory {
+    /// Creates a new uniquely named temporary directory under the system temp
+    /// path.
     fn new(name: &str) -> Self {
         let unique = format!(
             "no-expect-outside-tests-{name}-{}",
@@ -94,6 +108,7 @@ impl TemporaryDirectory {
         Self(directory)
     }
 
+    /// Returns the path to the temporary directory.
     fn path(&self) -> &Path {
         &self.0
     }
@@ -105,12 +120,16 @@ impl Drop for TemporaryDirectory {
     }
 }
 
+/// Creates an empty `.rlib` fixture file at `directory/file_name` and returns
+/// its path.
 fn create_rlib(directory: &Path, file_name: &str) -> PathBuf {
     let path = directory.join(file_name);
     File::create(&path).expect("rlib fixture should be created");
     path
 }
 
+/// Sets the last-modified time of `path` to `seconds_since_epoch` seconds
+/// after the Unix epoch.
 fn set_modified_time(path: &Path, seconds_since_epoch: u64) {
     let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(seconds_since_epoch);
     let file = File::options()

--- a/crates/no_expect_outside_tests/src/driver/mod.rs
+++ b/crates/no_expect_outside_tests/src/driver/mod.rs
@@ -121,8 +121,8 @@ impl<'tcx> LateLintPass<'tcx> for NoExpectOutsideTests {
         }
 
         let additional = self.additional_test_attributes.as_slice();
-        let (entries, has_cfg_test) = collect_context(cx, expr.hir_id, additional);
-        let summary = summarise_context(entries.as_slice(), has_cfg_test, additional);
+        let (entries, has_test_context_ancestry) = collect_context(cx, expr.hir_id, additional);
+        let summary = summarise_context(entries.as_slice(), has_test_context_ancestry, additional);
 
         if summary.is_test {
             return;

--- a/crates/no_expect_outside_tests/src/lib_ui_tests.rs
+++ b/crates/no_expect_outside_tests/src/lib_ui_tests.rs
@@ -24,7 +24,7 @@ struct ExampleHarnessRun<'a> {
 }
 
 impl<'a> ExampleHarnessRun<'a> {
-    /// Builds the default `--test` example harness run for `name`.
+    /// Creates a run spec using the default `--test` harness flag.
     fn new(name: &'a str, label: &'a str) -> Self {
         Self {
             name,
@@ -33,7 +33,8 @@ impl<'a> ExampleHarnessRun<'a> {
         }
     }
 
-    /// Builds an example harness run with explicit compiler flags.
+    /// Creates a run spec with caller-supplied rustc flags (no defaults
+    /// applied).
     fn with_flags(name: &'a str, label: &'a str, rustc_flags: &'a [&'a str]) -> Self {
         Self {
             name,
@@ -63,8 +64,8 @@ struct FixtureHarnessRun<'a> {
     extern_crates: &'a [&'a str],
 }
 
-/// Captures an `rlib` candidate discovered in the current test binary's deps
-/// directory for deterministic `--extern` resolution.
+/// A candidate rlib artefact found in the dependency directory, together with
+/// its last-modified timestamp for recency-based selection.
 #[derive(Debug)]
 struct DependencyRlib {
     /// Full path to the candidate artefact.
@@ -73,7 +74,10 @@ struct DependencyRlib {
     modified: SystemTime,
 }
 
-/// Runs one example target through the shared `rustc --test` harness workflow.
+/// Runs an example-based regression under the dylint UI test harness.
+///
+/// Applies `spec.rustc_flags` to the compilation and formats any failure
+/// message using `spec.label`.
 fn run_example_under_test_harness(spec: &ExampleHarnessRun<'_>) {
     let crate_name = env!("CARGO_PKG_NAME");
     let directory = "examples";
@@ -98,8 +102,12 @@ fn run_example_under_test_harness(spec: &ExampleHarnessRun<'_>) {
     });
 }
 
-/// Stages one source fixture into a temporary workspace and runs it under the
-/// lint test harness.
+/// Runs a single fixture file under the test harness inside the runner closure
+/// supplied by `run_with_runner`.
+///
+/// Prepares the fixture environment, assembles the full set of rustc flags
+/// (base flags plus any required extern crate links), and delegates to
+/// `run_test_runner`.
 fn run_fixture_under_test_harness(
     spec: &FixtureHarnessRun<'_>,
     directory: &Utf8Path,
@@ -130,7 +138,10 @@ fn run_fixture_under_test_harness(
     })
 }
 
-/// Adapts `run_fixture_under_test_harness` to the shared UI runner API.
+/// Drives a fixture-based harness test end-to-end.
+///
+/// Calls `run_with_runner` using `spec.directory` and panics with a labelled
+/// message (using `spec.label`) if the runner returns an error.
 fn run_fixture_harness_test(spec: &FixtureHarnessRun<'_>) {
     let crate_name = spec.crate_name;
     let directory = spec.directory;
@@ -147,13 +158,18 @@ fn run_fixture_harness_test(spec: &FixtureHarnessRun<'_>) {
     });
 }
 
-/// Resolves the `.rs` source path for a named fixture within `directory`.
+/// Returns the path to the `.rs` source file for a named fixture inside
+/// `directory`.
 fn fixture_source_path(directory: &Utf8Path, fixture_name: &str) -> PathBuf {
     directory.as_std_path().join(format!("{fixture_name}.rs"))
 }
 
-/// Builds the `rustc` flags for a staged harness run, adding `--edition=2024`,
-/// dependency search paths, and resolved `--extern` entries when required.
+/// Builds the full rustc flag list for a harness run.
+///
+/// Starts with `extra_flags`, appends `--edition=2024`, and — when
+/// `extern_crates` is non-empty — locates the dependency directory and inserts
+/// the necessary `-L dependency=…` and `--extern …` flags for each requested
+/// crate.
 fn test_harness_flags(extra_flags: &[&str], extern_crates: &[&str]) -> Result<Vec<String>, String> {
     let mut flags: Vec<String> = extra_flags.iter().map(|flag| (*flag).to_owned()).collect();
     flags.push("--edition=2024".to_owned());
@@ -176,7 +192,8 @@ fn test_harness_flags(extra_flags: &[&str], extern_crates: &[&str]) -> Result<Ve
     Ok(flags)
 }
 
-/// Returns the dependency directory adjacent to the current test binary.
+/// Returns the directory that contains the rlib artefacts for the current test
+/// binary (i.e. the directory of `std::env::current_exe()`).
 fn dependency_directory() -> Result<PathBuf, String> {
     let test_binary = std::env::current_exe()
         .map_err(|error| format!("failed to locate current test binary: {error}"))?;
@@ -188,7 +205,11 @@ fn dependency_directory() -> Result<PathBuf, String> {
     })
 }
 
-/// Resolves the freshest matching `rlib` for `crate_name` in `deps_dir`.
+/// Selects the most recently built rlib for `crate_name` from `deps_dir`.
+///
+/// When two artefacts share the same modification timestamp the one with the
+/// lexicographically earlier path is chosen, giving a stable, deterministic
+/// result.
 fn dependency_rlib(deps_dir: &Path, crate_name: &str) -> Result<PathBuf, String> {
     let prefix = format!("lib{crate_name}-");
     let mut matches = dependency_rlib_matches(deps_dir, &prefix)?;
@@ -212,7 +233,8 @@ fn dependency_rlib(deps_dir: &Path, crate_name: &str) -> Result<PathBuf, String>
         })
 }
 
-/// Collects candidate `rlib` artefacts that match `prefix` inside `deps_dir`.
+/// Collects all `lib{crate_name}-*.rlib` candidates from `deps_dir` together
+/// with their modification timestamps.
 fn dependency_rlib_matches(deps_dir: &Path, prefix: &str) -> Result<Vec<DependencyRlib>, String> {
     std::fs::read_dir(deps_dir)
         .map_err(|error| {
@@ -234,8 +256,8 @@ fn dependency_rlib_matches(deps_dir: &Path, prefix: &str) -> Result<Vec<Dependen
         .collect()
 }
 
-/// Converts one filesystem path into an `rlib` candidate when it matches the
-/// expected crate prefix.
+/// Inspects a single directory entry and returns a `DependencyRlib` if the
+/// path matches the expected rlib naming convention, or `Ok(None)` otherwise.
 fn dependency_rlib_candidate(
     path: PathBuf,
     prefix: &str,
@@ -256,7 +278,8 @@ fn dependency_rlib_candidate(
     Ok(Some(DependencyRlib { path, modified }))
 }
 
-/// Returns `true` when `path` names an `rlib` whose stem begins with `prefix`.
+/// Returns `true` when `path` names a file that starts with `prefix` and has
+/// the `.rlib` extension.
 fn is_dependency_rlib(path: &Path, prefix: &str) -> bool {
     path.file_name().is_some_and(|name| {
         name.to_str()
@@ -331,6 +354,11 @@ fn tokio_expect_outside_tests_still_fails_in_non_test_code() {
     });
 }
 
+/// Unit tests for the rlib artefact selection and resolution helpers.
+///
+/// These tests create temporary fixture `.rlib` files with controlled
+/// modification timestamps and assert that `dependency_rlib` selects the
+/// newest artefact, breaking ties by lexicographic path order.
 #[cfg(test)]
 #[path = "dependency_rlib_tests.rs"]
 mod dependency_rlib_tests;

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -817,6 +817,8 @@ Two structs group the string parameters that describe a single regression run:
 
 #### Harness driver functions
 
+Table: Harness driver functions and responsibilities.
+
 | Function                         | Purpose                                                                                                                                 |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `run_example_under_test_harness` | Runs one example target under the dylint UI test harness using the flags in the `ExampleHarnessRun` spec.                               |

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -795,6 +795,31 @@ Keep the regression split aligned with that compiler boundary:
 This separation exists so a proc-macro stub test cannot accidentally mask a
 failure in the real harness-descriptor path.
 
+### Test-context ancestry detection
+
+`no_expect_outside_tests` decides whether an `.expect(..)` call sits in test
+context by combining a HIR ancestry walk with attribute-shape matching.
+`collect_context` traverses the ancestors of the call site, accumulates
+`ContextEntry` items for modules, functions, impls, and blocks, and carries a
+boolean `has_test_context_ancestry` alongside that list. On each step,
+`has_test_ancestry` updates that boolean so the test-only decision can
+propagate from outer ancestors into nested helper code. `summarise_context`
+then combines the accumulated entries, the propagated boolean, and
+`in_test_like_context_with(additional_test_attributes)` to produce the final
+`ContextSummary.is_test` result. This pattern matters because user-configured
+test markers such as `my_framework::test` must affect the whole ancestry chain,
+not just the immediately enclosing function.
+
+- `collect_context` starts at the `.expect(..)` call site and walks outward.
+- `has_test_ancestry` returns `true` when any of these hold:
+  - a prior ancestor already set `has_test_context_ancestry`
+  - the current ancestor carries a `cfg(test)`-style attribute detected by
+    `is_cfg_test_attribute`
+  - the current ancestor is a function item whose attributes match Whitaker's
+    built-in test list or `additional_test_attributes`
+- `summarise_context` merges that ancestry flag with the collected
+  `ContextEntry` values to derive the final `ContextSummary.is_test` decision.
+
 ### UI test harness helpers (`lib_ui_tests.rs`)
 
 `crates/no_expect_outside_tests/src/lib_ui_tests.rs` provides the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -817,11 +817,11 @@ Two structs group the string parameters that describe a single regression run:
 
 #### Harness driver functions
 
-| Function                         | Purpose                                                                                                                                |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `run_example_under_test_harness` | Runs one example target under the dylint UI test harness using the flags in the `ExampleHarnessRun` spec.                              |
-| `run_fixture_under_test_harness` | Prepares a fixture directory, assembles rustc flags (including extern-crate links), and delegates to `run_test_runner`.                |
-| `run_fixture_harness_test`       | End-to-end driver: calls `run_with_runner` and panics with a labelled message on failure. Used by parametrised `#[rstest]` test cases. |
+| Function                         | Purpose                                                                                                                                 |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `run_example_under_test_harness` | Runs one example target under the dylint UI test harness using the flags in the `ExampleHarnessRun` spec.                               |
+| `run_fixture_under_test_harness` | Prepares a fixture directory, assembles rustc flags (including extern-crate links), and delegates to `run_test_runner`.                 |
+| `run_fixture_harness_test`       | End-to-end driver: calls `run_with_runner` and panics with a labelled message on failure. Used by parameterized `#[rstest]` test cases. |
 
 #### Dependency Rust library (`rlib`) resolution
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -823,7 +823,7 @@ Two structs group the string parameters that describe a single regression run:
 | `run_fixture_under_test_harness` | Prepares a fixture directory, assembles rustc flags (including extern-crate links), and delegates to `run_test_runner`.                |
 | `run_fixture_harness_test`       | End-to-end driver: calls `run_with_runner` and panics with a labelled message on failure. Used by parametrised `#[rstest]` test cases. |
 
-#### Dependency rlib resolution
+#### Dependency Rust library (`rlib`) resolution
 
 When a regression requires a real external crate (e.g. `tokio`), the harness
 must locate the built rlib so it can pass `--extern tokio=…` to the compiler.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -78,8 +78,8 @@ runner in `src/lib_ui_tests.rs`.
 The harness splits cases into two shapes:
 
 - Example-based runs use `ExampleHarnessRun` plus
-  `dylint_testing::ui::Test::example`
-  when a single example target is enough and no extra fixture assets are needed.
+  `dylint_testing::ui::Test::example` when a single example target is enough
+  and no extra fixture assets are needed.
 - Fixture-based runs use `FixtureHarnessRun`, `prepare_fixture`, and
   `Test::src_base` when the case needs copied support files, a per-fixture
   `dylint.toml`, or additional `--extern` wiring.
@@ -794,6 +794,55 @@ Keep the regression split aligned with that compiler boundary:
 
 This separation exists so a proc-macro stub test cannot accidentally mask a
 failure in the real harness-descriptor path.
+
+### UI test harness helpers (`lib_ui_tests.rs`)
+
+`crates/no_expect_outside_tests/src/lib_ui_tests.rs` provides the
+infrastructure for regressions that require compiler flags, example targets, or
+external crate dependencies that cannot be expressed with plain `ui/` source
+fixtures.
+
+#### Parameter structs
+
+Two structs group the string parameters that describe a single regression run:
+
+- **`ExampleHarnessRun`** — carries `name` (example binary name), `label`
+  (used in panic messages), and `rustc_flags`. Use `ExampleHarnessRun::new` for
+  the default `--test` flag, or `ExampleHarnessRun::with_flags` to supply a
+  custom flag list.
+- **`FixtureHarnessRun`** — carries `crate_name`, `directory` (top-level
+  directory such as `"examples"` or `"ui"`), `fixture_name`, `label`,
+  `rustc_flags`, and `extern_crates` (a list of additional crate names to wire
+  as `--extern` dependencies).
+
+#### Harness driver functions
+
+| Function                         | Purpose                                                                                                                                |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `run_example_under_test_harness` | Runs one example target under the dylint UI test harness using the flags in the `ExampleHarnessRun` spec.                              |
+| `run_fixture_under_test_harness` | Prepares a fixture directory, assembles rustc flags (including extern-crate links), and delegates to `run_test_runner`.                |
+| `run_fixture_harness_test`       | End-to-end driver: calls `run_with_runner` and panics with a labelled message on failure. Used by parametrised `#[rstest]` test cases. |
+
+#### Dependency rlib resolution
+
+When a regression requires a real external crate (e.g. `tokio`), the harness
+must locate the built rlib so it can pass `--extern tokio=…` to the compiler.
+`dependency_directory()` finds the parent of the running test binary, and
+`dependency_rlib()` scans that directory for `lib<crate>-*.rlib` files,
+selecting the most recently built artefact. Ties in modification time are
+broken by lexicographic path order for a stable, deterministic result.
+
+Unit tests for this selection logic live in
+`crates/no_expect_outside_tests/src/dependency_rlib_tests.rs`, loaded via a
+`#[path]` module declaration in `lib_ui_tests.rs`.
+
+#### `camino` dev-dependency
+
+`lib_ui_tests.rs` uses [`camino`](https://docs.rs/camino)'s `Utf8Path` to pass
+fixture directory paths to helper functions as UTF-8-guaranteed paths. This
+avoids repeated `.to_str().unwrap()` calls on `std::path::Path` throughout the
+harness. `camino` is a dev-dependency only; it is not present in the production
+library.
 
 ### Staged-suite installer shortcut
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -367,6 +367,30 @@ Set `additional_test_attributes` to an array of attribute paths written as
 strings. Each entry should match the path Whitaker sees on the test function,
 for example `my_framework::test` or `wasm_bindgen_test`.
 
+#### Ancestor context propagation
+
+`additional_test_attributes` now apply during ancestor context detection as
+well as direct annotation matching. If a parent function is annotated with a
+configured custom test attribute, Whitaker treats nested code within that
+function as test context too, so `.expect()` remains allowed throughout that
+ancestry chain.
+
+```rust
+// dylint.toml
+// [no_expect_outside_tests]
+// additional_test_attributes = ["my_framework::test"]
+
+#[my_framework::test]
+async fn my_test() {
+    helper(); // allowed — ancestor is a recognised test function
+}
+
+fn helper() {
+    let v: Option<u32> = Some(1);
+    let _ = v.expect("value present"); // allowed — called from within test ancestry
+}
+```
+
 #### What is allowed
 
 - Default markers such as `#[test]`, `#[::test]`,


### PR DESCRIPTION
## Summary

Document the `no_expect_outside_tests` UI harness helpers and dependency-rlib test support, and extend the developer guide's regression-infrastructure section with the harness workflow details.

Also tighten `collect_context` so function ancestors tagged via configured `additional_test_attributes` are treated as test context during summarisation.

## Why

The crate had documentation coverage warnings around the UI harness helpers and rlib-selection tests, and the maintainer guide did not explain when these harness helpers should be used.

The context-collection path also needed to ensure configured test-like attributes are recognised while walking HIR ancestors so async test harness regressions are classified correctly.

## Impact

- Raises Rustdoc coverage for the affected helper types and functions.
- Documents the harness parameter structs, driver functions, and rlib resolution path for maintainers.
- Keeps additional test attributes active during context summarisation for `no_expect_outside_tests`.

## Validation

- `cargo test -p no_expect_outside_tests --features dylint-driver`
- `make markdownlint`
- `make nixie`
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`

## Summary by Sourcery

Document the no_expect UI test harness helpers and refine test context detection for additional test attributes.

Bug Fixes:
- Ensure HIR ancestor traversal treats functions tagged via configured additional_test_attributes as test context when collecting context.

Documentation:
- Expand rustdoc for harness parameter structs, driver functions, and rlib resolution helpers in lib_ui_tests.rs and dependency_rlib_tests.rs.
- Extend the developer guide with a detailed description of the UI test harness workflow, parameter structs, rlib resolution behaviour, and camino usage.