### PR TITLE
Stop pinning the mutation-workflow SHA in the contract test

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -180,6 +180,42 @@ Table: Test profiles and typical usage.
 When working on `whitaker-installer` code, run the full suite locally before
 pushing to catch installer regressions early.
 
+### Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ### Failure-mock test helpers
 
 `installer/src/toolchain/tests/failure_mocks.rs` provides reusable helpers for

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -8,11 +8,17 @@ at a branch, widening permissions, or losing the workspace paths,
 scaffolding excludes, or feature-flag configuration) fails CI on the
 pull request rather than surfacing in a scheduled or manual run.
 
+The caller must reference the correct reusable workflow at a commit SHA;
+Dependabot owns the SHA value, so these tests assert the shape of the pin
+(the reusable workflow path, and a full 40-hex commit SHA) rather than the
+specific SHA currently in force.
+
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -21,12 +27,8 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The commit SHA of the estate-wide shared-workflow pin. Bump the
-#: workflow and this test together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: workspace source prefixes, the
@@ -66,25 +68,19 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call the correct reusable workflow at a commit SHA.
+
+    Dependabot owns the SHA value, so this asserts the shape of the pin
+    (reusable workflow path plus a 40-hex commit SHA) rather than the
+    specific SHA currently in force.
+    """
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the workflow and this test together"
+    assert USES_RE.match(uses), (
+        "jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"full 40-character lowercase hex commit SHA, not a branch or tag: "
+        f"{uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Stop the mutation-testing workflow contract test from pinning an exact `leynos/shared-actions` commit SHA, so Dependabot bumps of the caller no longer fail CI in lockstep with a hand-edited constant.
- Replace the equality assertion with a shape assertion: the caller must reference `leynos/shared-actions/.github/workflows/mutation-cargo.yml` pinned to a full 40-character lowercase hex commit SHA — not a branch or tag — but the specific SHA value is no longer checked.
- Document the policy in the developer's guide so future workflow contract tests follow the same shape-only convention.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: dropped the `PINNED_SHA` constant, the `EXPECTED_USES` string, and the exact-SHA equality assertion; added a `USES_RE` regex and renamed the test to `test_uses_reference_is_pinned_to_a_commit_sha`. The other five contract assertions (job permissions, workflow-level permissions, concurrency, triggers, and the `with` block) are unchanged.
- `docs/developers-guide.md`: added a "Workflow pins and Dependabot" subsection under "Running Tests" documenting the shape-only pinning policy, with the canonical example.
- Confirmed `.github/dependabot.yml` already has a `github-actions` ecosystem entry with `directory: "/"` and a weekly schedule — no change needed there.
- This is the only workflow contract test in the repo that pinned a shared-actions SHA (checked `tests/workflows/*.py` too — none of those assert a SHA).

## Validation

- `make test-workflow-contracts` — 6 passed, confirming the regex matches the workflow's current pin.
- Reasoned through the regex: `^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$` anchors on the full path and requires exactly 40 lowercase hex characters, so it accepts any future Dependabot-bumped SHA while still rejecting a branch/tag ref or a short SHA.
- `make markdownlint` — 0 errors across 69 files, including the updated developer's guide.

This hands SHA ownership of the mutation-testing caller to Dependabot while keeping every other structural contract (path, permissions, triggers, concurrency, and caller configuration) enforced.
