### PR TITLE
Bump the shared mutation workflow pin

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b09d10192627fd6e1034e7c12625dd266b45503
     with:
       # Workspace members live under common/, crates/, installer/, and
       # suite/ alongside the root crate's src/; there are no repo-root

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -21,10 +21,9 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The commit SHA of the estate-wide shared-workflow pin (the merge
-#: commit of leynos/shared-actions PR #319). Bump the workflow and this
-#: test together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+#: The commit SHA of the estate-wide shared-workflow pin. Bump the
+#: workflow and this test together.
+PINNED_SHA = "2b09d10192627fd6e1034e7c12625dd266b45503"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

This pull request bumps the `leynos/shared-actions` `mutation-cargo.yml` pin from `47aea18960d24f33aedc4782ec6b73e365418313` to `2b09d10192627fd6e1034e7c12625dd266b45503`, updating the contract test's `PINNED_SHA` in step.

## Why `--test-workspace=true` is not adopted here

The estate-wide follow-up to the rstest-bdd#569 review finding pairs this pin bump with cargo-mutants' `--test-workspace=true`, so dependent crates' tests catch mutants in workspace libraries. Whitaker cannot take that flag safely:

- CI never runs the full workspace suite as a baseline. Both `make test` and `make publish-check` apply `TEST_EXCLUDES`, which excludes the seven `rustc_*` proxy shims, the root `whitaker` crate, `function_attrs_follow_docs`, `module_max_lines`, and `no_expect_outside_tests`.
- The excluded suites are dylint UI tests needing nightly `rustc_private` with bespoke `RUSTFLAGS` (`-C prefer-dynamic -Z force-unstable-if-unmarked`) and a backup/restore safeguard around `~/.local/bin/whitaker`; `.cargo/config.toml` deliberately refuses to set those flags workspace-wide because they would break `cargo install` for `whitaker-installer`.
- The shared mutation runner provides none of that setup, so running the whole workspace's tests against each mutant would fail at baseline.

`extra-args` therefore stays at `--all-features`, mirroring the CI baseline.

## Validation

- YAML parse of `mutation-testing.yml` passes.
- `actionlint` passes on `mutation-testing.yml`.
- `make test-workflow-contracts`: 6 passed against the new pin.

## References

- Caller guide: https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md
- Review finding: https://github.com/leynos/rstest-bdd/pull/569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
