### PR TITLE
Add an agent skill for addressing Whitaker findings

### DIFF
--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -25,6 +25,7 @@ formal verification helpers.
 | `docs/`      | User, developer, design, roadmap, decision-record, and planning documentation.                                                        |
 | `installer/` | The `whitaker-installer` crate, packaging logic, and installer-specific behaviour tests.                                              |
 | `scripts/`   | Repository automation for checksums, Kani, and Verus setup and execution.                                                             |
+| `skills/`    | Agent-facing skills that document repeatable maintenance and remediation workflows.                                                   |
 | `src/`       | Root library code that assembles shared lint registration and workspace-facing APIs.                                                  |
 | `suite/`     | The suite crate used to package and expose the lint set coherently.                                                                   |
 | `tests/`     | Workspace-level integration, behaviour, UI harness, and workflow tests.                                                               |

--- a/skills/addressing-whitaker-findings/SKILL.md
+++ b/skills/addressing-whitaker-findings/SKILL.md
@@ -35,9 +35,6 @@ tests.** A fixture arranges state; arrangement can fail, so it must
 return `Result` and propagate errors. Only the test body may unwrap: a
 failure there is the test verdict.
 
-**Triage:** [type:grammar] The colon introduces the explanation for why
-the test body may unwrap.
-
 - Convert fixtures and helpers to return `anyhow::Result`,
   `io::Result`, or the domain error; tests consume with `?` or unwrap
   in the body.

--- a/skills/addressing-whitaker-findings/SKILL.md
+++ b/skills/addressing-whitaker-findings/SKILL.md
@@ -32,14 +32,19 @@ traps that cost earlier adopters rework.
 
 The policy behind these lints: **fixture and helper functions are not
 tests.** A fixture arranges state; arrangement can fail, so it must
-return `Result` and propagate errors. Only the test body may unwrap,
-because there a failure is the test verdict.
+return `Result` and propagate errors. Only the test body may unwrap: a
+failure there is the test verdict.
+
+**Triage:** [type:grammar] The colon introduces the explanation for why
+the test body may unwrap.
 
 - Convert fixtures and helpers to return `anyhow::Result`,
   `io::Result`, or the domain error; tests consume with `?` or unwrap
   in the body.
-- Poisoned-mutex panics in test doubles (`lock().unwrap_or_else(|e|
-  panic!(…))`) become `PoisonError::into_inner` recovery.
+- A poisoned mutex means a panic occurred while its lock was held. In
+  test doubles, use `PoisonError::into_inner` only when the double's
+  invariants remain valid; otherwise propagate the poison error or fail
+  the fixture.
 - `#[tokio::main]` expands to `.expect()` on runtime construction:
   build the runtime explicitly in binaries and BDD harnesses and
   propagate the error.
@@ -113,8 +118,10 @@ Sanctioned exclusion categories, each with a rationale comment:
   bootstrapper; a pyo3 crate mirroring CPython file-handler APIs).
   Say so in the comment, and name the migration path if one exists.
 
-New test crates that touch `std::fs` will fail CI until added to the
-exclusion list — that is the point: the policy decision stays visible.
+New test crates that use `std::fs` must either migrate to the
+capability-scoped API or receive a documented exclusion. CI must fail
+until one path is chosen — that is the point: the policy decision stays
+visible.
 
 ### `module_max_lines`
 

--- a/skills/addressing-whitaker-findings/SKILL.md
+++ b/skills/addressing-whitaker-findings/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: addressing-whitaker-findings
+description: Best practices for fixing Whitaker Dylint suite findings — per-lint remediation playbook, exclusion policy, and the interaction traps discovered during the leynos estate rollout
+---
+
+# Addressing Whitaker findings
+
+Use this skill when a repository fails the Whitaker Dylint suite and the
+findings need fixing. It distils the remediation patterns from adopting
+the suite across forty-plus repositories: what each lint wants, which
+fixes hold up under review, when an exclusion is legitimate, and the
+traps that cost earlier adopters rework.
+
+## Working stance
+
+- Prefer a real fix to a suppression, and a suppression to a lie. The
+  suite encodes house policy; most findings point at genuine debt.
+- Findings arrive in waves. `cargo dylint` stops at the first failing
+  crate, so expect build script → lib → lib tests → each integration
+  test crate, and budget three to four fix/re-run cycles on a repository
+  of any size. Re-run after every round; do not assume the first report
+  is complete.
+- The suite runs with `--all-targets`, which compiles benches and
+  examples that ordinary CI may never build. Expect to find (and fix)
+  bit-rotted benches as a side effect.
+- After refactoring, re-check module sizes: extracting helpers to fix
+  `bumpy_road_function` can push a module over `module_max_lines`.
+
+## Per-lint playbook
+
+### `no_expect_outside_tests` and `no_unwrap_or_else_panic`
+
+The policy behind these lints: **fixture and helper functions are not
+tests.** A fixture arranges state; arrangement can fail, so it must
+return `Result` and propagate errors. Only the test body may unwrap,
+because there a failure is the test verdict.
+
+- Convert fixtures and helpers to return `anyhow::Result`,
+  `io::Result`, or the domain error; tests consume with `?` or unwrap
+  in the body.
+- Poisoned-mutex panics in test doubles (`lock().unwrap_or_else(|e|
+  panic!(…))`) become `PoisonError::into_inner` recovery.
+- `#[tokio::main]` expands to `.expect()` on runtime construction:
+  build the runtime explicitly in binaries and BDD harnesses and
+  propagate the error.
+- Shared `LazyLock` statics that panic on construction should store
+  `Result` and surface the error at each use site.
+- Non-panicking `unwrap_or_else` fallbacks whose closure contains a
+  macro (`tracing::debug!` and similar) still trip the lint, which
+  cannot see through the expansion; rewrite as `if let`/`else` (a
+  plain `match` may then trip clippy's `single_match_else`).
+
+**Proc-macro erasure — functions the lint cannot recognise as tests.**
+Attributes are gone by the time lints see HIR, so these are treated as
+production code even inside `cfg(test)`:
+
+- rstest `#[fixture]` functions,
+- cucumber step functions (and `additional_test_attributes` cannot
+  help, because the macros consume their attributes),
+- `#[serial]`-wrapped `#[test]` functions.
+
+In each case, make the function fallible instead of suppressing.
+Plain `#[test]` and `#[rstest]` bodies ARE recognised.
+
+**Structural no-propagation contexts** get a documented escape hatch,
+not a scattering of expects: an extension trait (e.g. `ExpectValid`)
+for proptest strategy pipelines, or a single documented helper (e.g.
+`expect_bench`) for Criterion closures. One named, explained panic
+boundary beats twenty anonymous ones.
+
+### Assertions (house style, enforced by review if not by lint)
+
+Assertions follow command–query separation: run the fallible operation
+as its own statement and handle or unwrap its error there, then assert
+on the result of a pure query. Never bury a fallible call inside
+`assert!`/`assert_eq!`. When several tests share the same
+query-plus-assertion shape, extract a custom assertion **macro** (not
+a helper function) so panic line numbers keep pointing at the calling
+test — and note that macros are the only option where the assertion
+appears in `#[case(...)]` attributes.
+
+### `no_std_fs_operations`
+
+Prefer real fixes first:
+
+- Route file access through `cap_std` `Dir` handles opened at a
+  well-defined root (workspace, fixture directory).
+- Tempfile writes can go through `NamedTempFile`'s own `Write` impl
+  rather than `as_file_mut()`, avoiding the `std::fs::File` receiver
+  the lint keys on.
+- Test fixture staging can use cap-std throughout (create_dir_all,
+  write, set_permissions, read_to_string all exist on `Dir`).
+
+Know cap-std's limits before forcing it: `Dir::metadata` refuses
+symlinks that leave the directory, so PATH-probing code (`which`-style
+resolution of `/usr/bin/cc -> /etc/alternatives/cc`) cannot be
+capability-scoped. Irreducibly ambient operations belong in a small
+**boundary crate** (netsuke's `ambient_fs` is the reference) with a
+documented scope-and-reuse policy, excluded in `dylint.toml`.
+
+**In-source suppression does not work for this lint** (issue #270):
+`allow` leaves the diagnostic firing and `expect` adds an unfulfilled-
+expectation error on top. The only working escape hatch is crate-level
+`[no_std_fs_operations] excluded_crates` in the root `dylint.toml`.
+Sanctioned exclusion categories, each with a rationale comment:
+
+- `build_script_build` — build scripts get ambient paths from Cargo.
+- Test-support crates and integration-test crates that stage fixtures
+  ambiently (the crate name of `tests/foo.rs` is `foo`).
+- Boundary crates holding deliberately ambient probes.
+- Crates whose purpose is ambient filesystem or process management
+  (a daemon preparing its socket directory; an embedded-database
+  bootstrapper; a pyo3 crate mirroring CPython file-handler APIs).
+  Say so in the comment, and name the migration path if one exists.
+
+New test crates that touch `std::fs` will fail CI until added to the
+exclusion list — that is the point: the policy decision stays visible.
+
+### `module_max_lines`
+
+Split by extraction, following the repository's existing convention
+(`#[path]` sibling modules are common). Test modules extract cleanly
+to `foo_tests.rs`; keep behaviour identical. When splitting files under
+`tests/`, place helpers in a subdirectory so cargo does not
+auto-discover them as new test crates.
+
+### `module_must_have_inner_docs`
+
+Add a `//!` first line stating what the module is for. If the module
+already opens with an outer `///` on its first item, converting may be
+needed to avoid `clippy::mixed_attributes_style`.
+
+### `bumpy_road_function` and `conditional_max_n_branches`
+
+Extract intention-revealing helpers for each complexity cluster or
+branch bundle. Re-run the suite afterwards: the extraction changes
+module sizes and can surface follow-on findings.
+
+## Clippy interactions to budget for
+
+Converting tests to return `Result` interacts with strict clippy
+configurations:
+
+- `panic_in_result_fn` denies `assert!`/`assert_eq!` in
+  Result-returning tests — use `anyhow::ensure!`/`bail!` (or the
+  `eyre` equivalents).
+- `shadow_reuse` fires on `let x = x?;` rebinding — take the fixture
+  as a differently named parameter (rstest `#[from(fixture)]
+  fixture_res: Result<…>`) or destructure to fresh names.
+- Assertion macros expand inline: a macro used inside a test can push
+  it over `cognitive_complexity`.
+
+Always finish with the repository's full gate suite, not just the
+Whitaker run.
+
+## Toolchain and dependency wrinkles
+
+- The suite lints under its own pinned nightly regardless of the
+  repository toolchain, so in matrix CI run it on one leg only.
+- If a dependency's `rust-version` exceeds the suite's pinned nightly
+  rustc, pass `--ignore-rust-version` on the dylint invocation and
+  document why; the repository toolchain still enforces the real MSRV.
+- Mutually exclusive feature sets cannot be linted with
+  `--all-features`; run the suite once per feature leg with that leg's
+  flags.
+
+## What not to do
+
+- Do not add `#[allow]`/`#[expect]` for `no_std_fs_operations` — they
+  do not work (issue #270) and reviewers will flag them.
+- Do not soft-skip the suite ("run whitaker if installed"): a gate
+  that cannot fail is not a gate. The Makefile invocation should be
+  unconditional, with the binary overridable via a variable
+  (`WHITAKER ?= whitaker`).
+- Do not silence a fixture by renaming it to look like a test; make it
+  fallible instead.
+- Do not cache the staged lint libraries keyed by installer version in
+  CI while the suite floats on the rolling release — it pins stale
+  lints arbitrarily. Cache only the installer binary; revisit once the
+  suite is pinned by ref.

--- a/skills/addressing-whitaker-findings/SKILL.md
+++ b/skills/addressing-whitaker-findings/SKILL.md
@@ -50,7 +50,7 @@ because there a failure is the test verdict.
   cannot see through the expansion; rewrite as `if let`/`else` (a
   plain `match` may then trip clippy's `single_match_else`).
 
-**Proc-macro erasure — functions the lint cannot recognise as tests.**
+**Proc-macro erasure — functions the lint cannot recognize as tests.**
 Attributes are gone by the time lints see HIR, so these are treated as
 production code even inside `cfg(test)`:
 
@@ -60,7 +60,7 @@ production code even inside `cfg(test)`:
 - `#[serial]`-wrapped `#[test]` functions.
 
 In each case, make the function fallible instead of suppressing.
-Plain `#[test]` and `#[rstest]` bodies ARE recognised.
+Plain `#[test]` and `#[rstest]` bodies ARE recognized.
 
 **Structural no-propagation contexts** get a documented escape hatch,
 not a scattering of expects: an extension trait (e.g. `ExpectValid`)

--- a/skills/addressing-whitaker-findings/SKILL.md
+++ b/skills/addressing-whitaker-findings/SKILL.md
@@ -14,7 +14,7 @@ traps that cost earlier adopters rework.
 ## Working stance
 
 - Prefer a real fix to a suppression, and a suppression to a lie. The
-  suite encodes house policy; most findings point at genuine debt.
+  suite encodes house policy; most findings point to genuine debt.
 - Findings arrive in waves. `cargo dylint` stops at the first failing
   crate, so expect build script → lib → lib tests → each integration
   test crate, and budget three to four fix/re-run cycles on a repository
@@ -58,7 +58,7 @@ production code even inside `cfg(test)`:
 
 - rstest `#[fixture]` functions,
 - cucumber step functions (and `additional_test_attributes` cannot
-  help, because the macros consume their attributes),
+  help because the macros consume their attributes),
 - `#[serial]`-wrapped `#[test]` functions.
 
 In each case, make the function fallible instead of suppressing.


### PR DESCRIPTION
## Summary

This branch adds an agent skill,
[skills/addressing-whitaker-findings/SKILL.md](https://github.com/leynos/whitaker/blob/whitaker-findings-skill/skills/addressing-whitaker-findings/SKILL.md),
capturing the remediation best practices learned while rolling the
suite out across forty-plus leynos repositories (~1,000 findings
fixed). It gives an agent — or a human — a per-lint playbook and the
policy context behind each lint, so findings get real fixes rather
than suppressions.

Contents: the wave behaviour of `cargo dylint` and how to budget
re-runs; the fixtures-are-not-tests policy behind
`no_expect_outside_tests` (fixtures return `Result`; only test bodies
unwrap) with the proc-macro erasure cases the lints cannot recognise
(`#[fixture]`, cucumber steps, `#[serial]`); command–query assertion
style and when shared assertions become macros; cap-std conversion
patterns, cap-std's symlink limits, the boundary-crate pattern, and
the sanctioned `dylint.toml` exclusion categories (with the #270
context explaining why crate-level exclusion is currently the only
working escape hatch for `no_std_fs_operations`); documented escape
hatches for structurally no-propagation contexts (proptest strategy
pipelines, Criterion closures); clippy interactions
(`panic_in_result_fn`, `shadow_reuse`, `cognitive_complexity`);
toolchain wrinkles (`--ignore-rust-version`, per-feature-leg runs);
and the anti-patterns reviewers reject, including soft-skipped gates
and version-keyed suite caches under the rolling release.

## Review walkthrough

- The skill is a single file:
  [skills/addressing-whitaker-findings/SKILL.md](https://github.com/leynos/whitaker/blob/whitaker-findings-skill/skills/addressing-whitaker-findings/SKILL.md).
  Read it top to bottom — frontmatter, working stance, per-lint
  playbook, then the interaction and policy sections.

## Validation

- `make markdownlint`: 69 files, 0 errors.

## References

- [Lody session](https://lody.ai/leynos/sessions/93d755c4-e140-4a6c-ac7d-72d5865645e8)