### PR TITLE
Bump the Dylint dependency binaries to 6.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ release-installer-dry-run: ## Build and package the host-platform installer arch
 
 publish-check: ## Build, test, and validate packages before publishing
 	@export PATH="$$PATH:$(TOOL_PATH_SUFFIX)"; command -v cargo-nextest >/dev/null || { echo "Install cargo-nextest (cargo install cargo-nextest)"; exit 1; }
+	set -eu; \
 	export PATH="$$PATH:$(TOOL_PATH_SUFFIX)"; \
 	PINNED_TOOLCHAIN=$$(awk -F '\"' '/^channel/ {print $$2}' rust-toolchain.toml); \
 	TOOLCHAIN="$$PINNED_TOOLCHAIN"; \
@@ -248,16 +249,12 @@ publish-check: ## Build, test, and validate packages before publishing
 	TMP_DIR=$$(mktemp -d); \
 	trap 'rm -rf "$$TMP_DIR"' 0 INT TERM HUP; \
 	DYLINT_TOOLS_DIR="$$TMP_DIR/dylint-tools"; \
-	if [ "$$(cargo-dylint --version 2>/dev/null | awk '{print $$2}')" != "$(CARGO_DYLINT_VERSION)" ]; then \
-		$(CARGO) install --locked --version $(CARGO_DYLINT_VERSION) --root "$$DYLINT_TOOLS_DIR" cargo-dylint; \
-	fi; \
-	if ! $(CARGO) install --list 2>/dev/null | grep -q "^dylint-link v$(DYLINT_LINK_VERSION):"; then \
-		$(CARGO) install --locked --version $(DYLINT_LINK_VERSION) --root "$$DYLINT_TOOLS_DIR" dylint-link; \
-	fi; \
+	scripts/install-dylint-tools.sh "$$DYLINT_TOOLS_DIR" "$(CARGO_DYLINT_VERSION)" "$(DYLINT_LINK_VERSION)" "$(CARGO)"; \
 	if [ -d "$$DYLINT_TOOLS_DIR/bin" ]; then export PATH="$$DYLINT_TOOLS_DIR/bin:$$PATH"; fi; \
 	TARGET_DIR="$$TMP_DIR/target"; \
 	git clone "$(WHITAKER_REPO)" "$$TMP_DIR/whitaker-src"; \
-	cd "$$TMP_DIR/whitaker-src" && { \
+	cd "$$TMP_DIR/whitaker-src" || exit 1; \
+	{ \
 		CLONE_HEAD=$$(git rev-parse HEAD); \
 		TARGET_REV=$${GIT_TAG:-$${WHITAKER_REV:-$$CLONE_HEAD}}; \
 		git checkout "$$TARGET_REV"; \

--- a/Makefile
+++ b/Makefile
@@ -247,12 +247,14 @@ publish-check: ## Build, test, and validate packages before publishing
 	RUSTFLAGS="-Z force-unstable-if-unmarked $(RUST_FLAGS)" $(CARGO) +$$TOOLCHAIN nextest run --profile ci $(TEST_CARGO_FLAGS) $(BUILD_JOBS); \
 	TMP_DIR=$$(mktemp -d); \
 	trap 'rm -rf "$$TMP_DIR"' 0 INT TERM HUP; \
-	if ! command -v cargo-dylint >/dev/null 2>&1; then \
-		$(CARGO) install --locked --version $(CARGO_DYLINT_VERSION) cargo-dylint; \
+	DYLINT_TOOLS_DIR="$$TMP_DIR/dylint-tools"; \
+	if [ "$$(cargo-dylint --version 2>/dev/null | awk '{print $$2}')" != "$(CARGO_DYLINT_VERSION)" ]; then \
+		$(CARGO) install --locked --version $(CARGO_DYLINT_VERSION) --root "$$DYLINT_TOOLS_DIR" cargo-dylint; \
 	fi; \
-	if ! command -v dylint-link >/dev/null 2>&1; then \
-		$(CARGO) install --locked --version $(DYLINT_LINK_VERSION) dylint-link; \
+	if ! $(CARGO) install --list 2>/dev/null | grep -q "^dylint-link v$(DYLINT_LINK_VERSION):"; then \
+		$(CARGO) install --locked --version $(DYLINT_LINK_VERSION) --root "$$DYLINT_TOOLS_DIR" dylint-link; \
 	fi; \
+	if [ -d "$$DYLINT_TOOLS_DIR/bin" ]; then export PATH="$$DYLINT_TOOLS_DIR/bin:$$PATH"; fi; \
 	TARGET_DIR="$$TMP_DIR/target"; \
 	git clone "$(WHITAKER_REPO)" "$$TMP_DIR/whitaker-src"; \
 	cd "$$TMP_DIR/whitaker-src" && { \

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ WORKFLOW_TEST_VENV ?= .venv
 LINT_CRATES ?= bumpy_road_function conditional_max_n_branches function_attrs_follow_docs module_max_lines module_must_have_inner_docs no_expect_outside_tests test_must_not_have_example no_std_fs_operations no_unwrap_or_else_panic whitaker_suite
 CARGO_DYLINT_VERSION ?= 6.0.1
 DYLINT_LINK_VERSION ?= 6.0.1
+# Host-tool installs run under this toolchain: the dylint 6.0.1 lockfile
+# needs a newer rustc than the repository's pinned nightly provides.
+DYLINT_TOOLS_TOOLCHAIN ?= stable
 WHITAKER_SCRIPT ?= $(HOME)/.local/bin/whitaker
 
 build: target/debug/$(APP) ## Build debug binary
@@ -249,7 +252,7 @@ publish-check: ## Build, test, and validate packages before publishing
 	TMP_DIR=$$(mktemp -d); \
 	trap 'rm -rf "$$TMP_DIR"' 0 INT TERM HUP; \
 	DYLINT_TOOLS_DIR="$$TMP_DIR/dylint-tools"; \
-	scripts/install-dylint-tools.sh "$$DYLINT_TOOLS_DIR" "$(CARGO_DYLINT_VERSION)" "$(DYLINT_LINK_VERSION)" "$(CARGO)"; \
+	scripts/install-dylint-tools.sh "$$DYLINT_TOOLS_DIR" "$(CARGO_DYLINT_VERSION)" "$(DYLINT_LINK_VERSION)" "$(CARGO)" "$(DYLINT_TOOLS_TOOLCHAIN)"; \
 	if [ -d "$$DYLINT_TOOLS_DIR/bin" ]; then export PATH="$$DYLINT_TOOLS_DIR/bin:$$PATH"; fi; \
 	TARGET_DIR="$$TMP_DIR/target"; \
 	git clone "$(WHITAKER_REPO)" "$$TMP_DIR/whitaker-src"; \

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ PUBLISH_PACKAGES ?=
 UV ?= uv
 WORKFLOW_TEST_VENV ?= .venv
 LINT_CRATES ?= bumpy_road_function conditional_max_n_branches function_attrs_follow_docs module_max_lines module_must_have_inner_docs no_expect_outside_tests test_must_not_have_example no_std_fs_operations no_unwrap_or_else_panic whitaker_suite
-CARGO_DYLINT_VERSION ?= 5.0.0
-DYLINT_LINK_VERSION ?= 5.0.0
+CARGO_DYLINT_VERSION ?= 6.0.1
+DYLINT_LINK_VERSION ?= 6.0.1
 WHITAKER_SCRIPT ?= $(HOME)/.local/bin/whitaker
 
 build: target/debug/$(APP) ## Build debug binary

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -15,6 +15,9 @@ Whitaker itself. For using Whitaker lints in a project, see the
   cargo install cargo-dylint dylint-link
   ```
 
+  (`make publish-check` provisions these automatically at the pinned
+  versions; see [Pre-publish validation](publishing.md#pre-publish-validation).)
+
 CI also installs or provides job-specific tools such as `cargo-nextest`, `bun`,
 `uv`, Mermaid CLI, and Nixie before running the targets that need them. Local
 runs of those targets require the same tools on `PATH`.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -757,7 +757,7 @@ Example entry:
 [[dependency_binaries]]
 package = "cargo-dylint"
 binary = "cargo-dylint"
-version = "4.1.0"
+version = "6.0.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/trailofbits/dylint"
 ```

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -32,7 +32,22 @@ make publish-check PUBLISH_PACKAGES="whitaker-common whitaker-installer"
 
 This target builds the workspace, runs tests with the pinned toolchain, and
 packages the crates named in `PUBLISH_PACKAGES` for inspection, which here
-means both `whitaker-common` and `whitaker-installer`.
+means both `whitaker-common` and `whitaker-installer`. The target runs under
+`set -eu`, so any failed step aborts the gate immediately rather than
+continuing with a partially built or stale toolchain.
+
+Before building the lint libraries, `publish-check` provisions the pinned
+Dylint tools by delegating to `scripts/install-dylint-tools.sh`. The script
+compares any installed `cargo-dylint` against `CARGO_DYLINT_VERSION`, and
+checks `dylint-link` via `cargo install --list` (`dylint-link` is a linker
+shim whose `--version` is forwarded to `cc`, so it cannot be probed directly).
+Tools that are missing or mismatched are installed into an isolated, per-run
+temporary root; the Makefile prepends that root's `bin/` directory to `PATH`
+only when it exists, so the pinned versions take precedence without touching
+any system-wide install. If either install fails, the script exits non-zero
+and the gate fails fast rather than proceeding with stale or absent tools.
+This behaviour is covered by
+`tests/workflows/test_install_dylint_tools.py`.
 
 To validate the installer archive path used by the release workflow on the
 current host platform, run:

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -37,7 +37,7 @@ means both `whitaker-common` and `whitaker-installer`. The target runs under
 continuing with a partially built or stale toolchain.
 
 Before building the lint libraries, `publish-check` provisions the pinned
-Dylint tools by delegating to `scripts/install-dylint-tools.sh`. The script
+Dylint tools by delegating to `scripts/install-dylint-tools.sh`. Host-tool installs run under the toolchain named by `DYLINT_TOOLS_TOOLCHAIN` (default `stable`), because the dylint 6.0.1 lockfile requires a newer rustc than the repository's pinned nightly provides. The script
 compares any installed `cargo-dylint` against `CARGO_DYLINT_VERSION`, and
 checks `dylint-link` via `cargo install --list` (`dylint-link` is a linker
 shim whose `--version` is forwarded to `cc`, so it cannot be probed directly).

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -37,7 +37,10 @@ means both `whitaker-common` and `whitaker-installer`. The target runs under
 continuing with a partially built or stale toolchain.
 
 Before building the lint libraries, `publish-check` provisions the pinned
-Dylint tools by delegating to `scripts/install-dylint-tools.sh`. Host-tool installs run under the toolchain named by `DYLINT_TOOLS_TOOLCHAIN` (default `stable`), because the dylint 6.0.1 lockfile requires a newer rustc than the repository's pinned nightly provides. The script
+Dylint tools by delegating to `scripts/install-dylint-tools.sh`. Host-tool
+installs run under the toolchain named by `DYLINT_TOOLS_TOOLCHAIN` (default
+`stable`), because the dylint 6.0.1 lockfile requires a newer rustc than the
+repository's pinned nightly provides. The script
 compares any installed `cargo-dylint` against `CARGO_DYLINT_VERSION`, and
 checks `dylint-link` via `cargo install --list` (`dylint-link` is a linker
 shim whose `--version` is forwarded to `cc`, so it cannot be probed directly).

--- a/installer/dependency-binaries.toml
+++ b/installer/dependency-binaries.toml
@@ -1,13 +1,13 @@
 [[dependency_binaries]]
 package = "cargo-dylint"
 binary = "cargo-dylint"
-version = "4.1.0"
+version = "6.0.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/trailofbits/dylint"
 
 [[dependency_binaries]]
 package = "dylint-link"
 binary = "dylint-link"
-version = "4.1.0"
+version = "6.0.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/trailofbits/dylint"

--- a/installer/src/dependency_binaries/install/tests.rs
+++ b/installer/src/dependency_binaries/install/tests.rs
@@ -100,7 +100,7 @@ fn archive_filename_uses_dependency_version() {
         .expect("dependency should exist");
     assert_eq!(
         archive_filename(dependency, &target),
-        "cargo-dylint-x86_64-unknown-linux-gnu-v4.1.0.tgz"
+        "cargo-dylint-x86_64-unknown-linux-gnu-v6.0.1.tgz"
     );
 }
 

--- a/installer/src/dependency_binaries/manifest.rs
+++ b/installer/src/dependency_binaries/manifest.rs
@@ -159,7 +159,7 @@ pub fn manifest_contents() -> &'static str {
 ///     [[dependency_binaries]]
 ///     package = "cargo-dylint"
 ///     binary = "cargo-dylint"
-///     version = "4.1.0"
+///     version = "6.0.1"
 ///     license = "MIT OR Apache-2.0"
 ///     repository = "https://github.com/trailofbits/dylint"
 /// "#;
@@ -178,7 +178,7 @@ pub fn manifest_contents() -> &'static str {
 ///     [[dependency_binaries]]
 ///     package = "cargo-dylint"
 ///     binary = "cargo-dylint"
-///     version = "4.1.0"
+///     version = "6.0.1"
 ///     license = "MIT OR Apache-2.0"
 ///     repository = "https://github.com/trailofbits/dylint"
 ///
@@ -302,7 +302,7 @@ mod tests {
             [[dependency_binaries]]
             package = "cargo-dylint"
             binary = "cargo-dylint"
-            version = "4.1.0"
+            version = "6.0.1"
             license = "MIT OR Apache-2.0"
         "#
     }
@@ -313,7 +313,7 @@ mod tests {
             [[dependency_binaries]]
             package = "cargo-dylint"
             binary = "cargo-dylint"
-            version = "4.1.0"
+            version = "6.0.1"
             license = "MIT OR Apache-2.0"
             repository = "https://github.com/trailofbits/dylint"
 
@@ -366,6 +366,6 @@ mod tests {
             .expect("embedded manifest should stay parseable")
             .expect("tool should exist");
         assert_eq!(tool.binary(), "cargo-dylint");
-        assert_eq!(tool.version(), "4.1.0");
+        assert_eq!(tool.version(), "6.0.1");
     }
 }

--- a/installer/src/dependency_binaries/manifest.rs
+++ b/installer/src/dependency_binaries/manifest.rs
@@ -360,12 +360,18 @@ mod tests {
         }
     }
 
-    #[test]
-    fn find_dependency_binary_returns_matching_package() {
-        let tool = find_dependency_binary("cargo-dylint")
+    #[rstest]
+    #[case::cargo_dylint("cargo-dylint", "cargo-dylint", "6.0.1")]
+    #[case::dylint_link("dylint-link", "dylint-link", "6.0.1")]
+    fn find_dependency_binary_returns_matching_package(
+        #[case] package: &str,
+        #[case] binary: &str,
+        #[case] version: &str,
+    ) {
+        let tool = find_dependency_binary(package)
             .expect("embedded manifest should stay parseable")
             .expect("tool should exist");
-        assert_eq!(tool.binary(), "cargo-dylint");
-        assert_eq!(tool.version(), "6.0.1");
+        assert_eq!(tool.binary(), binary);
+        assert_eq!(tool.version(), version);
     }
 }

--- a/installer/src/deps/tests.rs
+++ b/installer/src/deps/tests.rs
@@ -109,7 +109,7 @@ fn install_dylint_tools_falls_back_to_cargo_install_when_binstall_missing() {
         binstall_version_check_with_result(Ok(failure_output("missing binstall"))),
         ExpectedCall {
             cmd: "cargo",
-            args: vec!["install", "--locked", "--version", "4.1.0", "cargo-dylint"],
+            args: vec!["install", "--locked", "--version", "6.0.1", "cargo-dylint"],
             result: Ok(success_output()),
         },
         cargo_dylint_check_with_result(Ok(success_output())),
@@ -173,7 +173,7 @@ fn install_dylint_tools_reports_total_failure_after_all_fallbacks() {
         binstall_install("cargo-dylint", Ok(failure_output("binstall failed"))),
         ExpectedCall {
             cmd: "cargo",
-            args: vec!["install", "--locked", "--version", "4.1.0", "cargo-dylint"],
+            args: vec!["install", "--locked", "--version", "6.0.1", "cargo-dylint"],
             result: Ok(failure_output("cargo install failed")),
         },
     ]);
@@ -205,14 +205,14 @@ fn install_dylint_tools_builds_from_source_when_repository_asset_is_missing() {
     let mut repository_installer = MockDependencyBinaryInstaller::new();
     repository_installer.expect_install().returning(|_, _, _| {
         Err(DependencyBinaryInstallError::NotFound {
-            url: "https://example.test/cargo-dylint-x86_64-unknown-linux-gnu-v4.1.0.tgz".to_owned(),
+            url: "https://example.test/cargo-dylint-x86_64-unknown-linux-gnu-v6.0.1.tgz".to_owned(),
         })
     });
     let executor = StubExecutor::new(vec![
         binstall_version_check_with_result(Ok(success_output())),
         ExpectedCall {
             cmd: "cargo",
-            args: vec!["install", "--locked", "--version", "4.1.0", "cargo-dylint"],
+            args: vec!["install", "--locked", "--version", "6.0.1", "cargo-dylint"],
             result: Ok(success_output()),
         },
         cargo_dylint_check_with_result(Ok(success_output())),
@@ -244,7 +244,7 @@ fn install_dylint_tools_skips_dylint_link_when_cargo_dylint_source_build_install
         .once()
         .returning(|_, _, _| {
             Err(DependencyBinaryInstallError::NotFound {
-                url: "https://example.test/cargo-dylint-x86_64-unknown-linux-gnu-v4.1.0.tgz"
+                url: "https://example.test/cargo-dylint-x86_64-unknown-linux-gnu-v6.0.1.tgz"
                     .to_owned(),
             })
         });
@@ -252,7 +252,7 @@ fn install_dylint_tools_skips_dylint_link_when_cargo_dylint_source_build_install
         binstall_version_check_with_result(Ok(success_output())),
         ExpectedCall {
             cmd: "cargo",
-            args: vec!["install", "--locked", "--version", "4.1.0", "cargo-dylint"],
+            args: vec!["install", "--locked", "--version", "6.0.1", "cargo-dylint"],
             result: Ok(success_output()),
         },
         cargo_dylint_check_with_result(Ok(success_output())),

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -155,7 +155,7 @@ fn ensure_dylint_tools_installs_missing_tools(
             },
             ExpectedCall {
                 cmd: "cargo",
-                args: vec!["install", "--locked", "--version", "4.1.0", "cargo-dylint"],
+                args: vec!["install", "--locked", "--version", "6.0.1", "cargo-dylint"],
                 result: Ok(success_output()),
             },
             ExpectedCall {
@@ -207,7 +207,7 @@ fn ensure_dylint_tools_propagates_install_failures(test_base_dirs: TestBaseDirs)
             },
             ExpectedCall {
                 cmd: "cargo",
-                args: vec!["install", "--locked", "--version", "4.1.0", "cargo-dylint"],
+                args: vec!["install", "--locked", "--version", "6.0.1", "cargo-dylint"],
                 result: Ok(failure_output("cargo install failed")),
             },
         ]);

--- a/scripts/install-dylint-tools.sh
+++ b/scripts/install-dylint-tools.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+# install-dylint-tools.sh — Ensure the pinned cargo-dylint and dylint-link
+# versions are available, installing into an isolated root when the
+# system-wide binaries are missing or the wrong version.
+#
+# Usage:
+#   scripts/install-dylint-tools.sh TOOLS_ROOT CARGO_DYLINT_VERSION DYLINT_LINK_VERSION [CARGO]
+#
+# TOOLS_ROOT is used as the cargo install --root; binaries land in
+# TOOLS_ROOT/bin, which the caller should prepend to PATH when it exists.
+# The root is only created when an install is needed, so callers can use
+# its absence to mean "the system tools already match".
+#
+# cargo-dylint is probed via its --version output. dylint-link cannot be
+# probed that way: it is a linker shim whose --version is forwarded to
+# cc, so the installed version is read from `cargo install --list`.
+#
+# Exits non-zero if any required install fails, so callers never proceed
+# with stale tools.
+set -eu
+
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+    echo "usage: $0 TOOLS_ROOT CARGO_DYLINT_VERSION DYLINT_LINK_VERSION [CARGO]" >&2
+    exit 2
+fi
+
+tools_root=$1
+cargo_dylint_version=$2
+dylint_link_version=$3
+cargo=${4:-cargo}
+
+installed_cargo_dylint=$(cargo-dylint --version 2>/dev/null | awk '{print $2}' || true)
+if [ "$installed_cargo_dylint" != "$cargo_dylint_version" ]; then
+    "$cargo" install --locked --version "$cargo_dylint_version" \
+        --root "$tools_root" cargo-dylint
+fi
+
+if ! "$cargo" install --list 2>/dev/null |
+    grep -q "^dylint-link v$dylint_link_version:"; then
+    "$cargo" install --locked --version "$dylint_link_version" \
+        --root "$tools_root" dylint-link
+fi

--- a/scripts/install-dylint-tools.sh
+++ b/scripts/install-dylint-tools.sh
@@ -4,23 +4,31 @@
 # system-wide binaries are missing or the wrong version.
 #
 # Usage:
-#   scripts/install-dylint-tools.sh TOOLS_ROOT CARGO_DYLINT_VERSION DYLINT_LINK_VERSION [CARGO]
+#   scripts/install-dylint-tools.sh TOOLS_ROOT CARGO_DYLINT_VERSION DYLINT_LINK_VERSION [CARGO] [TOOLCHAIN]
+#
+# When TOOLCHAIN is given, installs run under `cargo +TOOLCHAIN`. The
+# host tools are toolchain-independent, but their locked dependencies
+# can require a newer rustc than a repository's pinned nightly (e.g.
+# cargo-dylint 6.0.1 locks cargo-util 0.2.28, which needs rustc 1.93),
+# so callers pass a modern toolchain such as `stable`.
 #
 # TOOLS_ROOT is used as the cargo install --root; binaries land in
 # TOOLS_ROOT/bin, which the caller should prepend to PATH when it exists.
 # The root is only created when an install is needed, so callers can use
 # its absence to mean "the system tools already match".
 #
-# cargo-dylint is probed via its --version output. dylint-link cannot be
-# probed that way: it is a linker shim whose --version is forwarded to
-# cc, so the installed version is read from `cargo install --list`.
+# cargo-dylint is probed via `cargo-dylint dylint --version` (the
+# subcommand form: since 6.x the binary rejects a bare --version).
+# dylint-link cannot be probed either way: it is a linker shim whose
+# --version is forwarded to cc, so the installed version is read from
+# `cargo install --list`.
 #
 # Exits non-zero if any required install fails, so callers never proceed
 # with stale tools.
 set -eu
 
-if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
-    echo "usage: $0 TOOLS_ROOT CARGO_DYLINT_VERSION DYLINT_LINK_VERSION [CARGO]" >&2
+if [ "$#" -lt 3 ] || [ "$#" -gt 5 ]; then
+    echo "usage: $0 TOOLS_ROOT CARGO_DYLINT_VERSION DYLINT_LINK_VERSION [CARGO] [TOOLCHAIN]" >&2
     exit 2
 fi
 
@@ -28,15 +36,24 @@ tools_root=$1
 cargo_dylint_version=$2
 dylint_link_version=$3
 cargo=${4:-cargo}
+toolchain=${5:-}
 
-installed_cargo_dylint=$(cargo-dylint --version 2>/dev/null | awk '{print $2}' || true)
+run_cargo() {
+    if [ -n "$toolchain" ]; then
+        "$cargo" "+$toolchain" "$@"
+    else
+        "$cargo" "$@"
+    fi
+}
+
+installed_cargo_dylint=$(cargo-dylint dylint --version 2>/dev/null | awk '{print $2}' || true)
 if [ "$installed_cargo_dylint" != "$cargo_dylint_version" ]; then
-    "$cargo" install --locked --version "$cargo_dylint_version" \
+    run_cargo install --locked --version "$cargo_dylint_version" \
         --root "$tools_root" cargo-dylint
 fi
 
 if ! "$cargo" install --list 2>/dev/null |
     grep -q "^dylint-link v$dylint_link_version:"; then
-    "$cargo" install --locked --version "$dylint_link_version" \
+    run_cargo install --locked --version "$dylint_link_version" \
         --root "$tools_root" dylint-link
 fi

--- a/tests/workflows/test_install_dylint_tools.py
+++ b/tests/workflows/test_install_dylint_tools.py
@@ -101,6 +101,22 @@ esac""",
     )
 
 
+def _write_matching_tool_stubs(
+    tmp_path: Path,
+    *,
+    installed_dylint_link: str,
+) -> tuple[Path, Path]:
+    """Set up stubs with a matching cargo-dylint and return key paths.
+
+    Returns the stub directory and the (uncreated) tools root.
+    """
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_cargo_dylint_stub(stub_dir, f"cargo-dylint {CARGO_DYLINT_VERSION}")
+    _write_cargo_stub(stub_dir, installed_dylint_link=installed_dylint_link)
+    return stub_dir, tmp_path / "tools"
+
+
 def _run_script(
     stub_dir: Path,
     tools_root: Path,
@@ -135,11 +151,9 @@ def _install_log(stub_dir: Path) -> str:
 
 def test_matching_tools_install_nothing(tmp_path: Path) -> None:
     """Matching system versions must not trigger any install."""
-    stub_dir = tmp_path / "bin"
-    stub_dir.mkdir()
-    _write_cargo_dylint_stub(stub_dir, f"cargo-dylint {CARGO_DYLINT_VERSION}")
-    _write_cargo_stub(stub_dir, installed_dylint_link=DYLINT_LINK_VERSION)
-    tools_root = tmp_path / "tools"
+    stub_dir, tools_root = _write_matching_tool_stubs(
+        tmp_path, installed_dylint_link=DYLINT_LINK_VERSION
+    )
 
     result = _run_script(stub_dir, tools_root)
 
@@ -180,11 +194,9 @@ def test_stale_or_missing_cargo_dylint_installs_pin(
 
 def test_missing_dylint_link_installs_pin(tmp_path: Path) -> None:
     """An unpinned dylint-link in the install list triggers an install."""
-    stub_dir = tmp_path / "bin"
-    stub_dir.mkdir()
-    _write_cargo_dylint_stub(stub_dir, f"cargo-dylint {CARGO_DYLINT_VERSION}")
-    _write_cargo_stub(stub_dir, installed_dylint_link="5.0.0")
-    tools_root = tmp_path / "tools"
+    stub_dir, tools_root = _write_matching_tool_stubs(
+        tmp_path, installed_dylint_link="5.0.0"
+    )
 
     result = _run_script(stub_dir, tools_root)
 

--- a/tests/workflows/test_install_dylint_tools.py
+++ b/tests/workflows/test_install_dylint_tools.py
@@ -30,6 +30,7 @@ SCRIPT = REPO_ROOT / "scripts" / "install-dylint-tools.sh"
 
 CARGO_DYLINT_VERSION = "6.0.1"
 DYLINT_LINK_VERSION = "6.0.1"
+TOOLCHAIN = "stable"
 
 
 def _write_stub(directory: Path, name: str, body: str) -> Path:
@@ -38,6 +39,24 @@ def _write_stub(directory: Path, name: str, body: str) -> Path:
     stub.write_text(f"#!/bin/sh\n{body}\n")
     stub.chmod(0o755)
     return stub
+
+
+def _write_cargo_dylint_stub(directory: Path, version_line: str) -> Path:
+    """Write a fake ``cargo-dylint`` honouring only the 6.x probe form.
+
+    Since 6.x the binary rejects a bare ``--version``; the stub mirrors
+    that so the script's probe is exercised against the real contract.
+    """
+    return _write_stub(
+        directory,
+        "cargo-dylint",
+        f"""if [ "$1" = "dylint" ] && [ "$2" = "--version" ]; then
+    echo "{version_line}"
+    exit 0
+fi
+echo "error: unexpected argument" >&2
+exit 2""",
+    )
 
 
 def _write_cargo_stub(
@@ -61,6 +80,12 @@ def _write_cargo_stub(
         directory,
         "cargo",
         f"""case "$1" in
++*)
+    echo "$1" >> "{directory}/cargo-toolchain.log"
+    shift
+    ;;
+esac
+case "$1" in
 install)
     if [ "$2" = "--list" ]; then
         {list_line}
@@ -76,18 +101,26 @@ esac""",
     )
 
 
-def _run_script(stub_dir: Path, tools_root: Path) -> subprocess.CompletedProcess[str]:
+def _run_script(
+    stub_dir: Path,
+    tools_root: Path,
+    *,
+    toolchain: str | None = None,
+) -> subprocess.CompletedProcess[str]:
     """Run the script with PATH restricted to the stub directory."""
     env = os.environ.copy()
     env["PATH"] = f"{stub_dir}:/usr/bin:/bin"
+    argv = [
+        str(SCRIPT),
+        str(tools_root),
+        CARGO_DYLINT_VERSION,
+        DYLINT_LINK_VERSION,
+        str(stub_dir / "cargo"),
+    ]
+    if toolchain is not None:
+        argv.append(toolchain)
     return subprocess.run(
-        [
-            str(SCRIPT),
-            str(tools_root),
-            CARGO_DYLINT_VERSION,
-            DYLINT_LINK_VERSION,
-            str(stub_dir / "cargo"),
-        ],
+        argv,
         capture_output=True,
         text=True,
         env=env,
@@ -104,11 +137,7 @@ def test_matching_tools_install_nothing(tmp_path: Path) -> None:
     """Matching system versions must not trigger any install."""
     stub_dir = tmp_path / "bin"
     stub_dir.mkdir()
-    _write_stub(
-        stub_dir,
-        "cargo-dylint",
-        f'echo "cargo-dylint {CARGO_DYLINT_VERSION}"',
-    )
+    _write_cargo_dylint_stub(stub_dir, f"cargo-dylint {CARGO_DYLINT_VERSION}")
     _write_cargo_stub(stub_dir, installed_dylint_link=DYLINT_LINK_VERSION)
     tools_root = tmp_path / "tools"
 
@@ -136,7 +165,7 @@ def test_stale_or_missing_cargo_dylint_installs_pin(
     stub_dir = tmp_path / "bin"
     stub_dir.mkdir()
     if dylint_version_output:
-        _write_stub(stub_dir, "cargo-dylint", f'echo "{dylint_version_output}"')
+        _write_cargo_dylint_stub(stub_dir, dylint_version_output)
     _write_cargo_stub(stub_dir, installed_dylint_link=DYLINT_LINK_VERSION)
     tools_root = tmp_path / "tools"
 
@@ -153,11 +182,7 @@ def test_missing_dylint_link_installs_pin(tmp_path: Path) -> None:
     """An unpinned dylint-link in the install list triggers an install."""
     stub_dir = tmp_path / "bin"
     stub_dir.mkdir()
-    _write_stub(
-        stub_dir,
-        "cargo-dylint",
-        f'echo "cargo-dylint {CARGO_DYLINT_VERSION}"',
-    )
+    _write_cargo_dylint_stub(stub_dir, f"cargo-dylint {CARGO_DYLINT_VERSION}")
     _write_cargo_stub(stub_dir, installed_dylint_link="5.0.0")
     tools_root = tmp_path / "tools"
 
@@ -173,7 +198,7 @@ def test_failed_install_aborts_nonzero(tmp_path: Path) -> None:
     """A failing install must abort with a non-zero exit status."""
     stub_dir = tmp_path / "bin"
     stub_dir.mkdir()
-    _write_stub(stub_dir, "cargo-dylint", 'echo "cargo-dylint 5.0.0"')
+    _write_cargo_dylint_stub(stub_dir, "cargo-dylint 5.0.0")
     _write_cargo_stub(
         stub_dir,
         installed_dylint_link=DYLINT_LINK_VERSION,
@@ -195,3 +220,32 @@ def test_rejects_wrong_argument_count() -> None:
     )
     assert result.returncode == 2
     assert "usage:" in result.stderr
+
+
+def test_toolchain_argument_prefixes_installs(tmp_path: Path) -> None:
+    """A toolchain argument routes installs through ``cargo +toolchain``."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_cargo_dylint_stub(stub_dir, "cargo-dylint 5.0.0")
+    _write_cargo_stub(stub_dir, installed_dylint_link=DYLINT_LINK_VERSION)
+    tools_root = tmp_path / "tools"
+
+    result = _run_script(stub_dir, tools_root, toolchain=TOOLCHAIN)
+
+    assert result.returncode == 0, result.stderr
+    toolchain_log = stub_dir / "cargo-toolchain.log"
+    assert toolchain_log.read_text().strip() == f"+{TOOLCHAIN}"
+    assert f"--version {CARGO_DYLINT_VERSION}" in _install_log(stub_dir)
+
+
+def test_version_probe_ignores_toolchain(tmp_path: Path) -> None:
+    """The ``install --list`` probe stays on the default cargo."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_cargo_dylint_stub(stub_dir, f"cargo-dylint {CARGO_DYLINT_VERSION}")
+    _write_cargo_stub(stub_dir, installed_dylint_link=DYLINT_LINK_VERSION)
+
+    result = _run_script(stub_dir, tmp_path / "tools", toolchain=TOOLCHAIN)
+
+    assert result.returncode == 0, result.stderr
+    assert not (stub_dir / "cargo-toolchain.log").exists()

--- a/tests/workflows/test_install_dylint_tools.py
+++ b/tests/workflows/test_install_dylint_tools.py
@@ -1,0 +1,197 @@
+"""Behavioural tests for the install-dylint-tools script.
+
+This module exercises `scripts/install-dylint-tools.sh` under stubbed
+`cargo` and `cargo-dylint` binaries, covering the pinned-tool
+provisioning contract used by the `publish-check` Makefile target:
+
+- matching system tools produce no installs and no tools root
+- a stale or missing cargo-dylint triggers a pinned install into the root
+- a missing dylint-link pin in ``cargo install --list`` triggers a
+  pinned install into the root
+- a failing install aborts the script with a non-zero exit status, so
+  callers can never proceed with stale tools on PATH
+
+Examples
+--------
+Run all tests:
+    python3 -m pytest tests/workflows/test_install_dylint_tools.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "install-dylint-tools.sh"
+
+CARGO_DYLINT_VERSION = "6.0.1"
+DYLINT_LINK_VERSION = "6.0.1"
+
+
+def _write_stub(directory: Path, name: str, body: str) -> Path:
+    """Write an executable shell stub and return its path."""
+    stub = directory / name
+    stub.write_text(f"#!/bin/sh\n{body}\n")
+    stub.chmod(0o755)
+    return stub
+
+
+def _write_cargo_stub(
+    directory: Path,
+    *,
+    installed_dylint_link: str | None,
+    install_exit: int = 0,
+) -> Path:
+    """Write a fake ``cargo`` recording install invocations to a log.
+
+    ``install --list`` reports ``installed_dylint_link`` (or nothing);
+    ``install`` appends its arguments to ``cargo-install.log`` and exits
+    with ``install_exit``.
+    """
+    list_line = (
+        f'echo "dylint-link v{installed_dylint_link}:"'
+        if installed_dylint_link
+        else "true"
+    )
+    return _write_stub(
+        directory,
+        "cargo",
+        f"""case "$1" in
+install)
+    if [ "$2" = "--list" ]; then
+        {list_line}
+        exit 0
+    fi
+    echo "$@" >> "{directory}/cargo-install.log"
+    exit {install_exit}
+    ;;
+*)
+    exit 1
+    ;;
+esac""",
+    )
+
+
+def _run_script(stub_dir: Path, tools_root: Path) -> subprocess.CompletedProcess[str]:
+    """Run the script with PATH restricted to the stub directory."""
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_dir}:/usr/bin:/bin"
+    return subprocess.run(
+        [
+            str(SCRIPT),
+            str(tools_root),
+            CARGO_DYLINT_VERSION,
+            DYLINT_LINK_VERSION,
+            str(stub_dir / "cargo"),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def _install_log(stub_dir: Path) -> str:
+    log = stub_dir / "cargo-install.log"
+    return log.read_text() if log.exists() else ""
+
+
+def test_matching_tools_install_nothing(tmp_path: Path) -> None:
+    """Matching system versions must not trigger any install."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_stub(
+        stub_dir,
+        "cargo-dylint",
+        f'echo "cargo-dylint {CARGO_DYLINT_VERSION}"',
+    )
+    _write_cargo_stub(stub_dir, installed_dylint_link=DYLINT_LINK_VERSION)
+    tools_root = tmp_path / "tools"
+
+    result = _run_script(stub_dir, tools_root)
+
+    assert result.returncode == 0, result.stderr
+    assert _install_log(stub_dir) == ""
+    assert not tools_root.exists()
+
+
+@pytest.mark.parametrize(
+    ("dylint_version_output", "expected_package"),
+    [
+        ("cargo-dylint 5.0.0", "cargo-dylint"),
+        ("", "cargo-dylint"),
+    ],
+    ids=["stale", "missing"],
+)
+def test_stale_or_missing_cargo_dylint_installs_pin(
+    tmp_path: Path,
+    dylint_version_output: str,
+    expected_package: str,
+) -> None:
+    """A wrong or absent cargo-dylint installs the pin into the root."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    if dylint_version_output:
+        _write_stub(stub_dir, "cargo-dylint", f'echo "{dylint_version_output}"')
+    _write_cargo_stub(stub_dir, installed_dylint_link=DYLINT_LINK_VERSION)
+    tools_root = tmp_path / "tools"
+
+    result = _run_script(stub_dir, tools_root)
+
+    assert result.returncode == 0, result.stderr
+    log = _install_log(stub_dir)
+    assert f"--version {CARGO_DYLINT_VERSION}" in log
+    assert f"--root {tools_root}" in log
+    assert log.rstrip().endswith(expected_package)
+
+
+def test_missing_dylint_link_installs_pin(tmp_path: Path) -> None:
+    """An unpinned dylint-link in the install list triggers an install."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_stub(
+        stub_dir,
+        "cargo-dylint",
+        f'echo "cargo-dylint {CARGO_DYLINT_VERSION}"',
+    )
+    _write_cargo_stub(stub_dir, installed_dylint_link="5.0.0")
+    tools_root = tmp_path / "tools"
+
+    result = _run_script(stub_dir, tools_root)
+
+    assert result.returncode == 0, result.stderr
+    log = _install_log(stub_dir)
+    assert f"--version {DYLINT_LINK_VERSION}" in log
+    assert log.rstrip().endswith("dylint-link")
+
+
+def test_failed_install_aborts_nonzero(tmp_path: Path) -> None:
+    """A failing install must abort with a non-zero exit status."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    _write_stub(stub_dir, "cargo-dylint", 'echo "cargo-dylint 5.0.0"')
+    _write_cargo_stub(
+        stub_dir,
+        installed_dylint_link=DYLINT_LINK_VERSION,
+        install_exit=1,
+    )
+
+    result = _run_script(stub_dir, tmp_path / "tools")
+
+    assert result.returncode != 0
+
+
+def test_rejects_wrong_argument_count() -> None:
+    """The script demands its documented argument list."""
+    result = subprocess.run(
+        [str(SCRIPT), "only-one-arg"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "usage:" in result.stderr

--- a/tests/workflows/test_publish_check_provisioning.py
+++ b/tests/workflows/test_publish_check_provisioning.py
@@ -1,0 +1,193 @@
+"""Integration tests for the publish-check provisioning handoff.
+
+These tests run the real ``Makefile::publish-check`` recipe with every
+external command stubbed (``cargo``, ``cargo-dylint``, ``cargo-nextest``,
+``rustup``, and ``git``), proving the Makefile integration itself rather
+than `scripts/install-dylint-tools.sh` in isolation:
+
+- the recipe invokes the provisioning script;
+- a stale system ``cargo-dylint`` triggers installation into the
+  isolated root, and the later Dylint-facing command resolves
+  ``cargo-dylint`` from the isolated ``bin/`` ahead of the stale stub;
+- a failed install aborts the target, and no subsequent clone, build,
+  Dylint, or packaging command executes.
+
+No network access, Rust builds, or real tool installs occur; stubs
+record their invocations to a log inspected by the assertions. The
+direct tests in ``test_install_dylint_tools.py`` remain the unit-level
+coverage for version detection and Cargo invocation construction.
+
+Examples
+--------
+Run all tests:
+    python3 -m pytest tests/workflows/test_publish_check_provisioning.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+CARGO_DYLINT_VERSION = "6.0.1"
+DYLINT_LINK_VERSION = "6.0.1"
+
+
+def _write_stub(directory: Path, name: str, body: str) -> Path:
+    """Write an executable shell stub and return its path."""
+    stub = directory / name
+    stub.write_text(f"#!/bin/sh\n{body}\n")
+    stub.chmod(0o755)
+    return stub
+
+
+def _write_harness(stub_dir: Path, *, install_exit: int = 0) -> Path:
+    """Write the full stub command set for a publish-check run.
+
+    Every stub appends ``<command> <args>`` to ``invocations.log``. The
+    ``cargo`` stub additionally:
+
+    - creates the expected lint library on ``build --release`` so the
+      recipe's real ``cp`` succeeds;
+    - creates ``<root>/bin/cargo-dylint`` on ``install`` (when
+      ``install_exit`` is zero) so the recipe's ``PATH`` prepend fires;
+    - records ``command -v cargo-dylint`` on ``dylint`` so tests can
+      assert which binary a Dylint-facing command would resolve.
+    """
+    log = stub_dir / "invocations.log"
+    _write_stub(stub_dir, "rustup", f'echo "rustup $@" >> "{log}"')
+    _write_stub(stub_dir, "cargo-nextest", f'echo "cargo-nextest $@" >> "{log}"')
+    _write_stub(
+        stub_dir,
+        "cargo-dylint",
+        f"""echo "cargo-dylint $@" >> "{log}"
+if [ "$1" = "dylint" ] && [ "$2" = "--version" ]; then
+    echo "cargo-dylint 5.0.0"
+    exit 0
+fi
+exit 2""",
+    )
+    _write_stub(
+        stub_dir,
+        "git",
+        f"""echo "git $@" >> "{log}"
+case "$1" in
+clone) mkdir -p "$3" ;;
+rev-parse) echo 0000000000000000000000000000000000000000 ;;
+esac
+exit 0""",
+    )
+    _write_stub(
+        stub_dir,
+        "cargo",
+        f"""case "$1" in
++*) shift ;;
+esac
+echo "cargo $@" >> "{log}"
+case "$1" in
+install)
+    if [ "$2" = "--list" ]; then
+        echo "dylint-link v{DYLINT_LINK_VERSION}:"
+        exit 0
+    fi
+    if [ {install_exit} -ne 0 ]; then
+        exit {install_exit}
+    fi
+    root=""
+    prev=""
+    for arg in "$@"; do
+        if [ "$prev" = "--root" ]; then root="$arg"; fi
+        prev="$arg"
+    done
+    mkdir -p "$root/bin"
+    printf '#!/bin/sh\\nexit 0\\n' > "$root/bin/cargo-dylint"
+    chmod 755 "$root/bin/cargo-dylint"
+    exit 0
+    ;;
+build)
+    if [ -n "${{CARGO_TARGET_DIR:-}}" ]; then
+        crate=""
+        prev=""
+        for arg in "$@"; do
+            if [ "$prev" = "-p" ]; then crate="$arg"; fi
+            prev="$arg"
+        done
+        if [ -n "$crate" ]; then
+            mkdir -p "$CARGO_TARGET_DIR/release"
+            : > "$CARGO_TARGET_DIR/release/lib$crate.so"
+        fi
+    fi
+    exit 0
+    ;;
+dylint)
+    echo "dylint-resolved $(command -v cargo-dylint)" >> "{log}"
+    exit 0
+    ;;
+*)
+    exit 0
+    ;;
+esac""",
+    )
+    return log
+
+
+def _run_publish_check(stub_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Run the real publish-check target with stubs first on PATH."""
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_dir}:/usr/bin:/bin"
+    env.pop("WHITAKER", None)
+    return subprocess.run(
+        [
+            "make",
+            "publish-check",
+            f"CARGO={stub_dir}/cargo",
+            "LINT_CRATES=test_lint",
+            "PUBLISH_PACKAGES=pkg_one",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+
+def test_stale_tool_installs_and_isolated_bin_wins(tmp_path: Path) -> None:
+    """A stale cargo-dylint provisions the pin and yields PATH precedence."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    log_path = _write_harness(stub_dir)
+
+    result = _run_publish_check(stub_dir)
+
+    assert result.returncode == 0, result.stderr
+    log = log_path.read_text()
+    assert f"--version {CARGO_DYLINT_VERSION}" in log
+    assert "cargo-dylint" in log.split("dylint-resolved", 1)[1]
+    resolved = next(
+        line for line in log.splitlines() if line.startswith("dylint-resolved ")
+    ).removeprefix("dylint-resolved ")
+    assert resolved != str(stub_dir / "cargo-dylint"), (
+        "the stale system stub must not win once the isolated root exists"
+    )
+    assert resolved.endswith("/dylint-tools/bin/cargo-dylint")
+
+
+def test_failed_install_aborts_before_clone_and_packaging(tmp_path: Path) -> None:
+    """A failed install stops publish-check before any later stage runs."""
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    log_path = _write_harness(stub_dir, install_exit=1)
+
+    result = _run_publish_check(stub_dir)
+
+    assert result.returncode != 0
+    log = log_path.read_text()
+    assert "git clone" not in log
+    assert "dylint-resolved" not in log
+    assert "cargo package" not in log
+    assert "build --release" not in log, (
+        "no per-lint release build may run after a failed install"
+    )

--- a/tests/workflows/test_publish_check_provisioning.py
+++ b/tests/workflows/test_publish_check_provisioning.py
@@ -43,22 +43,13 @@ def _write_stub(directory: Path, name: str, body: str) -> Path:
     return stub
 
 
-def _write_harness(stub_dir: Path, *, install_exit: int = 0) -> Path:
-    """Write the full stub command set for a publish-check run.
+def _write_recording_stub(stub_dir: Path, log: Path, name: str) -> None:
+    """Write a stub that only records its invocation and succeeds."""
+    _write_stub(stub_dir, name, f'echo "{name} $@" >> "{log}"')
 
-    Every stub appends ``<command> <args>`` to ``invocations.log``. The
-    ``cargo`` stub additionally:
 
-    - creates the expected lint library on ``build --release`` so the
-      recipe's real ``cp`` succeeds;
-    - creates ``<root>/bin/cargo-dylint`` on ``install`` (when
-      ``install_exit`` is zero) so the recipe's ``PATH`` prepend fires;
-    - records ``command -v cargo-dylint`` on ``dylint`` so tests can
-      assert which binary a Dylint-facing command would resolve.
-    """
-    log = stub_dir / "invocations.log"
-    _write_stub(stub_dir, "rustup", f'echo "rustup $@" >> "{log}"')
-    _write_stub(stub_dir, "cargo-nextest", f'echo "cargo-nextest $@" >> "{log}"')
+def _write_stale_cargo_dylint_stub(stub_dir: Path, log: Path) -> None:
+    """Write a stale (5.0.0) cargo-dylint honouring the 6.x probe form."""
     _write_stub(
         stub_dir,
         "cargo-dylint",
@@ -69,6 +60,10 @@ if [ "$1" = "dylint" ] && [ "$2" = "--version" ]; then
 fi
 exit 2""",
     )
+
+
+def _write_git_stub(stub_dir: Path, log: Path) -> None:
+    """Write a git stub whose clone creates the destination directory."""
     _write_stub(
         stub_dir,
         "git",
@@ -79,15 +74,16 @@ rev-parse) echo 0000000000000000000000000000000000000000 ;;
 esac
 exit 0""",
     )
-    _write_stub(
-        stub_dir,
-        "cargo",
-        f"""case "$1" in
-+*) shift ;;
-esac
-echo "cargo $@" >> "{log}"
-case "$1" in
-install)
+
+
+def _cargo_install_case(install_exit: int) -> str:
+    """Return the install branch of the cargo stub.
+
+    Reports the pinned dylint-link for ``--list``; otherwise honours
+    ``install_exit`` and, on success, creates ``<root>/bin/cargo-dylint``
+    so the recipe's ``PATH`` prepend fires.
+    """
+    return f"""install)
     if [ "$2" = "--list" ]; then
         echo "dylint-link v{DYLINT_LINK_VERSION}:"
         exit 0
@@ -105,9 +101,17 @@ install)
     printf '#!/bin/sh\\nexit 0\\n' > "$root/bin/cargo-dylint"
     chmod 755 "$root/bin/cargo-dylint"
     exit 0
-    ;;
-build)
-    if [ -n "${{CARGO_TARGET_DIR:-}}" ]; then
+    ;;"""
+
+
+def _cargo_build_case() -> str:
+    """Return the build branch of the cargo stub.
+
+    Creates the expected lint library under ``CARGO_TARGET_DIR`` so the
+    recipe's real ``cp`` succeeds.
+    """
+    return """build)
+    if [ -n "${CARGO_TARGET_DIR:-}" ]; then
         crate=""
         prev=""
         for arg in "$@"; do
@@ -120,7 +124,21 @@ build)
         fi
     fi
     exit 0
-    ;;
+    ;;"""
+
+
+def _write_cargo_stub(stub_dir: Path, log: Path, *, install_exit: int) -> None:
+    """Write the cargo stub; the dylint branch records what PATH resolves."""
+    _write_stub(
+        stub_dir,
+        "cargo",
+        f"""case "$1" in
++*) shift ;;
+esac
+echo "cargo $@" >> "{log}"
+case "$1" in
+{_cargo_install_case(install_exit)}
+{_cargo_build_case()}
 dylint)
     echo "dylint-resolved $(command -v cargo-dylint)" >> "{log}"
     exit 0
@@ -130,6 +148,20 @@ dylint)
     ;;
 esac""",
     )
+
+
+def _write_harness(stub_dir: Path, *, install_exit: int = 0) -> Path:
+    """Write the full stub command set for a publish-check run.
+
+    Every stub appends ``<command> <args>`` to ``invocations.log``; each
+    stub's behaviour is documented on its writer.
+    """
+    log = stub_dir / "invocations.log"
+    _write_recording_stub(stub_dir, log, "rustup")
+    _write_recording_stub(stub_dir, log, "cargo-nextest")
+    _write_stale_cargo_dylint_stub(stub_dir, log)
+    _write_git_stub(stub_dir, log)
+    _write_cargo_stub(stub_dir, log, install_exit=install_exit)
     return log
 
 


### PR DESCRIPTION
## Summary

Bumps the Dylint dependency binaries from cargo-dylint/dylint-link 4.1.0 to
6.0.1, and the Makefile's local install pins from 5.0.0 to 6.0.1.

This is a standalone-safe prerequisite for the forthcoming toolchain
migration to nightly-2026-05-28. Dylint 6 works on the current pin
(nightly-2025-09-18) — the suite's own tests already build UI drivers with
`dylint_testing` 6.0.1 — but 4.1.0 and 5.0.0 cannot build a driver on newer
nightlies: `dylint_driver` ≤ 5.0.0 fails to compile there because
`ParseSess::env_depinfo`/`file_depinfo` were removed upstream (E0609,
verified empirically). Landing this first means the rolling release carries
6.0.1 dependency binaries before the pin flips, so consumer CI never sees a
driver that cannot build.

## Review walkthrough

- `installer/dependency-binaries.toml` — the single source of truth for the
  prebuilt dependency binaries; both entries move to 6.0.1. Changing this
  file auto-triggers the dependency-binary rebuild leg of the rolling
  release.
- `Makefile` — `CARGO_DYLINT_VERSION`/`DYLINT_LINK_VERSION` move
  5.0.0 → 6.0.1 for local `cargo install` paths.
- `installer/src/{deps/tests.rs,tests.rs}` — mock command expectations that
  assert the version sourced from the embedded manifest.
- `installer/src/dependency_binaries/{manifest.rs,install/tests.rs}` —
  assertions against the embedded manifest, plus doc examples and inline
  fixtures kept in step for consistency.

The Python workflow tests use their own fixture manifests and are
unaffected.

## Validation

- `env -u WHITAKER make check-fmt` — clean.
- `env -u WHITAKER make lint` — clean.
- `env -u WHITAKER make test` — full suite green.
- `env -u WHITAKER make markdownlint` — clean.
- cargo-dylint 6.0.1 verified end-to-end on nightly-2026-05-28: its driver
  builds and runs the rebuilt suite correctly on a toy crate, while 5.0.0
  fails with E0609 on `ParseSess` fields.
