### PR TITLE
Add PR-scoped CodeScene coverage gate to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,9 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: sccache
 # CodeScene coverage: main-branch coverage is uploaded by
-# coverage-main.yml on push. The pull-request changed-line gate
-# (`cs-coverage check`, mode: check) is intentionally omitted here: the
-# CodeScene project (71836) does not yet have a coverage gates
-# configuration, so `mode: check` would fail every run. Add a guarded
-# coverage job with `fetch-depth: 0` and `upload-codescene-coverage`
-# (mode: check) once CodeScene enables the gate for this project.
+# coverage-main.yml on push. The pull-request changed-line gate runs in
+# the coverage-check job below via `mode: check` against the same
+# `make coverage` lcov.info that coverage-main.yml generates.
 jobs:
   linux-full:
     runs-on: ubicloud-standard-4-ubuntu-2404
@@ -113,3 +110,42 @@ jobs:
       - name: Show sccache stats
         if: ${{ always() }}
         run: sccache --show-stats || true
+
+  coverage-check:
+    runs-on: ubicloud-standard-4-ubuntu-2404
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@d3cbe87e745e07b3ad53ddcb87deb19ffa95c9b8
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10
+        with:
+          tool: nextest@0.9.114
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@db22c42b5af88356329b9a8056bb2c2f026d5a10
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Generate coverage
+        run: make coverage
+
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/71836
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

- CodeScene project 71836's coverage gates configuration is now enabled
  (confirmed via `GET /v2/code-coverage/projects/71836/config`, which
  returns a populated `gates` array matching mxd's working project),
  so the deferred-gate comment in `ci.yml` is stale.
- whitaker has no shared `generate-coverage` PR job — coverage is
  bespoke, produced by `make coverage` (which reuses the `make test`
  crate-exclusion set with a `cargo llvm-cov nextest` driver) and only
  previously ran in `coverage-main.yml` on push to `main`. Since
  `mode: check` only makes sense on pull requests, this PR adds a new
  `coverage-check` job to `ci.yml` that mirrors `coverage-main.yml`'s
  generation steps on `pull_request`, then appends the guarded
  `upload-codescene-coverage` step in `mode: check` against the
  resulting `lcov.info`.
- The gate step is guarded (`CS_ACCESS_TOKEN != '' && github.event_name
  == 'pull_request'`), so token-less or non-PR runs skip cleanly.
  `coverage-main.yml` is unchanged and continues to run `mode: upload`
  on push to `main`.

## Review walkthrough

- [`.github/workflows/ci.yml`](../../blob/codescene-mode-check/.github/workflows/ci.yml):
  new `coverage-check` job (checkout with `fetch-depth: 0`, Rust/nextest/
  llvm-cov setup, `make coverage`, guarded gate step at
  `project-url: https://api.codescene.io/v2/projects/71836`, pinned to
  the same shared-actions SHA (`927edd4`) already used by
  `coverage-main.yml`'s upload step).
- `linux-full` and `windows-compat` are unchanged and remain the
  required checks; `coverage-check` is additive and not required.

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [x] `make test-workflow-contracts` (6 passed; no contract pins the
      coverage job shape)
- [ ] Confirm on the PR's own head that the `coverage-check` job's
      "Check coverage against CodeScene gates" step executes (not
      skipped) and succeeds, and that the `CodeScene Code Coverage`
      check completes rather than timing out.
