### PR TITLE
Verify findings and refine test guidance for unwrap_or_else

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -597,19 +597,22 @@ allow_in_main = true
 - Panicking `unwrap_or_else` fallbacks inside doctests
 - Panicking `unwrap_or_else` fallbacks inside `main` when
   `allow_in_main = true`
-- `unwrap_or_else(|| panic!("value was {:?}", value))` inside test code when
-  the closure interpolates a runtime value into the panic message
+- `unwrap_or_else(|| panic!("value was {:?}", value))` inside test code only
+  when the closure uses interpolation and does not also include a plain static
+  panic message
 - Non-panicking `unwrap_or_else` fallbacks
 
 **What is denied:**
 
-- `unwrap_or_else(|| panic!(..))`
-- `unwrap_or_else(|| panic!("static message"))` inside tests when the closure
-  does not interpolate a runtime value; use `.expect("static message")` instead
+- `unwrap_or_else(|| panic!(..))` outside doctests, except for test-only
+  closures whose panic path is interpolation-only
+- `unwrap_or_else(|| panic!("static message"))` inside tests; plain static
+  panic messages are still denied, so use `.expect("static message")` instead
 - `unwrap_or_else(|| value.unwrap())`
 
 **How to fix:** Propagate errors with `?` or use `.expect()` with a clear
 message if a panic is truly intended. In tests, replace
 `unwrap_or_else(|| panic!("msg"))` with `.expect("msg")` for clarity and
-brevity unless the closure needs to interpolate runtime state for a more useful
-diagnostic.
+brevity. Keep `unwrap_or_else(|| panic!(...))` only when the panic needs to
+interpolate runtime state into the message; static panic strings are still
+denied in test code.


### PR DESCRIPTION
## Summary
- Clarified unwrap_or_else panic handling for tests vs doctests in docs/users-guide.md
- Updated guidance to prefer `.expect` and `?`, with explicit allowance only for interpolation-based panics in test closures
- Adjusted the "What is denied" and "How to fix" sections to reflect test-only behavior

## Changes

### Documentation
- Updated docs/users-guide.md unwrap_or_else policy:
  - Deny `unwrap_or_else(|| panic!(..))` outside doctests unless the closure used for testing interpolates runtime state in the panic path
  - Deny `unwrap_or_else(|| panic!("static message"))` inside tests; static messages remain denied, use `.expect("static message")` instead
  - In tests, replace `unwrap_or_else(|| panic!("msg"))` with `.expect("msg")` for clarity and brevity
  - Keep `unwrap_or_else(|| panic!(...))` only when the panic relies on interpolating runtime state into the message

### Other
- Minor wording improvements for clarity and consistency

## Test plan
- [x] Review updated documentation sections for accuracy and clarity
- [x] Verify examples align with the new guidance
- [x] No code changes; ensure docs build cleanly if docs are built as part of CI

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/8651f091-767b-46e2-958f-95a77231bff5

## Summary by Sourcery

Documentation:
- Tighten and clarify documentation on when panicking unwrap_or_else fallbacks are allowed in tests and doctests, emphasizing interpolation-only test closures and preferring .expect for static messages.