### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Lint
         run: make lint
 
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
+
       - name: Publish dry run
         run: make publish-check PUBLISH_PACKAGES="whitaker-common whitaker-installer"
 

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,43 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
+
+on:
+  schedule:
+    - cron: "50 4 * * *" # Daily, 04:50 UTC
+  workflow_dispatch:
+
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
+
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    with:
+      # Workspace members live under common/, crates/, installer/, and
+      # suite/ alongside the root crate's src/; there are no repo-root
+      # examples/ or benches/ directories.
+      paths: "src/,common/,crates/,installer/,suite/"
+      # Scaffolding whose survivors are noise: the rustc_* proxy shims
+      # and the clippy_utils stub re-export compiler internals, the
+      # per-lint ui/ and examples/ directories hold dylint UI fixtures,
+      # and src/testing plus common/src/test_support are shared test
+      # infrastructure.
+      exclude-globs: "crates/rustc_*/**,crates/clippy_utils/**,crates/*/ui/**,crates/*/examples/**,src/testing/**,common/src/test_support/**"
+      # Match the CI baseline (Makefile CARGO_FLAGS uses --all-features)
+      # so feature-gated tests run against mutants.
+      extra-args: "--all-features"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie publish-check typecheck install-smoke release-installer-dry-run package-lints workflow-test workflow-test-deps verus kani verus-clone-detector kani-clone-detector
+.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie publish-check typecheck install-smoke release-installer-dry-run package-lints workflow-test workflow-test-deps test-workflow-contracts verus kani verus-clone-detector kani-clone-detector
 
 # Appended only on targets that invoke binaries commonly installed under these
 # prefixes (cargo/bun/user-local), so the default recipe environment stays
@@ -93,6 +93,10 @@ workflow-test: workflow-test-deps ## Run opt-in GitHub workflow smoke tests with
 		exit 1; \
 	}
 	@ACT_WORKFLOW_TESTS=1 $(WORKFLOW_TEST_VENV)/bin/python -m pytest tests/workflows
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	@export PATH="$$PATH:$(TOOL_PATH_SUFFIX)"; command -v $(UV) >/dev/null || { echo "uv is required for workflow contract tests"; exit 1; }
+	@export PATH="$$PATH:$(TOOL_PATH_SUFFIX)"; $(UV) run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 workflow-test-deps: ## Install Python dependencies for workflow tests
 	@export PATH="$$PATH:$(TOOL_PATH_SUFFIX)"; command -v $(UV) >/dev/null || { echo "uv is required for workflow tests"; exit 1; }

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,147 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests; whitaker's
+caller is declarative configuration. These tests parse the caller with
+PyYAML and pin the contract it must uphold, so drift (repointing the pin
+at a branch, widening permissions, or losing the workspace paths,
+scaffolding excludes, or feature-flag configuration) fails CI on the
+pull request rather than surfacing in a scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The commit SHA of the estate-wide shared-workflow pin (the merge
+#: commit of leynos/shared-actions PR #319). Bump the workflow and this
+#: test together.
+PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: The exact caller configuration: workspace source prefixes, the
+#: scaffolding excludes (rustc proxy shims, the clippy_utils stub,
+#: dylint UI fixtures, and shared test infrastructure), and the CI
+#: feature baseline.
+EXPECTED_WITH = {
+    "paths": "src/,common/,crates/,installer/,suite/",
+    "exclude-globs": (
+        "crates/rustc_*/**,crates/clippy_utils/**,crates/*/ui/**,"
+        "crates/*/examples/**,src/testing/**,common/src/test_support/**"
+    ),
+    "extra-args": "--all-features",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump the workflow and this test together"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "50 4 * * *"}], (
+        f"on.schedule must be the daily 04:50 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the paths, excludes, and feature args."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        "jobs.mutation.with must be exactly the documented configuration "
+        f"{EXPECTED_WITH!r}, got {with_block!r}"
+    )


### PR DESCRIPTION
## Summary

This pull request adds a thin caller of the shared mutation-testing reusable workflow, `leynos/shared-actions` `mutation-cargo.yml`, pinned to `47aea18960d24f33aedc4782ec6b73e365418313`. Runs are informational only: a daily guard at 04:50 UTC mutates files changed within the detection window, and manual dispatch fans a full run out across shards.

## Configuration for this repository

- `paths: "src/,common/,crates/,installer/,suite/"` — the workspace members live under `common/`, `crates/`, `installer/`, and `suite/` alongside the root crate's `src/`; there are no repository-root `examples/` or `benches/` directories.
- `exclude-globs` drops scaffolding whose survivors would be noise: the `crates/rustc_*` proxy shims and the `crates/clippy_utils` stub (thin re-exports of compiler internals), the per-lint `ui/` and `examples/` dylint fixture directories, and the shared test infrastructure in `src/testing` and `common/src/test_support`.
- `extra-args: "--all-features"` mirrors the CI test baseline (the Makefile's `CARGO_FLAGS` uses `--all-features`), so feature-gated tests run against mutants.
- No `extra-crate-dirs`: every crate is a workspace member.

A contract test suite under `tests/workflow_contracts` pins the caller's shape (SHA pin, least-privilege permissions, per-ref concurrency, the 04:50 schedule, and the exact `with:` block) so drift fails pull-request CI rather than a scheduled run. It runs via the new `test-workflow-contracts` Makefile target, wired into the `linux-full` CI job after the lint step (that job already sets up `uv`).

## Validation

- YAML parse of `mutation-testing.yml` and `ci.yml` passes.
- `actionlint` passes on `mutation-testing.yml`; the only finding on `ci.yml` is the pre-existing custom `ubicloud-standard-4-ubuntu-2404` runner-label warning, unchanged by this pull request.
- `make test-workflow-contracts`: 6 passed, including a negative test (repointing the pin at `@v1` fails the SHA assertion; restoring it returns the suite to green).

## References

- Caller guide: https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md
- Estate template: https://github.com/leynos/wireframe/pull/572

🤖 Generated with [Claude Code](https://claude.com/claude-code)
