### PR TITLE
Upload main-branch coverage to CodeScene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ env:
   RUSTDOCFLAGS: -D warnings
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: sccache
+# CodeScene coverage: main-branch coverage is uploaded by
+# coverage-main.yml on push. The pull-request changed-line gate
+# (`cs-coverage check`, mode: check) is intentionally omitted here: the
+# CodeScene project (71836) does not yet have a coverage gates
+# configuration, so `mode: check` would fail every run. Add a guarded
+# coverage job with `fetch-depth: 0` and `upload-codescene-coverage`
+# (mode: check) once CodeScene enables the gate for this project.
 jobs:
   linux-full:
     runs-on: ubicloud-standard-4-ubuntu-2404
@@ -30,7 +37,7 @@ jobs:
         run: scripts/check-verus-fragment-id-bridge.sh
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10
@@ -87,7 +94,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,66 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push to main. Pull requests do
+# not upload; the changed-line gate (`cs-coverage check`) is deferred
+# until CodeScene enables the coverage gate for this project (see the note
+# in ci.yml). `workflow_dispatch` allows a manual re-run: automerge merges
+# performed with GITHUB_TOKEN do not fire push-event workflows, so
+# dispatch is the fallback path for uploading coverage from main.
+#
+# Coverage is generated via `make coverage`, which reuses the `make test`
+# recipe (same crate-exclusion set and prefer-dynamic RUSTFLAGS) with a
+# `cargo llvm-cov nextest` driver. The shared `generate-coverage` action is
+# deliberately not used: it hard-codes `cargo llvm-cov --workspace` with no
+# way to exclude crates, and whitaker's suite cannot run a bare
+# `--workspace` build (eleven crates are excluded from CI test runs and the
+# dylint UI tests need per-target RUSTFLAGS).
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BUILD_PROFILE: debug
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage-upload:
+    runs-on: ubicloud-standard-4-ubuntu-2404
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10
+        with:
+          tool: nextest@0.9.114
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate coverage
+        run: make coverage
+
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1990e9a6aaa73f0929e04dbc7da12326005606bf
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b09d10192627fd6e1034e7c12625dd266b45503
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # Workspace members live under common/, crates/, installer/, and
       # suite/ alongside the root crate's src/; there are no repo-root

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
       - name: Install cross-compilation tools (aarch64-linux)
         if: matrix.cross
@@ -153,7 +153,7 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
       - name: Install cross-compilation tools (aarch64-linux)
         if: matrix.cross
@@ -237,7 +237,7 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
       - name: Build dependency packaging tool
         run: cargo build --release -p whitaker-installer --bin whitaker-package-dependency-binary

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
       - name: Install cross-compilation tools (aarch64-linux)
         if: matrix.cross
@@ -199,7 +199,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
       - name: Install cross-compilation tools (aarch64-linux)
         if: matrix.cross
@@ -290,7 +290,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@c749ab3a96026e14051a2198bf75f94650581b75
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
 
       - name: Build dependency packaging tool
         run: cargo build --release -p whitaker-installer --bin whitaker-package-dependency-binary

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release lint fmt check-fmt markdownlint nixie publish-check typecheck install-smoke release-installer-dry-run package-lints workflow-test workflow-test-deps test-workflow-contracts verus kani verus-clone-detector kani-clone-detector
+.PHONY: help all clean test coverage build release lint fmt check-fmt markdownlint nixie publish-check typecheck install-smoke release-installer-dry-run package-lints workflow-test workflow-test-deps test-workflow-contracts verus kani verus-clone-detector kani-clone-detector
 
 # Appended only on targets that invoke binaries commonly installed under these
 # prefixes (cargo/bun/user-local), so the default recipe environment stays
@@ -13,6 +13,11 @@ CARGO_FLAGS ?= --workspace --all-targets --all-features
 TEST_EXCLUDES ?= --exclude rustc_ast --exclude rustc_attr_data_structures --exclude rustc_hir --exclude rustc_lint --exclude rustc_middle --exclude rustc_session --exclude rustc_span --exclude whitaker --exclude function_attrs_follow_docs --exclude module_max_lines --exclude no_expect_outside_tests
 TEST_CARGO_FLAGS ?= $(CARGO_FLAGS) $(TEST_EXCLUDES)
 NEXTEST_PROFILE ?=
+# The cargo test driver. `test` runs `cargo nextest run`; `coverage`
+# overrides this with `cargo llvm-cov nextest ...` so instrumentation runs
+# over the exact same crate subset (TEST_CARGO_FLAGS) and RUSTFLAGS.
+TEST_RUNNER ?= nextest run
+COVERAGE_OUTPUT ?= lcov.info
 RUST_FLAGS ?= -D warnings
 RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 MDLINT ?= $(or $(shell command -v markdownlint-cli2 2>/dev/null),$(HOME)/.bun/bin/markdownlint-cli2)
@@ -78,10 +83,22 @@ test: ## Run tests with warnings treated as errors
 		rm -f "$$WHITAKER_BACKUP"; \
 		WHITAKER_BACKUP=""; \
 	fi; \
-	RUSTFLAGS="-C prefer-dynamic -Z force-unstable-if-unmarked $(RUST_FLAGS)" $(CARGO) nextest run $(TEST_CARGO_FLAGS) $(BUILD_JOBS) $(if $(NEXTEST_PROFILE),--profile $(NEXTEST_PROFILE)); \
+	RUSTFLAGS="-C prefer-dynamic -Z force-unstable-if-unmarked $(RUST_FLAGS)" $(CARGO) $(TEST_RUNNER) $(TEST_CARGO_FLAGS) $(BUILD_JOBS) $(if $(NEXTEST_PROFILE),--profile $(NEXTEST_PROFILE)); \
 	if [ "$${ACT_WORKFLOW_TESTS:-0}" = "1" ]; then \
 		$(MAKE) workflow-test; \
 	fi
+
+coverage: ## Generate LCOV coverage over the CI-tested crate subset
+	@# Reuse the `test` recipe verbatim (same TEST_CARGO_FLAGS excludes,
+	@# same prefer-dynamic RUSTFLAGS, same WHITAKER_SCRIPT safeguard) but
+	@# swap the driver to `cargo llvm-cov nextest`. This keeps the
+	@# instrumented run in lockstep with the plain test run: the 11
+	@# CI-excluded crates (rustc_* proxy shims, the whitaker root, and the
+	@# three lint crates whose dylint UI tests are excluded) stay excluded,
+	@# so coverage never attempts a bare `--workspace` build the suite
+	@# cannot support.
+	@export PATH="$$PATH:$(TOOL_PATH_SUFFIX)"; command -v cargo-llvm-cov >/dev/null || { echo "Install cargo-llvm-cov (cargo install cargo-llvm-cov)"; exit 1; }
+	@$(MAKE) test TEST_RUNNER="llvm-cov nextest --lcov --output-path $(COVERAGE_OUTPUT)"
 
 workflow-test: workflow-test-deps ## Run opt-in GitHub workflow smoke tests with act + pytest
 	@export PATH="$$PATH:$(TOOL_PATH_SUFFIX)"; command -v act >/dev/null || { echo "Install act to run workflow tests"; exit 1; }

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -23,7 +23,7 @@ WORKFLOW_PATH = (
 
 #: The commit SHA of the estate-wide shared-workflow pin. Bump the
 #: workflow and this test together.
-PINNED_SHA = "2b09d10192627fd6e1034e7c12625dd266b45503"
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

Onboards whitaker to the CodeScene coverage upload. whitaker is the
estate's Dylint lint suite (Tier 3: no coverage generation previously),
and its CodeScene project is
[71836](https://codescene.io/projects/71836).

whitaker's test run deliberately excludes eleven crates — the seven
`rustc_*` proxy shims, the `whitaker` root crate, and three lint crates
(`function_attrs_follow_docs`, `module_max_lines`,
`no_expect_outside_tests`) whose dylint UI tests need per-target
RUSTFLAGS — so a bare `cargo llvm-cov --workspace` build cannot run. The
shared [`generate-coverage`](https://github.com/leynos/shared-actions/tree/main/.github/actions/generate-coverage)
action hard-codes `cargo llvm-cov --workspace` with no crate-exclusion
input, so it cannot express whitaker's CI-tested subset. Coverage is
therefore generated by a new `make coverage` target that reuses the
`make test` recipe verbatim — the same `TEST_CARGO_FLAGS` exclusion set,
the same `-C prefer-dynamic -Z force-unstable-if-unmarked` RUSTFLAGS, and
the same `WHITAKER_SCRIPT` safeguard — swapping only the driver to
`cargo llvm-cov nextest`. This keeps the instrumented run in lockstep
with the tested subset (single source of truth for the excludes).

New `coverage-main.yml` uploads the resulting LCOV report to CodeScene on
push to `main`, with `workflow_dispatch` as the manual fallback (automerge
pushes made with `GITHUB_TOKEN` do not fire push-event workflows). The
upload step is guarded on `CS_ACCESS_TOKEN`, so token-less runs skip it.

The pull-request changed-line gate (`cs-coverage check`, `mode: check`)
is intentionally deferred: CodeScene project 71836 has no coverage gates
configuration yet, so `mode: check` fails every run estate-wide until
CodeScene enables the gate (a UI-only, operator action). A note in
`ci.yml` records how to wire the PR gate once that happens.

### Why this is not a required check

whitaker's required checks are `linux-full` and `windows-compat` only.
The CodeScene `Code Coverage` check is enabled per-CodeScene-project and
blocks via the status rollup, not the branch ruleset — but no coverage
check is posted for this project yet, so nothing is currently jammed.
This PR is the CI half; enabling the CodeScene-side gate is separate.

## Review walkthrough

- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/whitaker/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  — new push-to-main + dispatch workflow: setup-rust, nextest,
  cargo-llvm-cov, `make coverage`, guarded `upload-codescene-coverage`
  (`mode: upload`, `format: lcov`). No sccache (it interferes with
  coverage instrumentation).
- [`Makefile`](https://github.com/leynos/whitaker/blob/codescene-coverage-gate/Makefile)
  — new `coverage` target plus a `TEST_RUNNER` seam so `make test` and
  `make coverage` share one recipe.
- [`.github/workflows/ci.yml`](https://github.com/leynos/whitaker/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  — setup-rust pin bump and the deferred-gate note.
- `release.yml`, `rolling-release.yml`, `mutation-testing.yml`,
  `dependabot-automerge.yml` — repo-wide shared-actions pin bump to
  `927edd4` (single pin; supersedes Dependabot #136, which targeted an
  older SHA).
- [`tests/workflow_contracts/mutation_testing_test.py`](https://github.com/leynos/whitaker/blob/codescene-coverage-gate/tests/workflow_contracts/mutation_testing_test.py)
  — contract test updated to the new pinned SHA.

## Validation

- `python3 -c "import yaml; ..."` parses all six workflows.
- `make test-workflow-contracts` passes (6 tests) with the bumped SHA.
- `make coverage` and the CodeScene upload are exercised by CI on this
  branch and on the first push to `main` after merge.

## Merge mechanism

Dependabot automerge reads the whole status rollup. Because no CodeScene
coverage check is posted for project 71836 yet, this PR is not blocked by
a timed-out coverage check. The shared-actions pin bump also lets
Dependabot auto-close its in-flight bump PR (#136) rather than
ping-ponging pins.
