### PR TITLE
Migrate the pinned toolchain to nightly-2026-05-28

### DIFF
--- a/common/src/decomposition_advice/community.rs
+++ b/common/src/decomposition_advice/community.rs
@@ -143,7 +143,7 @@ pub(crate) fn build_adjacency(
     }
 
     for neighbours in &mut adjacency {
-        neighbours.sort_by(|left, right| left.0.cmp(&right.0));
+        neighbours.sort_by_key(|left| left.0);
     }
 
     adjacency

--- a/common/src/i18n/selection.rs
+++ b/common/src/i18n/selection.rs
@@ -144,9 +144,7 @@ pub fn resolve_localizer(
 /// Trim whitespace and discard empty locale candidates.
 #[must_use]
 pub fn normalise_locale(input: Option<&str>) -> Option<&str> {
-    input
-        .map(str::trim)
-        .and_then(|value| if value.is_empty() { None } else { Some(value) })
+    input.map(str::trim).filter(|value| !value.is_empty())
 }
 
 #[cfg(test)]

--- a/crates/bumpy_road_function/src/driver/diagnostic.rs
+++ b/crates/bumpy_road_function/src/driver/diagnostic.rs
@@ -55,20 +55,25 @@ pub(super) fn emit_diagnostic(
     let highlighted = top_two_bumps(input.bumps);
     let bump_spans = build_bump_spans(cx, input.body_span, &input.function_lines, &highlighted);
 
-    cx.span_lint(BUMPY_ROAD_FUNCTION, input.primary_span, |lint| {
-        lint.primary_message(messages.primary().to_string());
-        lint.span_note(input.primary_span, messages.note().to_string());
+    cx.emit_span_lint(
+        BUMPY_ROAD_FUNCTION,
+        input.primary_span,
+        rustc_lint::errors::DiagDecorator(|lint| {
+            lint.primary_message(messages.primary().to_string());
+            lint.span_note(input.primary_span, messages.note().to_string());
 
-        for (ordinal, interval) in highlighted.iter().enumerate() {
-            let Some(span) = bump_spans.get(ordinal).copied().flatten() else {
-                continue;
-            };
-            let label = resolve_bump_label(localizer, (ordinal + 1) as i64, interval.len() as i64);
-            lint.span_label(span, label);
-        }
+            for (ordinal, interval) in highlighted.iter().enumerate() {
+                let Some(span) = bump_spans.get(ordinal).copied().flatten() else {
+                    continue;
+                };
+                let label =
+                    resolve_bump_label(localizer, (ordinal + 1) as i64, interval.len() as i64);
+                lint.span_label(span, label);
+            }
 
-        lint.help(messages.help().to_string());
-    });
+            lint.help(messages.help().to_string());
+        }),
+    );
 }
 
 fn build_bump_spans(

--- a/crates/conditional_max_n_branches/src/driver.rs
+++ b/crates/conditional_max_n_branches/src/driver.rs
@@ -238,11 +238,15 @@ fn emit_diagnostic(
     let note = normalise_isolation_marks(messages.note());
     let help = normalise_isolation_marks(messages.help());
 
-    cx.span_lint(CONDITIONAL_MAX_N_BRANCHES, metadata.span, move |lint| {
-        lint.primary_message(primary);
-        lint.span_note(metadata.span, note);
-        lint.help(help);
-    });
+    cx.emit_span_lint(
+        CONDITIONAL_MAX_N_BRANCHES,
+        metadata.span,
+        rustc_lint::errors::DiagDecorator(move |lint| {
+            lint.primary_message(primary);
+            lint.span_note(metadata.span, note);
+            lint.help(help);
+        }),
+    );
 }
 
 fn normalise_isolation_marks(text: &str) -> String {

--- a/crates/function_attrs_follow_docs/src/driver.rs
+++ b/crates/function_attrs_follow_docs/src/driver.rs
@@ -302,9 +302,9 @@ fn emit_diagnostic(cx: &LateContext<'_>, context: DiagnosticContext, localizer: 
         FUNCTION_ATTRS_FOLLOW_DOCS,
         context.doc_span,
         rustc_lint::errors::DiagDecorator(move |lint| {
-            lint.primary_message(primary.clone());
-            lint.span_note(context.offending_span, note.clone());
-            lint.help(help.clone());
+            lint.primary_message(primary);
+            lint.span_note(context.offending_span, note);
+            lint.help(help);
         }),
     );
 }

--- a/crates/function_attrs_follow_docs/src/driver.rs
+++ b/crates/function_attrs_follow_docs/src/driver.rs
@@ -298,11 +298,15 @@ fn emit_diagnostic(cx: &LateContext<'_>, context: DiagnosticContext, localizer: 
     let note = messages.note().to_string();
     let help = messages.help().to_string();
 
-    cx.span_lint(FUNCTION_ATTRS_FOLLOW_DOCS, context.doc_span, move |lint| {
-        lint.primary_message(primary.clone());
-        lint.span_note(context.offending_span, note.clone());
-        lint.help(help.clone());
-    });
+    cx.emit_span_lint(
+        FUNCTION_ATTRS_FOLLOW_DOCS,
+        context.doc_span,
+        rustc_lint::errors::DiagDecorator(move |lint| {
+            lint.primary_message(primary.clone());
+            lint.span_note(context.offending_span, note.clone());
+            lint.help(help.clone());
+        }),
+    );
 }
 
 const MESSAGE_KEY: MessageKey<'static> = MessageKey::new("function_attrs_follow_docs");

--- a/crates/module_max_lines/src/driver.rs
+++ b/crates/module_max_lines/src/driver.rs
@@ -165,14 +165,18 @@ fn emit_diagnostic(cx: &LateContext<'_>, info: &ModuleDiagnosticInfo, localizer:
         fallback_messages(module_name, info.lines, info.limit)
     });
 
-    cx.span_lint(MODULE_MAX_LINES, info.ident.span, |lint| {
-        lint.primary_message(messages.primary().to_string());
-        lint.span_note(
-            module_header_span(info.item_span, info.ident.span),
-            messages.note().to_string(),
-        );
-        lint.help(messages.help().to_string());
-    });
+    cx.emit_span_lint(
+        MODULE_MAX_LINES,
+        info.ident.span,
+        rustc_lint::errors::DiagDecorator(|lint| {
+            lint.primary_message(messages.primary().to_string());
+            lint.span_note(
+                module_header_span(info.item_span, info.ident.span),
+                messages.note().to_string(),
+            );
+            lint.help(messages.help().to_string());
+        }),
+    );
 }
 
 fn fallback_messages(module: &str, lines: usize, limit: usize) -> DiagnosticMessageSet {

--- a/crates/module_must_have_inner_docs/src/driver.rs
+++ b/crates/module_must_have_inner_docs/src/driver.rs
@@ -301,11 +301,15 @@ fn emit_diagnostic(cx: &LateContext<'_>, context: &ModuleDiagnosticContext, loca
         fallback_messages(module_name)
     });
 
-    cx.span_lint(MODULE_MUST_HAVE_INNER_DOCS, context.primary_span, |lint| {
-        lint.primary_message(messages.primary().to_string());
-        lint.span_note(context.header_span, messages.note().to_string());
-        lint.help(messages.help().to_string());
-    });
+    cx.emit_span_lint(
+        MODULE_MUST_HAVE_INNER_DOCS,
+        context.primary_span,
+        rustc_lint::errors::DiagDecorator(|lint| {
+            lint.primary_message(messages.primary().to_string());
+            lint.span_note(context.header_span, messages.note().to_string());
+            lint.help(messages.help().to_string());
+        }),
+    );
 }
 
 type ModuleDocMessages = DiagnosticMessageSet;

--- a/crates/no_expect_outside_tests/src/context/tests.rs
+++ b/crates/no_expect_outside_tests/src/context/tests.rs
@@ -107,7 +107,7 @@ fn hir_attribute_from_segments(segments: PathSegments) -> hir::Attribute {
     let path_segments = segments
         .as_ref()
         .iter()
-        .map(|segment| Ident::from_str(segment))
+        .map(|segment| rustc_span::Symbol::intern(segment))
         .collect::<Vec<_>>()
         .into_boxed_slice();
     let attr_item = hir::AttrItem {
@@ -130,7 +130,7 @@ fn hir_attribute_from_segments(segments: PathSegments) -> hir::Attribute {
 fn hir_cfg_test_attribute() -> hir::Attribute {
     let attr_item = hir::AttrItem {
         path: hir::AttrPath {
-            segments: vec![Ident::from_str("cfg")].into_boxed_slice(),
+            segments: vec![rustc_span::Symbol::intern("cfg")].into_boxed_slice(),
             span: DUMMY_SP,
         },
         args: hir::AttrArgs::Delimited(DelimArgs {

--- a/crates/no_expect_outside_tests/src/diagnostics.rs
+++ b/crates/no_expect_outside_tests/src/diagnostics.rs
@@ -175,11 +175,15 @@ pub(crate) fn emit_diagnostic(
     let note = messages.note().to_string();
     let help = messages.help().to_string();
 
-    cx.span_lint(NO_EXPECT_OUTSIDE_TESTS, expr.span, move |lint| {
-        lint.primary_message(primary.clone());
-        lint.note(note.clone());
-        lint.help(help.clone());
-    });
+    cx.emit_span_lint(
+        NO_EXPECT_OUTSIDE_TESTS,
+        expr.span,
+        rustc_lint::errors::DiagDecorator(move |lint| {
+            lint.primary_message(primary.clone());
+            lint.note(note.clone());
+            lint.help(help.clone());
+        }),
+    );
 }
 
 const MESSAGE_KEY: MessageKey<'static> = MessageKey::new("no_expect_outside_tests");

--- a/crates/no_expect_outside_tests/src/diagnostics.rs
+++ b/crates/no_expect_outside_tests/src/diagnostics.rs
@@ -179,9 +179,9 @@ pub(crate) fn emit_diagnostic(
         NO_EXPECT_OUTSIDE_TESTS,
         expr.span,
         rustc_lint::errors::DiagDecorator(move |lint| {
-            lint.primary_message(primary.clone());
-            lint.note(note.clone());
-            lint.help(help.clone());
+            lint.primary_message(primary);
+            lint.note(note);
+            lint.help(help);
         }),
     );
 }

--- a/crates/no_expect_outside_tests/src/driver/mod.rs
+++ b/crates/no_expect_outside_tests/src/driver/mod.rs
@@ -153,11 +153,10 @@ fn receiver_is_option_or_result<'tcx>(
 }
 
 fn ty_is_option_or_result<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
-    let typing_env = ty::TypingEnv {
-        typing_mode: ty::TypingMode::non_body_analysis(),
-        param_env: cx.param_env,
-    };
-    let ty = cx.tcx.normalize_erasing_regions(typing_env, ty).peel_refs();
+    let ty = cx
+        .tcx
+        .normalize_erasing_regions(cx.typing_env(), ty::Unnormalized::new_wip(ty))
+        .peel_refs();
 
     let Some(adt) = ty.ty_adt_def() else {
         return false;

--- a/crates/no_expect_outside_tests/src/driver/tests.rs
+++ b/crates/no_expect_outside_tests/src/driver/tests.rs
@@ -4,7 +4,6 @@ use super::*;
 use rstest::rstest;
 use rustc_ast::AttrStyle;
 use rustc_hir::attrs::AttributeKind as HirAttributeKind;
-use rustc_span::symbol::Ident;
 use rustc_span::{AttrId, DUMMY_SP, create_default_session_globals_then};
 
 // -------------------------------------------------------------------------
@@ -14,7 +13,7 @@ use rustc_span::{AttrId, DUMMY_SP, create_default_session_globals_then};
 fn hir_attribute_from_segments(segments: &[&str]) -> hir::Attribute {
     let path_segments = segments
         .iter()
-        .map(|segment| Ident::from_str(segment))
+        .map(|segment| rustc_span::Symbol::intern(segment))
         .collect::<Vec<_>>()
         .into_boxed_slice();
     let attr_item = hir::AttrItem {

--- a/crates/no_std_fs_operations/src/diagnostics.rs
+++ b/crates/no_std_fs_operations/src/diagnostics.rs
@@ -36,11 +36,15 @@ pub(crate) fn emit_diagnostic(
         fallback_messages(&fallback_operation)
     });
 
-    cx.span_lint(NO_STD_FS_OPERATIONS, span, move |lint| {
-        lint.primary_message(sanitize_message(messages.primary().to_string()));
-        lint.note(sanitize_message(messages.note().to_string()));
-        lint.help(sanitize_message(messages.help().to_string()));
-    });
+    cx.emit_span_lint(
+        NO_STD_FS_OPERATIONS,
+        span,
+        rustc_lint::errors::DiagDecorator(move |lint| {
+            lint.primary_message(sanitize_message(messages.primary().to_string()));
+            lint.note(sanitize_message(messages.note().to_string()));
+            lint.help(sanitize_message(messages.help().to_string()));
+        }),
+    );
 }
 
 const MESSAGE_KEY: MessageKey<'static> = MessageKey::new("no_std_fs_operations");

--- a/crates/no_unwrap_or_else_panic/src/diagnostics.rs
+++ b/crates/no_unwrap_or_else_panic/src/diagnostics.rs
@@ -44,11 +44,15 @@ pub(crate) fn emit_diagnostic(
         fallback_messages(&receiver_label)
     });
 
-    cx.span_lint(NO_UNWRAP_OR_ELSE_PANIC, expr.span, |lint| {
-        lint.primary_message(messages.primary().to_string());
-        lint.span_note(receiver.span, messages.note().to_string());
-        lint.help(messages.help().to_string());
-    });
+    cx.emit_span_lint(
+        NO_UNWRAP_OR_ELSE_PANIC,
+        expr.span,
+        rustc_lint::errors::DiagDecorator(|lint| {
+            lint.primary_message(messages.primary().to_string());
+            lint.span_note(receiver.span, messages.note().to_string());
+            lint.help(messages.help().to_string());
+        }),
+    );
 }
 
 fn fallback_messages(receiver: &str) -> DiagnosticMessageSet {

--- a/crates/no_unwrap_or_else_panic/src/panic_detector.rs
+++ b/crates/no_unwrap_or_else_panic/src/panic_detector.rs
@@ -85,11 +85,10 @@ pub(crate) fn receiver_is_option_or_result<'tcx>(
 }
 
 fn ty_is_option_or_result<'tcx>(cx: &LateContext<'tcx>, ty: ty::Ty<'tcx>) -> bool {
-    let typing_env = ty::TypingEnv {
-        typing_mode: ty::TypingMode::non_body_analysis(),
-        param_env: cx.param_env,
-    };
-    let ty = cx.tcx.normalize_erasing_regions(typing_env, ty).peel_refs();
+    let ty = cx
+        .tcx
+        .normalize_erasing_regions(cx.typing_env(), ty::Unnormalized::new_wip(ty))
+        .peel_refs();
 
     let Some(adt) = ty.ty_adt_def() else {
         return false;
@@ -220,7 +219,7 @@ fn is_fmt_args_runtime_call<'tcx>(cx: &LateContext<'tcx>, callee: &Expr<'tcx>) -
         return false;
     };
 
-    if !matches!(segment.ident.name, sym::new_v1 | sym::new_v1_formatted) {
+    if segment.ident.name != sym::new {
         return false;
     }
 

--- a/crates/rustc_lint/src/lib.rs
+++ b/crates/rustc_lint/src/lib.rs
@@ -13,8 +13,8 @@ extern crate rustc_lint as upstream;
 
 pub use upstream::*;
 
-/// Diagnostic-construction helpers from `rustc_errors` needed by lint
-/// emission call sites (e.g. `errors::DiagDecorator`).
 pub mod errors {
+    //! Diagnostic-construction helpers from `rustc_errors` needed by lint
+    //! emission call sites (e.g. `errors::DiagDecorator`).
     pub use rustc_errors::{Diag, DiagDecorator};
 }

--- a/crates/rustc_lint/src/lib.rs
+++ b/crates/rustc_lint/src/lib.rs
@@ -8,6 +8,13 @@
 
 extern crate rustc_driver;
 
+extern crate rustc_errors;
 extern crate rustc_lint as upstream;
 
 pub use upstream::*;
+
+/// Diagnostic-construction helpers from `rustc_errors` needed by lint
+/// emission call sites (e.g. `errors::DiagDecorator`).
+pub mod errors {
+    pub use rustc_errors::{Diag, DiagDecorator};
+}

--- a/crates/test_must_not_have_example/src/driver.rs
+++ b/crates/test_must_not_have_example/src/driver.rs
@@ -183,11 +183,15 @@ impl TestMustNotHaveExample {
         let note = messages.note().to_string();
         let help = messages.help().to_string();
 
-        cx.span_lint(TEST_MUST_NOT_HAVE_EXAMPLE, function.span, move |lint| {
-            lint.primary_message(primary);
-            lint.note(note);
-            lint.help(help);
-        });
+        cx.emit_span_lint(
+            TEST_MUST_NOT_HAVE_EXAMPLE,
+            function.span,
+            rustc_lint::errors::DiagDecorator(move |lint| {
+                lint.primary_message(primary);
+                lint.note(note);
+                lint.help(help);
+            }),
+        );
     }
 
     fn check_function_item<'tcx>(

--- a/docs/adr-001-prebuilt-dylint-libraries.md
+++ b/docs/adr-001-prebuilt-dylint-libraries.md
@@ -106,11 +106,11 @@ Screen reader note: The following JSON snippet illustrates the manifest format.
 {
   "git_sha": "abc1234",
   "schema_version": 1,
-  "toolchain": "nightly-2025-09-18",
+  "toolchain": "nightly-2026-05-28",
   "target": "x86_64-unknown-linux-gnu",
   "generated_at": "2026-02-03T00:00:00Z",
   "files": [
-    "libwhitaker_lints@nightly-2025-09-18-x86_64-unknown-linux-gnu.so"
+    "libwhitaker_lints@nightly-2026-05-28-x86_64-unknown-linux-gnu.so"
   ],
   "sha256": "..."
 }

--- a/docs/adr-001-prebuilt-dylint-libraries.md
+++ b/docs/adr-001-prebuilt-dylint-libraries.md
@@ -108,7 +108,7 @@ Screen reader note: The following JSON snippet illustrates the manifest format.
   "schema_version": 1,
   "toolchain": "nightly-2026-05-28",
   "target": "x86_64-unknown-linux-gnu",
-  "generated_at": "2026-02-03T00:00:00Z",
+  "generated_at": "2026-05-28T00:00:00Z",
   "files": [
     "libwhitaker_lints@nightly-2026-05-28-x86_64-unknown-linux-gnu.so"
   ],

--- a/docs/whitaker-cli-design.md
+++ b/docs/whitaker-cli-design.md
@@ -506,7 +506,7 @@ Each installed bundle should therefore carry a manifest:
   "schema_version": 1,
   "whitaker_version": "0.3.0",
   "source_sha": "502edb6",
-  "build_date": "2026-04-05T19:14:00Z",
+  "build_date": "2026-06-05T19:14:00Z",
   "toolchain": "nightly-2026-05-28",
   "target": "x86_64-unknown-linux-gnu",
   "origin": "prebuilt",
@@ -526,7 +526,7 @@ toolchain  nightly-2026-05-28
 target     x86_64-unknown-linux-gnu
 version    0.3.0
 source     502edb6
-built      2026-04-05T19:14:00Z
+built      2026-06-05T19:14:00Z
 origin     prebuilt
 config     /work/foo/whitaker.toml
 
@@ -594,7 +594,7 @@ phase: cargo build
 toolchain: nightly-2026-05-28
 target: x86_64-unknown-linux-gnu
 source: 502edb6
-log: ~/.local/share/whitaker/state/failures/2026-04-12T14-22-03Z-build.log
+log: ~/.local/share/whitaker/state/failures/2026-06-12T14-22-03Z-build.log
 
 This failure has been recorded. Run `whitaker doctor` for a summary.
 ```

--- a/docs/whitaker-cli-design.md
+++ b/docs/whitaker-cli-design.md
@@ -471,7 +471,7 @@ smaller and more explicit contract:
 whitaker install
 whitaker install --build-from-source
 whitaker install --offline
-whitaker install --toolchain nightly-2025-09-18
+whitaker install --toolchain nightly-2026-05-28
 ```
 
 Semantically, `install` should do four things:
@@ -507,7 +507,7 @@ Each installed bundle should therefore carry a manifest:
   "whitaker_version": "0.3.0",
   "source_sha": "502edb6",
   "build_date": "2026-04-05T19:14:00Z",
-  "toolchain": "nightly-2025-09-18",
+  "toolchain": "nightly-2026-05-28",
   "target": "x86_64-unknown-linux-gnu",
   "origin": "prebuilt",
   "bundles": [
@@ -522,7 +522,7 @@ effective enablement:
 
 ```plaintext
 $ whitaker ls
-toolchain  nightly-2025-09-18
+toolchain  nightly-2026-05-28
 target     x86_64-unknown-linux-gnu
 version    0.3.0
 source     502edb6
@@ -591,7 +591,7 @@ and rotate the oldest entries first.
 ```plaintext
 error: failed to build Whitaker core lints from source
 phase: cargo build
-toolchain: nightly-2025-09-18
+toolchain: nightly-2026-05-28
 target: x86_64-unknown-linux-gnu
 source: 502edb6
 log: ~/.local/share/whitaker/state/failures/2026-04-12T14-22-03Z-build.log

--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -95,7 +95,7 @@ libraries = [ { git = "https://example.com/your/repo.git", pattern = "crates/*" 
   `camino`, `serde`, `thiserror`, `toml`, and proxy crates such as
   `rustc_attr_data_structures` so lint crates can opt into shared versions via
   `workspace = true`.
-- The workspace pins `nightly-2025-09-18` in `rust-toolchain.toml` and
+- The workspace pins `nightly-2026-05-28` in `rust-toolchain.toml` and
   forces `-C prefer-dynamic` via `.cargo/config.toml`. Preferring dynamic
   std/core keeps `rustc_private` consumers (for example `rustc_driver` in
   Dylint) from pulling mixed static and dynamic runtimes, eliminating the

--- a/installer/src/artefact/manifest.rs
+++ b/installer/src/artefact/manifest.rs
@@ -51,10 +51,10 @@ pub struct ManifestContent {
 /// {
 ///   "git_sha": "abc1234",
 ///   "schema_version": 1,
-///   "toolchain": "nightly-2025-09-18",
+///   "toolchain": "nightly-2026-05-28",
 ///   "target": "x86_64-unknown-linux-gnu",
 ///   "generated_at": "2026-02-03T00:00:00Z",
-///   "files": ["libwhitaker_lints@nightly-2025-09-18-x86_64-unknown-linux-gnu.so"],
+///   "files": ["libwhitaker_lints@nightly-2026-05-28-x86_64-unknown-linux-gnu.so"],
 ///   "sha256": "..."
 /// }
 /// ```
@@ -74,7 +74,7 @@ pub struct ManifestContent {
 /// let provenance = ManifestProvenance {
 ///     git_sha: GitSha::try_from("abc1234").expect("valid git SHA"),
 ///     schema_version: SchemaVersion::current(),
-///     toolchain: ToolchainChannel::try_from("nightly-2025-09-18")
+///     toolchain: ToolchainChannel::try_from("nightly-2026-05-28")
 ///         .expect("valid toolchain channel"),
 ///     target: TargetTriple::try_from("x86_64-unknown-linux-gnu")
 ///         .expect("valid target triple"),
@@ -163,7 +163,7 @@ macro_rules! _manifest_doc_setup {
         let provenance = ManifestProvenance {
             git_sha: GitSha::try_from("abc1234").expect("valid git SHA"),
             schema_version: SchemaVersion::current(),
-            toolchain: ToolchainChannel::try_from("nightly-2025-09-18")
+            toolchain: ToolchainChannel::try_from("nightly-2026-05-28")
                 .expect("valid toolchain channel"),
             target: TargetTriple::try_from("x86_64-unknown-linux-gnu")
                 .expect("valid target triple"),
@@ -226,7 +226,7 @@ impl Manifest {
     ///
     /// ```
     /// whitaker_installer::_manifest_doc_setup!(manifest);
-    /// assert_eq!(manifest.toolchain().as_str(), "nightly-2025-09-18");
+    /// assert_eq!(manifest.toolchain().as_str(), "nightly-2026-05-28");
     /// ```
     #[must_use]
     pub fn toolchain(&self) -> &ToolchainChannel {

--- a/installer/src/artefact/manifest_parser.rs
+++ b/installer/src/artefact/manifest_parser.rs
@@ -33,7 +33,7 @@ pub enum ManifestParseError {
 ///
 /// let json = concat!(
 ///     r#"{"git_sha":"abc1234","schema_version":1,"#,
-///     r#""toolchain":"nightly-2025-09-18","#,
+///     r#""toolchain":"nightly-2026-05-28","#,
 ///     r#""target":"x86_64-unknown-linux-gnu","#,
 ///     r#""generated_at":"2026-02-03T00:00:00Z","#,
 ///     r#""files":["lib.so"],"#,
@@ -54,7 +54,7 @@ mod tests {
     fn valid_manifest_json() -> String {
         concat!(
             r#"{"git_sha":"abc1234","schema_version":1,"#,
-            r#""toolchain":"nightly-2025-09-18","#,
+            r#""toolchain":"nightly-2026-05-28","#,
             r#""target":"x86_64-unknown-linux-gnu","#,
             r#""generated_at":"2026-02-03T00:00:00Z","#,
             r#""files":["lib.so"],"#,
@@ -67,7 +67,7 @@ mod tests {
     fn parses_valid_manifest() {
         let manifest = parse_manifest(&valid_manifest_json()).expect("valid");
         assert_eq!(manifest.git_sha().as_str(), "abc1234");
-        assert_eq!(manifest.toolchain().as_str(), "nightly-2025-09-18");
+        assert_eq!(manifest.toolchain().as_str(), "nightly-2026-05-28");
         assert_eq!(manifest.target().as_str(), "x86_64-unknown-linux-gnu");
         assert_eq!(manifest.schema_version().as_u32(), 1);
         assert_eq!(manifest.files(), &["lib.so"]);

--- a/installer/src/artefact/manifest_tests.rs
+++ b/installer/src/artefact/manifest_tests.rs
@@ -9,7 +9,7 @@ fn sample_provenance() -> ManifestProvenance {
     ManifestProvenance {
         git_sha: GitSha::try_from("abc1234").expect("valid sha"),
         schema_version: SchemaVersion::current(),
-        toolchain: ToolchainChannel::try_from("nightly-2025-09-18").expect("valid channel"),
+        toolchain: ToolchainChannel::try_from("nightly-2026-05-28").expect("valid channel"),
         target: TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid target"),
     }
 }
@@ -18,7 +18,7 @@ fn sample_provenance() -> ManifestProvenance {
 fn sample_content() -> ManifestContent {
     ManifestContent {
         generated_at: GeneratedAt::new("2026-02-03T00:00:00Z"),
-        files: vec!["libwhitaker_lints@nightly-2025-09-18-x86_64-unknown-linux-gnu.so".to_owned()],
+        files: vec!["libwhitaker_lints@nightly-2026-05-28-x86_64-unknown-linux-gnu.so".to_owned()],
         sha256: Sha256Digest::try_from("a".repeat(64).as_str()).expect("valid digest"),
     }
 }
@@ -35,7 +35,7 @@ fn sample_manifest(
 fn accessors_return_all_fields(sample_manifest: Manifest) {
     assert_eq!(sample_manifest.git_sha().as_str(), "abc1234");
     assert_eq!(sample_manifest.schema_version().as_u32(), 1);
-    assert_eq!(sample_manifest.toolchain().as_str(), "nightly-2025-09-18");
+    assert_eq!(sample_manifest.toolchain().as_str(), "nightly-2026-05-28");
     assert_eq!(
         sample_manifest.target().as_str(),
         "x86_64-unknown-linux-gnu"
@@ -78,7 +78,7 @@ fn serialized_json_contains_all_adr_001_keys(sample_manifest: Manifest) {
     assert_eq!(obj.get("schema_version").and_then(Value::as_u64), Some(1));
     assert_eq!(
         obj.get("toolchain").and_then(Value::as_str),
-        Some("nightly-2025-09-18")
+        Some("nightly-2026-05-28")
     );
     assert_eq!(
         obj.get("target").and_then(Value::as_str),
@@ -97,7 +97,7 @@ fn manifest_with_multiple_files() {
     let provenance = ManifestProvenance {
         git_sha: GitSha::try_from("deadbeef").expect("valid"),
         schema_version: SchemaVersion::current(),
-        toolchain: ToolchainChannel::try_from("nightly-2025-09-18").expect("valid"),
+        toolchain: ToolchainChannel::try_from("nightly-2026-05-28").expect("valid"),
         target: TargetTriple::try_from("aarch64-apple-darwin").expect("valid"),
     };
     let content = ManifestContent {
@@ -121,7 +121,7 @@ fn serde_round_trip(sample_manifest: Manifest) {
     r#"{
         "git_sha": "abc1234",
         "schema_version": 1,
-        "toolchain": "nightly-2025-09-18",
+        "toolchain": "nightly-2026-05-28",
         "target": "wasm32-unknown-unknown",
         "generated_at": "2026-02-03T00:00:00Z",
         "files": ["lib.so"],

--- a/installer/src/artefact/naming.rs
+++ b/installer/src/artefact/naming.rs
@@ -28,7 +28,7 @@ const ARTEFACT_EXTENSION: &str = ".tar.zst";
 /// use whitaker_installer::artefact::target::TargetTriple;
 ///
 /// let sha: GitSha = "abc1234".try_into().expect("valid git SHA");
-/// let toolchain: ToolchainChannel = "nightly-2025-09-18"
+/// let toolchain: ToolchainChannel = "nightly-2026-05-28"
 ///     .try_into()
 ///     .expect("valid toolchain channel");
 /// let target: TargetTriple = "x86_64-unknown-linux-gnu"
@@ -38,7 +38,7 @@ const ARTEFACT_EXTENSION: &str = ".tar.zst";
 /// let name = ArtefactName::new(sha, toolchain, target);
 /// assert_eq!(
 ///     name.to_string(),
-///     "whitaker-lints-abc1234-nightly-2025-09-18-x86_64-unknown-linux-gnu.tar.zst"
+///     "whitaker-lints-abc1234-nightly-2026-05-28-x86_64-unknown-linux-gnu.tar.zst"
 /// );
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,7 +103,7 @@ mod tests {
     fn sample_name() -> ArtefactName {
         ArtefactName::new(
             GitSha::try_from("abc1234").expect("valid sha"),
-            ToolchainChannel::try_from("nightly-2025-09-18").expect("valid channel"),
+            ToolchainChannel::try_from("nightly-2026-05-28").expect("valid channel"),
             TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid target"),
         )
     }
@@ -113,7 +113,7 @@ mod tests {
         assert_eq!(
             sample_name.to_string(),
             concat!(
-                "whitaker-lints-abc1234-nightly-2025-09-18",
+                "whitaker-lints-abc1234-nightly-2026-05-28",
                 "-x86_64-unknown-linux-gnu.tar.zst"
             )
         );
@@ -127,14 +127,14 @@ mod tests {
     #[rstest]
     fn accessors_return_components(sample_name: ArtefactName) {
         assert_eq!(sample_name.git_sha().as_str(), "abc1234");
-        assert_eq!(sample_name.toolchain().as_str(), "nightly-2025-09-18");
+        assert_eq!(sample_name.toolchain().as_str(), "nightly-2026-05-28");
         assert_eq!(sample_name.target().as_str(), "x86_64-unknown-linux-gnu");
     }
 
     #[rstest]
     fn different_targets_produce_different_names() {
         let sha = GitSha::try_from("abc1234").expect("valid");
-        let ch = ToolchainChannel::try_from("nightly-2025-09-18").expect("valid");
+        let ch = ToolchainChannel::try_from("nightly-2026-05-28").expect("valid");
 
         let linux = ArtefactName::new(
             sha.clone(),

--- a/installer/src/artefact/packaging_tests.rs
+++ b/installer/src/artefact/packaging_tests.rs
@@ -16,7 +16,7 @@ fn sample_git_sha() -> GitSha {
 
 #[fixture]
 fn sample_toolchain() -> ToolchainChannel {
-    ToolchainChannel::try_from("nightly-2025-09-18").expect("valid channel")
+    ToolchainChannel::try_from("nightly-2026-05-28").expect("valid channel")
 }
 
 #[fixture]
@@ -143,7 +143,7 @@ fn package_artefact_rejects_empty_files(temp_dir: TempDir) {
 
     let params = PackageParams {
         git_sha: GitSha::try_from("abc1234").expect("valid"),
-        toolchain: ToolchainChannel::try_from("nightly-2025-09-18").expect("valid"),
+        toolchain: ToolchainChannel::try_from("nightly-2026-05-28").expect("valid"),
         target: TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid"),
         library_files: vec![],
         output_dir,
@@ -165,7 +165,7 @@ fn package_artefact_fails_when_library_file_missing(temp_dir: TempDir) {
 
     let params = PackageParams {
         git_sha: GitSha::try_from("abc1234").expect("valid"),
-        toolchain: ToolchainChannel::try_from("nightly-2025-09-18").expect("valid"),
+        toolchain: ToolchainChannel::try_from("nightly-2026-05-28").expect("valid"),
         target: TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid"),
         library_files: vec![missing],
         output_dir,
@@ -225,7 +225,7 @@ fn create_test_package(temp_dir: &TempDir) -> PackageOutput {
 
     let params = PackageParams {
         git_sha: GitSha::try_from("deadbeef").expect("valid"),
-        toolchain: ToolchainChannel::try_from("nightly-2025-09-18").expect("valid"),
+        toolchain: ToolchainChannel::try_from("nightly-2026-05-28").expect("valid"),
         target: TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid"),
         library_files: vec![lib_path],
         output_dir,
@@ -272,7 +272,7 @@ fn packaging_produces_deterministic_digest(temp_dir: TempDir) {
         fs::create_dir_all(&output_dir).expect("mkdir");
         let params = PackageParams {
             git_sha: GitSha::try_from("abc1234").expect("valid"),
-            toolchain: ToolchainChannel::try_from("nightly-2025-09-18").expect("valid"),
+            toolchain: ToolchainChannel::try_from("nightly-2026-05-28").expect("valid"),
             target: TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid"),
             library_files: vec![lib_path.clone()],
             output_dir,

--- a/installer/src/artefact/toolchain_channel.rs
+++ b/installer/src/artefact/toolchain_channel.rs
@@ -3,23 +3,23 @@
 //! Validates that the channel string is non-empty and contains only
 //! ASCII alphanumeric characters, hyphens, dots, and underscores — the
 //! characters permitted in Rust toolchain channel specifiers, including
-//! host-qualified names such as `nightly-2025-09-18-x86_64-unknown-linux-gnu`.
+//! host-qualified names such as `nightly-2026-05-28-x86_64-unknown-linux-gnu`.
 
 use super::error::{ArtefactError, Result};
 use serde::Serialize;
 use std::fmt;
 
-/// A validated Rust toolchain channel string (e.g. `nightly-2025-09-18`).
+/// A validated Rust toolchain channel string (e.g. `nightly-2026-05-28`).
 ///
 /// # Examples
 ///
 /// ```
 /// use whitaker_installer::artefact::toolchain_channel::ToolchainChannel;
 ///
-/// let channel: ToolchainChannel = "nightly-2025-09-18"
+/// let channel: ToolchainChannel = "nightly-2026-05-28"
 ///     .try_into()
 ///     .expect("valid toolchain channel");
-/// assert_eq!(channel.as_str(), "nightly-2025-09-18");
+/// assert_eq!(channel.as_str(), "nightly-2026-05-28");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(transparent)]
@@ -27,7 +27,7 @@ pub struct ToolchainChannel(String);
 
 /// Check that every byte is ASCII alphanumeric, a hyphen, a dot, or an
 /// underscore.  Underscores appear in host-qualified toolchain names
-/// (e.g. `nightly-2025-09-18-x86_64-unknown-linux-gnu`).
+/// (e.g. `nightly-2026-05-28-x86_64-unknown-linux-gnu`).
 fn is_valid_channel_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '_'
 }
@@ -57,11 +57,11 @@ impl ToolchainChannel {
     /// ```
     /// use whitaker_installer::artefact::toolchain_channel::ToolchainChannel;
     ///
-    /// let channel: ToolchainChannel = "nightly-2025-09-18"
+    /// let channel: ToolchainChannel = "nightly-2026-05-28"
     ///     .try_into()
     ///     .expect("valid toolchain channel");
     /// let inner: String = channel.into_inner();
-    /// assert_eq!(inner, "nightly-2025-09-18");
+    /// assert_eq!(inner, "nightly-2026-05-28");
     /// ```
     #[must_use]
     pub fn into_inner(self) -> String {
@@ -125,10 +125,10 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case::nightly_with_date("nightly-2025-09-18")]
+    #[case::nightly_with_date("nightly-2026-05-28")]
     #[case::stable("stable")]
     #[case::version_with_dots("1.75.0")]
-    #[case::host_qualified("nightly-2025-09-18-x86_64-unknown-linux-gnu")]
+    #[case::host_qualified("nightly-2026-05-28-x86_64-unknown-linux-gnu")]
     fn accepts_valid_channel(#[case] input: &str) {
         let ch = ToolchainChannel::try_from(input).expect("expected valid channel");
         assert_eq!(ch.as_str(), input);
@@ -149,19 +149,19 @@ mod tests {
 
     #[test]
     fn display_shows_inner_value() {
-        let ch = ToolchainChannel::try_from("nightly-2025-09-18").expect("known good");
-        assert_eq!(format!("{ch}"), "nightly-2025-09-18");
+        let ch = ToolchainChannel::try_from("nightly-2026-05-28").expect("known good");
+        assert_eq!(format!("{ch}"), "nightly-2026-05-28");
     }
 
     #[test]
     fn from_owned_string_accepts_valid() {
-        let ch = ToolchainChannel::try_from(String::from("nightly-2025-09-18"));
+        let ch = ToolchainChannel::try_from(String::from("nightly-2026-05-28"));
         assert!(ch.is_ok());
     }
 
     #[test]
     fn serde_round_trip() {
-        let ch = ToolchainChannel::try_from("nightly-2025-09-18").expect("valid");
+        let ch = ToolchainChannel::try_from("nightly-2026-05-28").expect("valid");
         let json = serde_json::to_string(&ch).expect("serialize");
         let back: ToolchainChannel = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(ch, back);

--- a/installer/src/bin/package_lints.rs
+++ b/installer/src/bin/package_lints.rs
@@ -30,7 +30,7 @@ struct PackageCli {
     #[arg(long)]
     git_sha: String,
 
-    /// Rust toolchain channel (e.g. "nightly-2025-09-18").
+    /// Rust toolchain channel (e.g. "nightly-2026-05-28").
     #[arg(long)]
     toolchain: String,
 
@@ -257,7 +257,7 @@ mod tests {
         "--git-sha",
         "abc1234",
         "--toolchain",
-        "nightly-2025-09-18",
+        "nightly-2026-05-28",
         "--target",
         "x86_64-unknown-linux-gnu",
         "--output-dir",
@@ -282,7 +282,7 @@ mod tests {
     fn cli_parses_all_required_args() {
         let cli = PackageCli::parse_from(cli_args(&["/tmp/libfoo.so", "/tmp/libbar.so"]));
         assert_eq!(cli.git_sha, "abc1234");
-        assert_eq!(cli.toolchain, "nightly-2025-09-18");
+        assert_eq!(cli.toolchain, "nightly-2026-05-28");
         assert_eq!(cli.target, "x86_64-unknown-linux-gnu");
         assert_eq!(cli.output_dir, PathBuf::from("/tmp/dist"));
         assert_eq!(cli.library_files.len(), 2);

--- a/installer/src/builder.rs
+++ b/installer/src/builder.rs
@@ -238,7 +238,7 @@ mod tests {
             config: BuildConfig {
                 toolchain: Toolchain::with_override(
                     &Utf8PathBuf::from("/tmp/test"),
-                    "nightly-2025-09-18",
+                    "nightly-2026-05-28",
                 ),
                 target_dir: Utf8PathBuf::from("/tmp/target"),
                 jobs: None,

--- a/installer/src/deps.rs
+++ b/installer/src/deps.rs
@@ -5,7 +5,8 @@
 //! release archives before falling back to `cargo binstall` or `cargo install`.
 
 use crate::dependency_binaries::{
-    DependencyBinaryInstaller, RepositoryDependencyBinaryInstaller, host_target,
+    DependencyBinaryInstaller, RepositoryDependencyBinaryInstaller, find_dependency_binary,
+    host_target,
 };
 use crate::dirs::{BaseDirs, SystemBaseDirs};
 use crate::error::{InstallerError, Result};
@@ -163,14 +164,99 @@ pub fn install_dylint_tools_with_options(
     )
 }
 
+/// Arguments used to query Cargo's registry of installed binaries.
+const CARGO_INSTALL_LIST_ARGS: [&str; 2] = ["install", "--list"];
+
 fn is_tool_installed(executor: &dyn CommandExecutor, tool: &DependencyTool) -> bool {
+    // The manifest is embedded in the binary, so a lookup failure is
+    // effectively unreachable. Should it ever occur, degrade to the previous
+    // success-only probes rather than reporting every tool as missing.
+    let expected_version = find_dependency_binary(tool.package)
+        .ok()
+        .flatten()
+        .map(|dependency| dependency.version());
+
     if tool == &DYLINT_LINK_TOOL {
-        return match find_binary_on_path(tool.command) {
-            Some(binary_path) => dylint_link_probe_succeeds(&binary_path),
-            None => false,
-        };
+        return is_dylint_link_installed(executor, expected_version);
     }
-    command_succeeds(executor, tool.command, tool.args)
+    is_versioned_tool_installed(executor, tool, expected_version)
+}
+
+fn is_dylint_link_installed(
+    executor: &dyn CommandExecutor,
+    expected_version: Option<&str>,
+) -> bool {
+    // The existence probe runs first so that a missing binary never consults
+    // the executor.
+    let is_present = match find_binary_on_path(DYLINT_LINK_TOOL.command) {
+        Some(binary_path) => dylint_link_probe_succeeds(&binary_path),
+        None => false,
+    };
+    if !is_present {
+        return false;
+    }
+    let Some(expected_version) = expected_version else {
+        return true;
+    };
+    // `dylint-link` is a pure linker wrapper: it forwards its entire argument
+    // list to the underlying linker and can never report its own version, so
+    // `dylint-link --version` is not a usable version source. Query Cargo's
+    // registry of installed binaries instead, which records the version each
+    // binary was installed at.
+    cargo_installed_version(executor, DYLINT_LINK_TOOL.package)
+        .is_some_and(|version| version == expected_version)
+}
+
+fn is_versioned_tool_installed(
+    executor: &dyn CommandExecutor,
+    tool: &DependencyTool,
+    expected_version: Option<&str>,
+) -> bool {
+    let Some(expected_version) = expected_version else {
+        return command_succeeds(executor, tool.command, tool.args);
+    };
+    executor.run(tool.command, tool.args).is_ok_and(|output| {
+        output.status.success()
+            && first_semver_token(&String::from_utf8_lossy(&output.stdout))
+                .is_some_and(|version| version == expected_version)
+    })
+}
+
+/// Extracts the installed version of `package` from `cargo install --list`.
+///
+/// Matches lines of the form `dylint-link v6.0.1:` (or
+/// `dylint-link v6.0.1 (/path):` for path installs), returning the version
+/// with the leading `v` and trailing `:` stripped.
+fn cargo_installed_version(executor: &dyn CommandExecutor, package: &str) -> Option<String> {
+    let output = executor.run("cargo", &CARGO_INSTALL_LIST_ARGS).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout.lines().find_map(|line| {
+        let mut tokens = line.split_whitespace();
+        if tokens.next() != Some(package) {
+            return None;
+        }
+        tokens
+            .next()
+            .and_then(|token| token.strip_prefix('v'))
+            .map(|version| version.trim_end_matches(':').to_owned())
+    })
+}
+
+/// Returns the first whitespace-separated token shaped like `MAJOR.MINOR.PATCH`.
+fn first_semver_token(text: &str) -> Option<&str> {
+    text.split_whitespace().find(|token| {
+        let components: Vec<&str> = token.split('.').collect();
+        components.len() == 3
+            && components.iter().all(|component| {
+                !component.is_empty()
+                    && component
+                        .chars()
+                        .all(|character| character.is_ascii_digit())
+            })
+    })
 }
 
 fn is_binstall_available(executor: &dyn CommandExecutor) -> bool {

--- a/installer/src/deps/install_tests.rs
+++ b/installer/src/deps/install_tests.rs
@@ -1,7 +1,9 @@
 //! Tests for dependency-install status refresh behaviour.
 
 use super::*;
-use crate::test_utils::dependency_binary_helpers::with_fake_binary_on_path;
+use crate::test_utils::dependency_binary_helpers::{
+    dylint_link_install_list_check, with_fake_binary_on_path,
+};
 use rstest::rstest;
 
 #[rstest]
@@ -11,7 +13,9 @@ fn update_status_after_install_refreshes_link_for_local_cargo_dylint_installs(
     #[case] outcome: InstallOutcome,
 ) {
     with_fake_binary_on_path("dylint-link", || {
-        let executor = crate::test_utils::StubExecutor::new(vec![]);
+        // The companion refresh confirms the dylint-link version against
+        // Cargo's installed-binary registry after the PATH probe passes.
+        let executor = crate::test_utils::StubExecutor::new(vec![dylint_link_install_list_check()]);
         let mut status = DylintToolStatus {
             cargo_dylint: false,
             dylint_link: false,

--- a/installer/src/deps/path_tests.rs
+++ b/installer/src/deps/path_tests.rs
@@ -3,17 +3,18 @@
 use super::*;
 use crate::test_support::env_test_guard;
 use crate::test_utils::dependency_binary_helpers::{
-    cargo_dylint_check_with_result, with_fake_binary_on_path, with_fake_path, write_fake_binary,
-    write_fake_binary_with_status,
+    cargo_dylint_check, cargo_dylint_check_with_result, dylint_link_install_list_check,
+    dylint_link_install_list_check_with_version, with_fake_binary_on_path, with_fake_path,
+    write_fake_binary, write_fake_binary_with_status,
 };
-use crate::test_utils::{StubExecutor, success_output};
+use crate::test_utils::{ExpectedCall, StubExecutor, stdout_output};
 use temp_env::with_vars_unset;
 
 #[test]
 fn check_dylint_tools_reports_installed_tools() {
     with_fake_binary_on_path("dylint-link", || {
         let executor =
-            StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
+            StubExecutor::new(vec![cargo_dylint_check(), dylint_link_install_list_check()]);
 
         let status = check_dylint_tools(&executor);
 
@@ -22,6 +23,99 @@ fn check_dylint_tools_reports_installed_tools() {
             DylintToolStatus {
                 cargo_dylint: true,
                 dylint_link: true,
+            }
+        );
+        executor.assert_finished();
+    });
+}
+
+#[test]
+fn check_dylint_tools_rejects_stale_cargo_dylint_version() {
+    // The fake PATH keeps dylint-link absent so only cargo-dylint is probed.
+    with_fake_path(
+        |_| {},
+        || {
+            let executor = StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(
+                stdout_output("cargo-dylint 5.0.0\n"),
+            ))]);
+
+            let status = check_dylint_tools(&executor);
+
+            assert_eq!(
+                status,
+                DylintToolStatus {
+                    cargo_dylint: false,
+                    dylint_link: false,
+                }
+            );
+            executor.assert_finished();
+        },
+    );
+}
+
+#[test]
+fn check_dylint_tools_rejects_unparsable_cargo_dylint_output() {
+    with_fake_path(
+        |_| {},
+        || {
+            let executor = StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(
+                stdout_output("not a version\n"),
+            ))]);
+
+            let status = check_dylint_tools(&executor);
+
+            assert_eq!(
+                status,
+                DylintToolStatus {
+                    cargo_dylint: false,
+                    dylint_link: false,
+                }
+            );
+            executor.assert_finished();
+        },
+    );
+}
+
+#[test]
+fn check_dylint_tools_rejects_stale_dylint_link_version() {
+    with_fake_binary_on_path("dylint-link", || {
+        let executor = StubExecutor::new(vec![
+            cargo_dylint_check(),
+            dylint_link_install_list_check_with_version("5.0.0"),
+        ]);
+
+        let status = check_dylint_tools(&executor);
+
+        assert_eq!(
+            status,
+            DylintToolStatus {
+                cargo_dylint: true,
+                dylint_link: false,
+            }
+        );
+        executor.assert_finished();
+    });
+}
+
+#[test]
+fn check_dylint_tools_rejects_dylint_link_missing_from_install_list() {
+    with_fake_binary_on_path("dylint-link", || {
+        let executor = StubExecutor::new(vec![
+            cargo_dylint_check(),
+            ExpectedCall {
+                cmd: "cargo",
+                args: vec!["install", "--list"],
+                result: Ok(stdout_output("ripgrep v14.1.0:\n    rg\n")),
+            },
+        ]);
+
+        let status = check_dylint_tools(&executor);
+
+        assert_eq!(
+            status,
+            DylintToolStatus {
+                cargo_dylint: true,
+                dylint_link: false,
             }
         );
         executor.assert_finished();
@@ -40,8 +134,7 @@ fn check_dylint_tools_rejects_non_invocable_dylint_link_on_path() {
             write_fake_binary_with_status(&binary_path, true, 1);
         },
         || {
-            let executor =
-                StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
+            let executor = StubExecutor::new(vec![cargo_dylint_check()]);
 
             let status = check_dylint_tools(&executor);
 
@@ -147,7 +240,7 @@ fn check_dylint_tools_detects_dylint_link_via_pathext_suffix() {
         || {
             temp_env::with_var("PATHEXT", Some(".CMD;.BAT"), || {
                 let executor =
-                    StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(success_output()))]);
+                    StubExecutor::new(vec![cargo_dylint_check(), dylint_link_install_list_check()]);
 
                 let status = check_dylint_tools(&executor);
 

--- a/installer/src/deps/path_tests.rs
+++ b/installer/src/deps/path_tests.rs
@@ -29,14 +29,16 @@ fn check_dylint_tools_reports_installed_tools() {
     });
 }
 
-#[test]
-fn check_dylint_tools_rejects_stale_cargo_dylint_version() {
+#[rstest::rstest]
+#[case::stale_version("cargo-dylint 5.0.0\n")]
+#[case::unparsable_output("not a version\n")]
+fn check_dylint_tools_rejects_unusable_cargo_dylint_output(#[case] version_stdout: &str) {
     // The fake PATH keeps dylint-link absent so only cargo-dylint is probed.
     with_fake_path(
         |_| {},
         || {
             let executor = StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(
-                stdout_output("cargo-dylint 5.0.0\n"),
+                stdout_output(version_stdout),
             ))]);
 
             let status = check_dylint_tools(&executor);
@@ -53,61 +55,16 @@ fn check_dylint_tools_rejects_stale_cargo_dylint_version() {
     );
 }
 
-#[test]
-fn check_dylint_tools_rejects_unparsable_cargo_dylint_output() {
-    with_fake_path(
-        |_| {},
-        || {
-            let executor = StubExecutor::new(vec![cargo_dylint_check_with_result(Ok(
-                stdout_output("not a version\n"),
-            ))]);
-
-            let status = check_dylint_tools(&executor);
-
-            assert_eq!(
-                status,
-                DylintToolStatus {
-                    cargo_dylint: false,
-                    dylint_link: false,
-                }
-            );
-            executor.assert_finished();
-        },
-    );
-}
-
-#[test]
-fn check_dylint_tools_rejects_stale_dylint_link_version() {
+#[rstest::rstest]
+#[case::stale_version(dylint_link_install_list_check_with_version("5.0.0"))]
+#[case::missing_from_list(ExpectedCall {
+    cmd: "cargo",
+    args: vec!["install", "--list"],
+    result: Ok(stdout_output("ripgrep v14.1.0:\n    rg\n")),
+})]
+fn check_dylint_tools_rejects_unpinned_dylint_link(#[case] install_list_check: ExpectedCall) {
     with_fake_binary_on_path("dylint-link", || {
-        let executor = StubExecutor::new(vec![
-            cargo_dylint_check(),
-            dylint_link_install_list_check_with_version("5.0.0"),
-        ]);
-
-        let status = check_dylint_tools(&executor);
-
-        assert_eq!(
-            status,
-            DylintToolStatus {
-                cargo_dylint: true,
-                dylint_link: false,
-            }
-        );
-        executor.assert_finished();
-    });
-}
-
-#[test]
-fn check_dylint_tools_rejects_dylint_link_missing_from_install_list() {
-    with_fake_binary_on_path("dylint-link", || {
-        let executor = StubExecutor::new(vec![
-            cargo_dylint_check(),
-            ExpectedCall {
-                cmd: "cargo",
-                args: vec!["install", "--list"],
-                result: Ok(stdout_output("ripgrep v14.1.0:\n    rg\n")),
-            },
-        ]);
+        let executor = StubExecutor::new(vec![cargo_dylint_check(), install_list_check]);
 
         let status = check_dylint_tools(&executor);
 

--- a/installer/src/deps/tests.rs
+++ b/installer/src/deps/tests.rs
@@ -4,8 +4,8 @@ use super::*;
 use crate::dependency_binaries::{DependencyBinaryInstallError, MockDependencyBinaryInstaller};
 use crate::installer_packaging::TargetTriple;
 use crate::test_utils::dependency_binary_helpers::{
-    binstall_install, binstall_version_check_with_result, cargo_dylint_check_with_result,
-    with_fake_binary_on_path,
+    binstall_install, binstall_version_check_with_result, cargo_dylint_check,
+    cargo_dylint_check_with_result, dylint_link_install_list_check, with_fake_binary_on_path,
 };
 use crate::test_utils::{ExpectedCall, StubDirs, StubExecutor, failure_output, success_output};
 use std::path::PathBuf;
@@ -46,7 +46,7 @@ fn install_dylint_tools_uses_repository_release_first() {
         .returning(|_, _, _| Ok(PathBuf::from("/tmp/bin/cargo-dylint")));
     let executor = StubExecutor::new(vec![
         binstall_version_check_with_result(Ok(success_output())),
-        cargo_dylint_check_with_result(Ok(success_output())),
+        cargo_dylint_check(),
     ]);
     let mut stderr = Vec::new();
 
@@ -78,7 +78,7 @@ fn install_dylint_tools_falls_back_to_binstall_when_repository_unavailable() {
     let executor = StubExecutor::new(vec![
         binstall_version_check_with_result(Ok(success_output())),
         binstall_install("cargo-dylint", Ok(success_output())),
-        cargo_dylint_check_with_result(Ok(success_output())),
+        cargo_dylint_check(),
     ]);
     let mut stderr = Vec::new();
 
@@ -112,7 +112,7 @@ fn install_dylint_tools_falls_back_to_cargo_install_when_binstall_missing() {
             args: vec!["install", "--locked", "--version", "6.0.1", "cargo-dylint"],
             result: Ok(success_output()),
         },
-        cargo_dylint_check_with_result(Ok(success_output())),
+        cargo_dylint_check(),
     ]);
     let mut stderr = Vec::new();
 
@@ -142,7 +142,7 @@ fn install_dylint_tools_falls_back_when_repository_verification_fails() {
         binstall_version_check_with_result(Ok(success_output())),
         cargo_dylint_check_with_result(Ok(failure_output("still missing"))),
         binstall_install("cargo-dylint", Ok(success_output())),
-        cargo_dylint_check_with_result(Ok(success_output())),
+        cargo_dylint_check(),
     ]);
     let mut stderr = Vec::new();
 
@@ -215,7 +215,7 @@ fn install_dylint_tools_builds_from_source_when_repository_asset_is_missing() {
             args: vec!["install", "--locked", "--version", "6.0.1", "cargo-dylint"],
             result: Ok(success_output()),
         },
-        cargo_dylint_check_with_result(Ok(success_output())),
+        cargo_dylint_check(),
     ]);
     let mut stderr = Vec::new();
 
@@ -255,7 +255,10 @@ fn install_dylint_tools_skips_dylint_link_when_cargo_dylint_source_build_install
             args: vec!["install", "--locked", "--version", "6.0.1", "cargo-dylint"],
             result: Ok(success_output()),
         },
-        cargo_dylint_check_with_result(Ok(success_output())),
+        cargo_dylint_check(),
+        // Refreshing the companion dylint-link status consults Cargo's
+        // installed-binary registry once the PATH probe passes.
+        dylint_link_install_list_check(),
     ]);
     let mut stderr = Vec::new();
 

--- a/installer/src/error.rs
+++ b/installer/src/error.rs
@@ -277,33 +277,33 @@ mod tests {
     #[test]
     fn toolchain_not_installed_suggests_install_command() {
         let err = InstallerError::ToolchainNotInstalled {
-            toolchain: "nightly-2025-09-18".to_owned(),
+            toolchain: "nightly-2026-05-28".to_owned(),
         };
         let msg = err.to_string();
         assert!(msg.contains("rustup toolchain install"));
-        assert!(msg.contains("nightly-2025-09-18"));
+        assert!(msg.contains("nightly-2026-05-28"));
     }
 
     #[test]
     fn toolchain_install_failed_includes_toolchain_and_message() {
         let err = InstallerError::ToolchainInstallFailed {
-            toolchain: "nightly-2025-09-18".to_owned(),
+            toolchain: "nightly-2026-05-28".to_owned(),
             message: "network error".to_owned(),
         };
         let msg = err.to_string();
-        assert!(msg.contains("nightly-2025-09-18"));
+        assert!(msg.contains("nightly-2026-05-28"));
         assert!(msg.contains("network error"));
     }
 
     #[test]
     fn toolchain_component_install_failed_includes_components() {
         let err = InstallerError::ToolchainComponentInstallFailed {
-            toolchain: "nightly-2025-09-18".to_owned(),
+            toolchain: "nightly-2026-05-28".to_owned(),
             components: "rust-src, rustc-dev".to_owned(),
             message: "component error".to_owned(),
         };
         let msg = err.to_string();
-        assert!(msg.contains("nightly-2025-09-18"));
+        assert!(msg.contains("nightly-2026-05-28"));
         assert!(msg.contains("rust-src, rustc-dev"));
         assert!(msg.contains("component error"));
     }

--- a/installer/src/install_flow/tests.rs
+++ b/installer/src/install_flow/tests.rs
@@ -68,7 +68,7 @@ fn staging_fixture() -> StagingFixture {
     StagingFixture {
         _temp_dir: temp_dir,
         staging_path,
-        toolchain: "nightly-2025-09-18",
+        toolchain: "nightly-2026-05-28",
     }
 }
 
@@ -111,7 +111,7 @@ fn prune_prebuilt_libraries_keeps_only_requested_crates(
         toolchain,
     } = staging_fixture;
 
-    let foreign_path = staging_path.join("libforeign_lint@nightly-2025-09-18.so");
+    let foreign_path = staging_path.join("libforeign_lint@nightly-2026-05-28.so");
     fs::write(foreign_path.as_std_path(), b"foreign library")
         .expect("test setup should write foreign library");
 
@@ -172,7 +172,7 @@ fn try_prebuilt_installation_prune_error_falls_back_to_local_build() {
         args: &args,
         dirs: &dirs,
         requested_crates: &requested_crates,
-        toolchain_channel: "nightly-2025-09-18",
+        toolchain_channel: "nightly-2026-05-28",
     };
 
     let mut stderr = Vec::new();

--- a/installer/src/install_metrics.rs
+++ b/installer/src/install_metrics.rs
@@ -342,10 +342,7 @@ fn rate(part: u64, whole: u64) -> f64 {
 }
 
 fn duration_to_millis(duration: Duration) -> u64 {
-    match u64::try_from(duration.as_millis()) {
-        Ok(millis) => millis,
-        Err(_) => u64::MAX,
-    }
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
 fn format_duration(duration: Duration) -> String {

--- a/installer/src/list.rs
+++ b/installer/src/list.rs
@@ -286,20 +286,20 @@ mod tests {
 
     #[rstest]
     #[case::json_format(true, &["toolchains", "\"active\""])]
-    #[case::human_format(false, &["nightly-2025-09-18", "whitaker_suite"])]
+    #[case::human_format(false, &["nightly-2026-05-28", "whitaker_suite"])]
     fn run_list_with_installed_library_includes_expected_output(
         temp_target: TempTarget,
         #[case] json: bool,
         #[case] expected: &[&str],
     ) {
-        create_mock_library(&temp_target.path, "nightly-2025-09-18");
+        create_mock_library(&temp_target.path, "nightly-2026-05-28");
         let args = ListArgs {
             json,
             target_dir: Some(temp_target.path.clone()),
         };
         let mut stdout = Vec::new();
 
-        let result = run_list_with(&args, &mut stdout, || Some("nightly-2025-09-18".to_owned()));
+        let result = run_list_with(&args, &mut stdout, || Some("nightly-2026-05-28".to_owned()));
 
         assert!(result.is_ok(), "expected success, got: {result:?}");
         let output = String::from_utf8_lossy(&stdout);
@@ -315,7 +315,7 @@ mod tests {
     fn run_list_finds_prebuilt_layout_libraries(temp_target: TempTarget) {
         create_mock_prebuilt_library(
             &temp_target.path,
-            "nightly-2025-09-18",
+            "nightly-2026-05-28",
             "x86_64-unknown-linux-gnu",
         );
         let args = ListArgs {
@@ -324,11 +324,11 @@ mod tests {
         };
         let mut stdout = Vec::new();
 
-        let result = run_list_with(&args, &mut stdout, || Some("nightly-2025-09-18".to_owned()));
+        let result = run_list_with(&args, &mut stdout, || Some("nightly-2026-05-28".to_owned()));
 
         assert!(result.is_ok(), "expected success, got: {result:?}");
         let output = String::from_utf8_lossy(&stdout);
-        assert!(output.contains("nightly-2025-09-18"), "got: {output}");
+        assert!(output.contains("nightly-2026-05-28"), "got: {output}");
         assert!(output.contains("whitaker_suite"), "got: {output}");
     }
 
@@ -368,7 +368,7 @@ mod tests {
     ) {
         // Create a rust-toolchain.toml file
         let toolchain_content = r#"[toolchain]
-channel = "nightly-2025-09-18"
+channel = "nightly-2026-05-28"
 "#;
         fs::write(
             temp_target.path.join("rust-toolchain.toml"),
@@ -378,7 +378,7 @@ channel = "nightly-2025-09-18"
 
         let result = detect_active_toolchain_in(&temp_target.path);
 
-        assert_eq!(result, Some("nightly-2025-09-18".to_owned()));
+        assert_eq!(result, Some("nightly-2026-05-28".to_owned()));
     }
 
     // -------------------------------------------------------------------------

--- a/installer/src/list_output.rs
+++ b/installer/src/list_output.rs
@@ -142,11 +142,11 @@ mod tests {
     fn sample_lints() -> InstalledLints {
         let mut by_toolchain = BTreeMap::new();
         by_toolchain.insert(
-            "nightly-2025-09-18".to_owned(),
+            "nightly-2026-05-28".to_owned(),
             vec![InstalledLibrary {
                 crate_name: CrateName::from("whitaker_suite"),
-                toolchain: "nightly-2025-09-18".to_owned(),
-                path: Utf8PathBuf::from("/fake/path/libwhitaker_suite@nightly-2025-09-18.so"),
+                toolchain: "nightly-2026-05-28".to_owned(),
+                path: Utf8PathBuf::from("/fake/path/libwhitaker_suite@nightly-2026-05-28.so"),
             }],
         );
         InstalledLints { by_toolchain }
@@ -166,7 +166,7 @@ mod tests {
         let output = format_human(&lints, None);
 
         assert!(output.contains("Installed lints:"));
-        assert!(output.contains("Toolchain: nightly-2025-09-18"));
+        assert!(output.contains("Toolchain: nightly-2026-05-28"));
         assert!(output.contains("whitaker_suite"));
         assert!(output.contains("module_max_lines"));
     }
@@ -174,7 +174,7 @@ mod tests {
     #[test]
     fn format_human_marks_active_toolchain() {
         let lints = sample_lints();
-        let output = format_human(&lints, Some("nightly-2025-09-18"));
+        let output = format_human(&lints, Some("nightly-2026-05-28"));
 
         assert!(output.contains("(active)"));
     }
@@ -199,7 +199,7 @@ mod tests {
     #[test]
     fn format_json_includes_all_fields() {
         let lints = sample_lints();
-        let json = format_json(&lints, Some("nightly-2025-09-18"));
+        let json = format_json(&lints, Some("nightly-2026-05-28"));
 
         assert!(json.contains("\"channel\""));
         assert!(json.contains("\"active\": true"));

--- a/installer/src/pipeline_staging_tests.rs
+++ b/installer/src/pipeline_staging_tests.rs
@@ -36,7 +36,7 @@ impl StagingTestContext {
         Self {
             _temp_dir: temp_dir,
             target_dir,
-            toolchain: Toolchain::with_override(&workspace_root, "nightly-2025-09-18"),
+            toolchain: Toolchain::with_override(&workspace_root, "nightly-2026-05-28"),
             workspace_root,
             jobs: None,
             verbosity: 0,
@@ -127,7 +127,7 @@ fn stage_libraries_returns_correct_staging_path(staging_ctx: StagingTestContext)
     // toolchain and profile when scanner logic depends on path layout.
     let expected_path = staging_ctx
         .target_dir()
-        .join("nightly-2025-09-18")
+        .join("nightly-2026-05-28")
         .join("release");
     assert_eq!(
         staging_path, expected_path,
@@ -176,7 +176,7 @@ fn stage_libraries_stages_build_results(staging_ctx: StagingTestContext) {
     // The staged filename must preserve crate and toolchain identity so
     // multi-toolchain installs do not collide.
     let staged_filename = format!(
-        "{}whitaker_suite@nightly-2025-09-18{}",
+        "{}whitaker_suite@nightly-2026-05-28{}",
         library_prefix(),
         library_extension()
     );

--- a/installer/src/pipeline_tests.rs
+++ b/installer/src/pipeline_tests.rs
@@ -43,7 +43,7 @@ impl TestContext {
         Self {
             workspace_root: base.clone(),
             target_dir: base.join("target"),
-            toolchain: Toolchain::with_override(&base, "nightly-2025-09-18"),
+            toolchain: Toolchain::with_override(&base, "nightly-2026-05-28"),
             jobs: None,
             verbosity: 0,
             experimental: false,
@@ -99,7 +99,7 @@ fn test_ctx() -> TestContext {
 #[rstest]
 fn build_config_from_context_sets_toolchain(test_ctx: TestContext) {
     let config = build_config_from_context(&test_ctx.pipeline_context());
-    assert_eq!(config.toolchain.channel(), "nightly-2025-09-18");
+    assert_eq!(config.toolchain.channel(), "nightly-2026-05-28");
 }
 
 #[rstest]
@@ -226,7 +226,7 @@ fn pipeline_context_fields_are_accessible() {
 
     assert_eq!(context.workspace_root, Utf8Path::new("test_workspace"));
     assert_eq!(context.target_dir, Utf8Path::new("test_workspace/target"));
-    assert_eq!(context.toolchain.channel(), "nightly-2025-09-18");
+    assert_eq!(context.toolchain.channel(), "nightly-2026-05-28");
     assert_eq!(context.jobs, Some(4));
     assert_eq!(context.verbosity, 2);
     assert!(context.experimental);

--- a/installer/src/prebuilt.rs
+++ b/installer/src/prebuilt.rs
@@ -46,7 +46,7 @@ pub enum PrebuiltResult {
 pub struct PrebuiltConfig<'a> {
     /// The host target triple (e.g. `x86_64-unknown-linux-gnu`).
     pub target: &'a str,
-    /// The expected toolchain channel (e.g. `nightly-2025-09-18`).
+    /// The expected toolchain channel (e.g. `nightly-2026-05-28`).
     pub toolchain: &'a str,
     /// The directory where libraries are extracted and staged.
     pub destination_dir: &'a Utf8Path,

--- a/installer/src/prebuilt_path.rs
+++ b/installer/src/prebuilt_path.rs
@@ -56,11 +56,11 @@ mod tests {
         dirs.expect_whitaker_data_dir()
             .returning(|| Some(PathBuf::from("/home/test/.local/share/whitaker")));
 
-        let result = prebuilt_library_dir(&dirs, "nightly-2025-09-18", "x86_64-unknown-linux-gnu")
+        let result = prebuilt_library_dir(&dirs, "nightly-2026-05-28", "x86_64-unknown-linux-gnu")
             .expect("expected path construction to succeed");
         let expected = Utf8PathBuf::from("/home/test/.local/share/whitaker")
             .join("lints")
-            .join("nightly-2025-09-18")
+            .join("nightly-2026-05-28")
             .join("x86_64-unknown-linux-gnu")
             .join("lib");
 
@@ -77,7 +77,7 @@ mod tests {
         dirs.expect_whitaker_data_dir()
             .return_once(move || data_dir.clone());
 
-        let err = prebuilt_library_dir(&dirs, "nightly-2025-09-18", "x86_64-unknown-linux-gnu")
+        let err = prebuilt_library_dir(&dirs, "nightly-2026-05-28", "x86_64-unknown-linux-gnu")
             .expect_err("expected error");
         assert!(
             matches!(err, InstallerError::StagingFailed { ref reason } if reason.contains(expected_reason)),
@@ -98,7 +98,7 @@ mod tests {
             ])))
         });
 
-        let err = prebuilt_library_dir(&dirs, "nightly-2025-09-18", "x86_64-unknown-linux-gnu")
+        let err = prebuilt_library_dir(&dirs, "nightly-2026-05-28", "x86_64-unknown-linux-gnu")
             .expect_err("expected UTF-8 conversion error");
         assert!(
             matches!(err, InstallerError::StagingFailed { ref reason } if reason.contains("not valid UTF-8")),

--- a/installer/src/prebuilt_tests.rs
+++ b/installer/src/prebuilt_tests.rs
@@ -8,7 +8,7 @@ use rstest::rstest;
 
 const FAKE_ARCHIVE: &[u8] = b"fake archive content";
 const TARGET: &str = "x86_64-unknown-linux-gnu";
-const TOOLCHAIN: &str = "nightly-2025-09-18";
+const TOOLCHAIN: &str = "nightly-2026-05-28";
 
 fn base_config(destination_dir: &Utf8Path) -> PrebuiltConfig<'_> {
     PrebuiltConfig {

--- a/installer/src/scanner.rs
+++ b/installer/src/scanner.rs
@@ -143,11 +143,11 @@ fn scan_toolchain_release(
 /// ```
 /// use whitaker_installer::scanner::parse_library_filename;
 ///
-/// let result = parse_library_filename("libmodule_max_lines@nightly-2025-09-18.so");
+/// let result = parse_library_filename("libmodule_max_lines@nightly-2026-05-28.so");
 /// assert!(result.is_some());
 /// let (crate_name, toolchain) = result.expect("valid library filename");
 /// assert_eq!(crate_name.as_str(), "module_max_lines");
-/// assert_eq!(toolchain, "nightly-2025-09-18");
+/// assert_eq!(toolchain, "nightly-2026-05-28");
 /// ```
 #[must_use]
 pub fn parse_library_filename(filename: &str) -> Option<(CrateName, String)> {
@@ -256,14 +256,14 @@ mod tests {
 
     #[rstest]
     #[case::standard_linux(
-        "libmodule_max_lines@nightly-2025-09-18.so",
+        "libmodule_max_lines@nightly-2026-05-28.so",
         "module_max_lines",
-        "nightly-2025-09-18"
+        "nightly-2026-05-28"
     )]
     #[case::suite(
-        "libwhitaker_suite@nightly-2025-09-18.so",
+        "libwhitaker_suite@nightly-2026-05-28.so",
         "whitaker_suite",
-        "nightly-2025-09-18"
+        "nightly-2026-05-28"
     )]
     #[case::stable_toolchain(
         "libno_expect_outside_tests@stable-1.80.0.so",
@@ -287,10 +287,10 @@ mod tests {
 
     #[rstest]
     #[case::no_at_sign("libmodule_max_lines.so")]
-    #[case::empty_crate("lib@nightly-2025-09-18.so")]
+    #[case::empty_crate("lib@nightly-2026-05-28.so")]
     #[case::empty_toolchain("libmodule_max_lines@.so")]
-    #[case::wrong_prefix("module_max_lines@nightly-2025-09-18.so")]
-    #[case::wrong_extension("libmodule_max_lines@nightly-2025-09-18.dll")]
+    #[case::wrong_prefix("module_max_lines@nightly-2026-05-28.so")]
+    #[case::wrong_extension("libmodule_max_lines@nightly-2026-05-28.dll")]
     #[case::random_file("readme.txt")]
     fn parse_library_filename_invalid(#[case] filename: &str) {
         skip_unless_linux!();
@@ -378,7 +378,7 @@ mod tests {
         let target_dir = Utf8Path::from_path(temp.path()).expect("non-UTF8 path");
 
         // Create toolchain directory structure
-        let toolchain = "nightly-2025-09-18";
+        let toolchain = "nightly-2026-05-28";
         let release_dir = target_dir.join(toolchain).join("release");
         std::fs::create_dir_all(&release_dir).expect("failed to create dirs");
 

--- a/installer/src/staged_suite.rs
+++ b/installer/src/staged_suite.rs
@@ -96,7 +96,7 @@ mod tests {
     }
 
     fn test_toolchain() -> Toolchain {
-        Toolchain::with_override(Utf8Path::new("."), "nightly-2025-09-18")
+        Toolchain::with_override(Utf8Path::new("."), "nightly-2026-05-28")
     }
 
     fn utf8_temp_dir(temp_dir: &TempDir) -> Utf8PathBuf {

--- a/installer/src/stager.rs
+++ b/installer/src/stager.rs
@@ -139,11 +139,11 @@ mod tests {
 
     #[test]
     fn staged_filename_includes_toolchain() {
-        let stager = Stager::new(Utf8PathBuf::from("/tmp/test"), "nightly-2025-09-18");
+        let stager = Stager::new(Utf8PathBuf::from("/tmp/test"), "nightly-2026-05-28");
         let crate_name = CrateName::from("module_max_lines");
         let filename = stager.staged_filename(&crate_name);
 
-        assert!(filename.contains("nightly-2025-09-18"));
+        assert!(filename.contains("nightly-2026-05-28"));
         assert!(filename.contains("module_max_lines"));
     }
 
@@ -151,13 +151,13 @@ mod tests {
     fn staging_path_includes_toolchain_and_release() {
         let stager = Stager::new(
             Utf8PathBuf::from("/home/user/.local/share/dylint/lib"),
-            "nightly-2025-09-18",
+            "nightly-2026-05-28",
         );
         let path = stager.staging_path();
 
         // Use ends_with for platform-independent path checking (compares components,
         // not strings, so it works with both / and \ separators)
-        assert!(path.ends_with("nightly-2025-09-18/release"));
+        assert!(path.ends_with("nightly-2026-05-28/release"));
         assert!(path.as_str().contains("dylint"));
         assert!(path.as_str().contains("lib"));
     }

--- a/installer/src/test_utils.rs
+++ b/installer/src/test_utils.rs
@@ -71,6 +71,26 @@ pub fn success_output() -> Output {
     }
 }
 
+/// Creates a successful command `Output` with the given stdout text.
+///
+/// # Examples
+///
+/// ```
+/// use whitaker_installer::test_utils::stdout_output;
+///
+/// let output = stdout_output("cargo-dylint 1.2.3");
+/// assert!(output.status.success());
+/// assert_eq!(output.stdout, b"cargo-dylint 1.2.3");
+/// assert!(output.stderr.is_empty());
+/// ```
+pub fn stdout_output(stdout: impl AsRef<str>) -> Output {
+    Output {
+        status: exit_status(0),
+        stdout: stdout.as_ref().as_bytes().to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
 /// Creates a failed command `Output` with the given stderr message.
 ///
 /// # Examples

--- a/installer/src/test_utils/dependency_binary_helpers.rs
+++ b/installer/src/test_utils/dependency_binary_helpers.rs
@@ -12,7 +12,7 @@ use crate::error::Result;
 use crate::installer_packaging::TargetTriple;
 #[cfg(any(test, feature = "test-support"))]
 use crate::test_support::env_test_guard;
-use crate::test_utils::{ExpectedCall, failure_output, success_output};
+use crate::test_utils::{ExpectedCall, failure_output, stdout_output, success_output};
 #[cfg(any(test, feature = "test-support"))]
 use std::fs;
 #[cfg(all(any(test, feature = "test-support"), unix))]
@@ -189,32 +189,69 @@ fn cargo_source_install(
     }
 }
 
-fn dependency_version(tool: &str) -> &'static str {
+/// Returns the manifest-pinned version for a dependency tool.
+///
+/// # Panics
+///
+/// Panics when the manifest cannot be parsed or the tool is unknown.
+pub fn dependency_version(tool: &str) -> &'static str {
     find_dependency_binary(tool)
         .expect("dependency manifest should parse")
         .map(|dependency| dependency.version())
         .unwrap_or_else(|| panic!("unexpected tool: {tool}"))
 }
 
+/// Successful `cargo dylint --version` output reporting the manifest version.
+pub fn cargo_dylint_version_output() -> Output {
+    stdout_output(format!(
+        "cargo-dylint {}\n",
+        dependency_version("cargo-dylint")
+    ))
+}
+
+/// Expected `cargo install --list` call reporting the manifest-pinned
+/// `dylint-link` version.
+pub fn dylint_link_install_list_check() -> ExpectedCall {
+    dylint_link_install_list_check_with_version(dependency_version("dylint-link"))
+}
+
+/// Expected `cargo install --list` call reporting the given `dylint-link`
+/// version.
+pub fn dylint_link_install_list_check_with_version(version: &str) -> ExpectedCall {
+    ExpectedCall {
+        cmd: "cargo",
+        args: vec!["install", "--list"],
+        result: Ok(stdout_output(format!(
+            "dylint-link v{version}:\n    dylint-link\n"
+        ))),
+    }
+}
+
 /// Creates an expected call for verifying repository installation.
 pub fn repository_verification_call(tool: &str, verification_fails: bool) -> Option<ExpectedCall> {
-    let result = if verification_fails {
-        Ok(failure_output("still missing"))
-    } else {
-        Ok(success_output())
-    };
     match tool {
         "cargo-dylint" => Some(ExpectedCall {
             cmd: "cargo",
             args: vec!["dylint", "--version"],
-            result,
+            result: if verification_fails {
+                Ok(failure_output("still missing"))
+            } else {
+                Ok(cargo_dylint_version_output())
+            },
         }),
-        "dylint-link" => None,
+        // Successful verification consults Cargo's installed-binary registry
+        // once the PATH existence probe passes. A failing verification is
+        // modelled as the binary being absent from PATH, which short-circuits
+        // before the executor is consulted.
+        "dylint-link" => (!verification_fails).then(dylint_link_install_list_check),
         other => panic!("unexpected tool: {other}"),
     }
 }
 
 /// Returns the expected verification call for a given tool.
+///
+/// Cargo-fallback scenarios in the behaviour suite model `dylint-link` as
+/// absent from PATH, so its verification never reaches the executor there.
 fn tool_verification_check(tool: &str) -> Option<ExpectedCall> {
     match tool {
         "cargo-dylint" => Some(cargo_dylint_check()),
@@ -384,7 +421,7 @@ pub fn cargo_dylint_check() -> ExpectedCall {
     ExpectedCall {
         cmd: "cargo",
         args: vec!["dylint", "--version"],
-        result: Ok(success_output()),
+        result: Ok(cargo_dylint_version_output()),
     }
 }
 

--- a/installer/src/test_utils/dependency_binary_helpers_tests.rs
+++ b/installer/src/test_utils/dependency_binary_helpers_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for dependency binary helper fixtures and expected call builders.
 
 use crate::test_utils::dependency_binary_helpers::{
-    ExpectedCallConfig, expected_calls, repository_verification_call,
+    ExpectedCallConfig, dependency_version, expected_calls, repository_verification_call,
 };
 
 #[test]
@@ -14,12 +14,34 @@ fn repository_verification_call_returns_probe_for_cargo_dylint() {
 
     assert_eq!(call.cmd, "cargo");
     assert_eq!(call.args, vec!["dylint", "--version"]);
-    assert!(call.result.is_ok());
+    let output = call.result.expect("verification probe should succeed");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(
+        stdout.contains(dependency_version("cargo-dylint")),
+        "expected stdout to report the manifest version, got {stdout:?}"
+    );
 }
 
 #[test]
-fn repository_verification_call_skips_dylint_link_version_probe() {
-    assert!(repository_verification_call("dylint-link", false).is_none());
+fn repository_verification_call_consults_install_list_for_dylint_link() {
+    let call = repository_verification_call("dylint-link", false)
+        .expect("successful dylint-link verification should query the install list");
+
+    assert_eq!(call.cmd, "cargo");
+    assert_eq!(call.args, vec!["install", "--list"]);
+    let output = call.result.expect("install list query should succeed");
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(
+        stdout.contains(&format!(
+            "dylint-link v{}:",
+            dependency_version("dylint-link")
+        )),
+        "expected stdout to list the manifest version, got {stdout:?}"
+    );
+}
+
+#[test]
+fn repository_verification_call_skips_executor_for_failed_dylint_link() {
     assert!(repository_verification_call("dylint-link", true).is_none());
 }
 
@@ -44,7 +66,7 @@ fn expected_calls_include_repository_probe_for_cargo_dylint() {
 }
 
 #[test]
-fn expected_calls_skip_repository_probe_for_dylint_link() {
+fn expected_calls_include_install_list_probe_for_dylint_link() {
     let calls = expected_calls(
         "dylint-link",
         ExpectedCallConfig {
@@ -58,7 +80,9 @@ fn expected_calls_skip_repository_probe_for_dylint_link() {
         },
     );
 
-    assert_eq!(calls.len(), 1);
+    assert_eq!(calls.len(), 2);
     assert_eq!(calls[0].cmd, "cargo");
     assert_eq!(calls[0].args, vec!["binstall", "--version"]);
+    assert_eq!(calls[1].cmd, "cargo");
+    assert_eq!(calls[1].args, vec!["install", "--list"]);
 }

--- a/installer/src/tests.rs
+++ b/installer/src/tests.rs
@@ -12,7 +12,8 @@ use whitaker_installer::deps::DependencyInstallOptions;
 use whitaker_installer::dirs::BaseDirs;
 use whitaker_installer::installer_packaging::TargetTriple;
 use whitaker_installer::test_utils::dependency_binary_helpers::{
-    AlwaysNotFoundRepositoryInstaller, with_fake_binary_on_path,
+    AlwaysNotFoundRepositoryInstaller, cargo_dylint_check, dylint_link_install_list_check,
+    with_fake_binary_on_path,
 };
 use whitaker_installer::test_utils::*;
 
@@ -111,11 +112,8 @@ fn resolve_requested_crates_rejects_unknown_lints() {
 #[rstest]
 fn ensure_dylint_tools_skips_install_when_installed(test_base_dirs: TestBaseDirs) {
     with_fake_binary_on_path("dylint-link", || {
-        let executor = StubExecutor::new(vec![ExpectedCall {
-            cmd: "cargo",
-            args: vec!["dylint", "--version"],
-            result: Ok(success_output()),
-        }]);
+        let executor =
+            StubExecutor::new(vec![cargo_dylint_check(), dylint_link_install_list_check()]);
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
 
         let mut stderr = Vec::new();
@@ -148,6 +146,7 @@ fn ensure_dylint_tools_installs_missing_tools(
                 args: vec!["dylint", "--version"],
                 result: Ok(failure_output("missing cargo-dylint")),
             },
+            dylint_link_install_list_check(),
             ExpectedCall {
                 cmd: "cargo",
                 args: vec!["binstall", "--version"],
@@ -158,11 +157,7 @@ fn ensure_dylint_tools_installs_missing_tools(
                 args: vec!["install", "--locked", "--version", "6.0.1", "cargo-dylint"],
                 result: Ok(success_output()),
             },
-            ExpectedCall {
-                cmd: "cargo",
-                args: vec!["dylint", "--version"],
-                result: Ok(success_output()),
-            },
+            cargo_dylint_check(),
         ]);
         let repository_installer = AlwaysNotFoundRepositoryInstaller;
 
@@ -200,6 +195,7 @@ fn ensure_dylint_tools_propagates_install_failures(test_base_dirs: TestBaseDirs)
                 args: vec!["dylint", "--version"],
                 result: Ok(failure_output("missing cargo-dylint")),
             },
+            dylint_link_install_list_check(),
             ExpectedCall {
                 cmd: "cargo",
                 args: vec!["binstall", "--version"],

--- a/installer/src/tests/fast_path.rs
+++ b/installer/src/tests/fast_path.rs
@@ -37,7 +37,7 @@ fn fast_path_fixture() -> FastPathFixture {
             bin_dir: Some("/tmp/bin".into()),
             data_dir: Some("/tmp".into()),
         },
-        toolchain: Toolchain::with_override(Utf8Path::new("."), "nightly-2025-09-18"),
+        toolchain: Toolchain::with_override(Utf8Path::new("."), "nightly-2026-05-28"),
         target_dir: Utf8PathBuf::from("/tmp/target"),
         requested_crates: vec![],
     }
@@ -61,7 +61,7 @@ fn fast_path_context_holds_supplied_values(fast_path_fixture: FastPathFixture) {
 
     assert!(std::ptr::eq(ctx.args, &fast_path_fixture.args));
     assert_eq!(ctx.dirs.home_dir(), Some(PathBuf::from("/tmp")));
-    assert_eq!(ctx.toolchain.channel(), "nightly-2025-09-18");
+    assert_eq!(ctx.toolchain.channel(), "nightly-2026-05-28");
     assert_eq!(ctx.target_dir, &Utf8PathBuf::from("/tmp/target"));
     assert!(ctx.requested_crates.is_empty());
 }

--- a/installer/src/toolchain.rs
+++ b/installer/src/toolchain.rs
@@ -229,10 +229,10 @@ impl Toolchain {
 ///
 /// let contents = r#"
 /// [toolchain]
-/// channel = "nightly-2025-09-18"
+/// channel = "nightly-2026-05-28"
 /// "#;
 /// let channel = parse_toolchain_channel(contents).unwrap();
-/// assert_eq!(channel, "nightly-2025-09-18");
+/// assert_eq!(channel, "nightly-2026-05-28");
 /// ```
 ///
 /// # Errors

--- a/installer/src/toolchain/tests/failure_mocks.rs
+++ b/installer/src/toolchain/tests/failure_mocks.rs
@@ -29,12 +29,12 @@ pub(super) struct FailureSetup<'a> {
     pub(super) additional_components: &'a [&'a str],
 }
 
-/// A typed toolchain channel identifier (e.g. `"nightly-2025-09-18"`).
+/// A typed toolchain channel identifier (e.g. `"nightly-2026-05-28"`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct ToolchainChannel<'a>(pub(super) &'a str);
 
 impl<'a> ToolchainChannel<'a> {
-    /// Returns the inner channel string slice (e.g. `"nightly-2025-09-18"`).
+    /// Returns the inner channel string slice (e.g. `"nightly-2026-05-28"`).
     pub(super) fn as_str(self) -> &'a str {
         self.0
     }

--- a/installer/src/toolchain/tests/mod.rs
+++ b/installer/src/toolchain/tests/mod.rs
@@ -39,12 +39,12 @@ where
 fn parses_standard_toolchain_format() {
     let contents = r#"
 [toolchain]
-channel = "nightly-2025-09-18"
+channel = "nightly-2026-05-28"
 components = ["rust-src", "rustc-dev"]
 "#;
     let channel =
         parse_toolchain_channel(contents).expect("should parse standard toolchain format");
-    assert_eq!(channel, "nightly-2025-09-18");
+    assert_eq!(channel, "nightly-2026-05-28");
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn rejects_invalid_toolchain_file(#[case] contents: &str, #[case] expected_reaso
 }
 
 fn run_missing_toolchain_install_test(extra: &[&str], expected_components: &[&str]) {
-    let channel = "nightly-2025-09-18";
+    let channel = "nightly-2026-05-28";
     let toolchain = test_toolchain(channel);
     let mut runner = MockCommandRunner::new();
     let mut seq = mockall::Sequence::new();
@@ -111,7 +111,7 @@ fn ensure_installed_installs_missing_toolchain(
 }
 
 fn run_component_installation_test(extra: &[&str], expected: &[&str]) {
-    let channel = "nightly-2025-09-18";
+    let channel = "nightly-2026-05-28";
     let toolchain = test_toolchain(channel);
     let mut runner = MockCommandRunner::new();
     let mut seq = mockall::Sequence::new();
@@ -146,14 +146,14 @@ fn ensure_installed_adds_correct_components(
 
 #[test]
 fn install_components_with_additional_components_assembles_rustup_args_in_order() {
-    let toolchain = test_toolchain("nightly-2025-09-18");
+    let toolchain = test_toolchain("nightly-2026-05-28");
     let runner = CapturingCommandRunner::new(output_with_status(0));
 
     toolchain
         .install_components_with(&runner, &[CRANELIFT_COMPONENT])
         .expect("component installation should succeed");
 
-    let expected_args: Vec<String> = ["component", "add", "--toolchain", "nightly-2025-09-18"]
+    let expected_args: Vec<String> = ["component", "add", "--toolchain", "nightly-2026-05-28"]
         .into_iter()
         .chain(REQUIRED_COMPONENTS.iter().copied())
         .chain([CRANELIFT_COMPONENT])
@@ -167,7 +167,7 @@ fn install_components_with_additional_components_assembles_rustup_args_in_order(
 
 #[test]
 fn install_components_with_failure_reports_all_components() {
-    let toolchain = test_toolchain("nightly-2025-09-18");
+    let toolchain = test_toolchain("nightly-2026-05-28");
     let runner =
         CapturingCommandRunner::new(output_with_stderr(1, COMPONENT_INSTALL_FAILURE_MESSAGE));
     let expected_components = [REQUIRED_COMPONENTS, &[CRANELIFT_COMPONENT]].concat();
@@ -184,7 +184,7 @@ fn install_components_with_failure_reports_all_components() {
                 ref toolchain,
                 ref components,
                 ref message,
-            } if toolchain == "nightly-2025-09-18"
+            } if toolchain == "nightly-2026-05-28"
                 && components == &expected_component_list
                 && message == COMPONENT_INSTALL_FAILURE_MESSAGE
         ),
@@ -208,7 +208,7 @@ fn ensure_installed_reports_failure(
     #[case] failure: InstallFailure,
     #[case] additional_components: &[&str],
 ) {
-    let channel = ToolchainChannel("nightly-2025-09-18");
+    let channel = ToolchainChannel("nightly-2026-05-28");
     let toolchain = test_toolchain(channel.as_str());
     let setup = FailureSetup {
         failure,

--- a/installer/tests/behaviour_artefact.rs
+++ b/installer/tests/behaviour_artefact.rs
@@ -146,7 +146,7 @@ fn then_channel_rejected(world: &mut ArtefactWorld) {
 fn given_manifest_fields(world: &mut ArtefactWorld) {
     world.git_sha = Some(GitSha::try_from("abc1234").expect("valid sha"));
     world.toolchain =
-        Some(ToolchainChannel::try_from("nightly-2025-09-18").expect("valid channel"));
+        Some(ToolchainChannel::try_from("nightly-2026-05-28").expect("valid channel"));
     world.target = Some(TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid target"));
 }
 
@@ -172,7 +172,7 @@ fn then_manifest_accessible(world: &mut ArtefactWorld) {
     let m = world.manifest.as_ref().expect("manifest set");
     assert_eq!(m.git_sha().as_str(), "abc1234");
     assert_eq!(m.schema_version().as_u32(), 1);
-    assert_eq!(m.toolchain().as_str(), "nightly-2025-09-18");
+    assert_eq!(m.toolchain().as_str(), "nightly-2026-05-28");
     assert_eq!(m.target().as_str(), "x86_64-unknown-linux-gnu");
     assert_eq!(m.generated_at().as_str(), "2026-02-03T00:00:00Z");
     assert_eq!(m.files().len(), 1);

--- a/installer/tests/behaviour_artefact_packaging.rs
+++ b/installer/tests/behaviour_artefact_packaging.rs
@@ -156,7 +156,7 @@ fn given_packaged_artefact(world: &mut PackagingWorld) {
     fs::write(&path, b"fake library").expect("write");
     world.library_files.push(path);
     world.git_sha = Some(GitSha::try_from("abc1234").expect("valid"));
-    world.toolchain = Some(ToolchainChannel::try_from("nightly-2025-09-18").expect("valid"));
+    world.toolchain = Some(ToolchainChannel::try_from("nightly-2026-05-28").expect("valid"));
     world.target = Some(TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid"));
     run_packaging(world);
 }
@@ -212,7 +212,7 @@ fn then_valid_hex(world: &mut PackagingWorld) {
 fn given_no_files(world: &mut PackagingWorld) {
     world.library_files.clear();
     world.git_sha = Some(GitSha::try_from("abc1234").expect("valid"));
-    world.toolchain = Some(ToolchainChannel::try_from("nightly-2025-09-18").expect("valid"));
+    world.toolchain = Some(ToolchainChannel::try_from("nightly-2026-05-28").expect("valid"));
     world.target = Some(TargetTriple::try_from("x86_64-unknown-linux-gnu").expect("valid"));
 }
 

--- a/installer/tests/behaviour_core.rs
+++ b/installer/tests/behaviour_core.rs
@@ -228,7 +228,7 @@ fn given_standard_toolchain(toolchain_world: &ToolchainWorld) {
     toolchain_world.contents.replace(
         r#"
 [toolchain]
-channel = "nightly-2025-09-18"
+channel = "nightly-2026-05-28"
 components = ["rust-src"]
 "#
         .to_owned(),
@@ -239,7 +239,7 @@ components = ["rust-src"]
 fn given_top_level_channel(toolchain_world: &ToolchainWorld) {
     toolchain_world
         .contents
-        .replace(r#"channel = "nightly-2025-09-18""#.to_owned());
+        .replace(r#"channel = "nightly-2026-05-28""#.to_owned());
 }
 
 #[given("a rust-toolchain.toml without a channel")]
@@ -268,7 +268,7 @@ fn when_toolchain_detected(toolchain_world: &ToolchainWorld) {
 #[then("the channel is extracted correctly")]
 fn then_channel_extracted(toolchain_world: &ToolchainWorld) {
     let channel = toolchain_world.channel.borrow();
-    assert_eq!(*channel, Some("nightly-2025-09-18".to_owned()));
+    assert_eq!(*channel, Some("nightly-2026-05-28".to_owned()));
 }
 
 #[then("detection fails with an invalid file error")]

--- a/installer/tests/behaviour_prebuilt.rs
+++ b/installer/tests/behaviour_prebuilt.rs
@@ -15,7 +15,7 @@ use whitaker_installer::test_utils::{prebuilt_manifest_json, sha256_hex};
 
 const FAKE_ARCHIVE: &[u8] = b"fake archive content";
 const DEFAULT_TARGET: &str = "x86_64-unknown-linux-gnu";
-const DEFAULT_TOOLCHAIN: &str = "nightly-2025-09-18";
+const DEFAULT_TOOLCHAIN: &str = "nightly-2026-05-28";
 
 /// How the stub downloader should respond to `download_manifest`.
 enum ManifestBehaviour {

--- a/installer/tests/behaviour_staging.rs
+++ b/installer/tests/behaviour_staging.rs
@@ -40,7 +40,7 @@ fn given_built_library(staging_world: &StagingWorld) {
 fn given_staging_dir(staging_world: &StagingWorld) {
     staging_world
         .toolchain
-        .replace("nightly-2025-09-18".to_owned());
+        .replace("nightly-2026-05-28".to_owned());
 }
 
 #[when("the library is staged")]
@@ -62,7 +62,7 @@ fn when_library_staged(staging_world: &StagingWorld) {
 #[then("the staged filename includes the toolchain")]
 fn then_staged_includes_toolchain(staging_world: &StagingWorld) {
     let name = staging_world.staged_name.borrow();
-    assert!(name.contains("nightly-2025-09-18"));
+    assert!(name.contains("nightly-2026-05-28"));
     assert!(name.contains("module_max_lines"));
 }
 
@@ -114,7 +114,7 @@ mod staging_failure {
         let dir_path = temp_dir.path();
 
         // Create the nested staging path structure that Stager expects.
-        let staging_path = dir_path.join("nightly-2025-09-18").join("release");
+        let staging_path = dir_path.join("nightly-2026-05-28").join("release");
         fs::create_dir_all(&staging_path).expect("failed to create staging path");
 
         // Make the directory read-only (no write permission).
@@ -126,7 +126,7 @@ mod staging_failure {
 
         let utf8_path =
             Utf8PathBuf::try_from(dir_path.to_path_buf()).expect("temp dir path not UTF-8");
-        let stager = Stager::new(utf8_path, "nightly-2025-09-18");
+        let stager = Stager::new(utf8_path, "nightly-2026-05-28");
 
         staging_failure_world.stager.replace(Some(stager));
         staging_failure_world._temp_dir.replace(Some(temp_dir));

--- a/installer/tests/features/artefact_packaging.feature
+++ b/installer/tests/features/artefact_packaging.feature
@@ -5,7 +5,7 @@ Feature: Artefact packaging for rolling release
   Scenario: Package a single library file into a tar.zst archive
     Given a library file "libwhitaker_suite.so"
     And a git SHA "abc1234"
-    And a toolchain channel "nightly-2025-09-18"
+    And a toolchain channel "nightly-2026-05-28"
     And a target triple "x86_64-unknown-linux-gnu"
     When the artefact is packaged
     Then the archive exists with the expected ADR-001 filename
@@ -46,7 +46,7 @@ Feature: Artefact packaging for rolling release
   Scenario: Archive contains multiple library files
     Given library files "libfoo.so" and "libbar.so" and "libbaz.so"
     And a git SHA "abc1234"
-    And a toolchain channel "nightly-2025-09-18"
+    And a toolchain channel "nightly-2026-05-28"
     And a target triple "x86_64-unknown-linux-gnu"
     When the artefact is packaged
     Then the archive contains 3 library files
@@ -55,7 +55,7 @@ Feature: Artefact packaging for rolling release
   Scenario: Manifest files field lists all library basenames
     Given library files "libfoo.so" and "libbar.so"
     And a git SHA "abc1234"
-    And a toolchain channel "nightly-2025-09-18"
+    And a toolchain channel "nightly-2026-05-28"
     And a target triple "x86_64-unknown-linux-gnu"
     When the artefact is packaged
     And the manifest JSON is generated

--- a/installer/tests/features/artefact_policy.feature
+++ b/installer/tests/features/artefact_policy.feature
@@ -4,10 +4,10 @@ Feature: Artefact naming, manifest schema, and verification policy
 
   Scenario: Construct artefact name from valid components
     Given a git SHA "abc1234"
-    And a toolchain channel "nightly-2025-09-18"
+    And a toolchain channel "nightly-2026-05-28"
     And a target triple "x86_64-unknown-linux-gnu"
     When an artefact name is constructed
-    Then the filename is "whitaker-lints-abc1234-nightly-2025-09-18-x86_64-unknown-linux-gnu.tar.zst"
+    Then the filename is "whitaker-lints-abc1234-nightly-2026-05-28-x86_64-unknown-linux-gnu.tar.zst"
 
   Scenario: Reject unsupported target triple
     Given an invalid target triple "wasm32-unknown-unknown"

--- a/installer/tests/features/prebuilt_download.feature
+++ b/installer/tests/features/prebuilt_download.feature
@@ -32,7 +32,7 @@ Feature: Prebuilt artefact download and verification
 
   Scenario: Toolchain mismatch triggers fallback
     Given a valid manifest with toolchain "nightly-2025-01-01"
-    And the expected toolchain is "nightly-2025-09-18"
+    And the expected toolchain is "nightly-2026-05-28"
     When prebuilt download is attempted
     Then the prebuilt result is fallback
     And the fallback reason mentions "toolchain mismatch"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-09-18"
+channel = "nightly-2026-05-28"
 components = ["rustfmt", "clippy", "rustc-dev", "llvm-tools-preview", "rust-src"]

--- a/src/hir/tests.rs
+++ b/src/hir/tests.rs
@@ -17,11 +17,12 @@
 
 use super::{recover_user_editable_hir_span, span_recovery_frames};
 use rstest::{fixture, rstest};
-use rustc_data_structures::stable_hasher::HashingControls;
-use rustc_span::def_id::{DefId, DefPathHash, LocalDefId};
+use rustc_data_structures::stable_hash::{
+    RawDefId, RawDefPathHash, RawSpan, StableHashControls, StableHashCtxt, StableHasher,
+};
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{ExpnData, ExpnKind, LocalExpnId, MacroKind, Transparency};
-use rustc_span::{BytePos, DUMMY_SP, Span, SpanData, StableSourceFileId, SyntaxContext, sym};
+use rustc_span::{BytePos, DUMMY_SP, Span, SyntaxContext, sym};
 use whitaker_common::SpanRecoveryFrame;
 
 fn test_span(lo: u32, hi: u32) -> Span {
@@ -31,33 +32,18 @@ fn test_span(lo: u32, hi: u32) -> Span {
 #[derive(Clone, Copy)]
 struct TestHashStableContext;
 
-impl rustc_span::HashStableContext for TestHashStableContext {
-    fn def_path_hash(&self, _def_id: DefId) -> DefPathHash {
-        DefPathHash::default()
+impl StableHashCtxt for TestHashStableContext {
+    fn stable_hash_span(&mut self, _span: RawSpan, _hasher: &mut StableHasher) {}
+
+    fn def_path_hash(&self, _def_id: RawDefId) -> RawDefPathHash {
+        RawDefPathHash([0; 16])
     }
 
-    fn hash_spans(&self) -> bool {
-        false
+    fn stable_hash_controls(&self) -> StableHashControls {
+        StableHashControls { hash_spans: false }
     }
 
-    fn unstable_opts_incremental_ignore_spans(&self) -> bool {
-        true
-    }
-
-    fn def_span(&self, _def_id: LocalDefId) -> Span {
-        DUMMY_SP
-    }
-
-    fn span_data_to_lines_and_cols(
-        &mut self,
-        _span: &SpanData,
-    ) -> Option<(StableSourceFileId, usize, BytePos, usize, BytePos)> {
-        None
-    }
-
-    fn hashing_controls(&self) -> HashingControls {
-        HashingControls { hash_spans: false }
-    }
+    fn assert_default_stable_hash_controls(&self, _msg: &str) {}
 }
 
 fn expanded_span(span: Span, call_site: Span) -> Span {


### PR DESCRIPTION
## Summary

Migrates the pinned toolchain from nightly-2025-09-18 to nightly-2026-05-28
(rustc 1.98.0-nightly, 2026-05-27).

> **BLOCKED on #283 merging first.** The dependency binaries in the rolling
> release must be cargo-dylint/dylint-link 6.0.1 before the pin flips:
> `dylint_driver` ≤ 5.0.0 does not compile on this nightly
> (`ParseSess::env_depinfo`/`file_depinfo` removed upstream), so flipping
> the pin while consumers still receive 4.1.0 would turn estate CI red.

## API breaks accommodated (commit 1)

Five compiler API changes, fixed mechanically across 15 files
(+48/−58 lines):

1. The closure form of `LintContext::span_lint` was removed — lint emission
   moves to `emit_span_lint` + `rustc_errors::DiagDecorator` (nine call
   sites, eight lint crates); the `rustc_lint` shim gains an `errors`
   re-export module so lint crates need no direct `rustc_errors` dependency.
2. `ty::TypingEnv` field construction and the `normalize_erasing_regions`
   signature changed — the two affected sites use `cx.typing_env()` and
   `ty::Unnormalized::new_wip`.
3. `format_args!` now lowers to `<core::fmt::Arguments>::new` — the panic
   detector matches `sym::new` in place of the removed `sym::new_v1`/
   `sym::new_v1_formatted` (receiver-type lang-item guard unchanged).
4. `hir::AttrPath::segments` is now `Box<[Symbol]>` — test fixtures intern
   symbols.
5. `rustc_span::HashStableContext` was replaced by
   `rustc_data_structures::stable_hash::StableHashCtxt` — the test-only
   hash context is rewritten.

Note: commit 1 intentionally does not build on the old pin (the replacement
APIs do not exist there); it is split from the flip purely for review
focus. Commit 2 flips `rust-toolchain.toml` and sweeps the old channel
literal from documentation prose and installer doc examples/test fixtures
(historical plans under `docs/execplans/` are left untouched).

## Validation

- `env -u WHITAKER make check-fmt lint test markdownlint` under the new
  nightly — all clean; **1453/1453 tests pass with zero UI-fixture
  blessing** (diagnostic wording did not drift across the jump).
- End-to-end: cargo-dylint 6.0.1 builds its driver under nightly-2026-05-28
  and the rebuilt `whitaker_suite` fires `no_unwrap_or_else_panic` and
  `no_std_fs_operations` correctly on a toy crate.
- Failures in the three CI-excluded lint crates
  (`function_attrs_follow_docs`, `no_expect_outside_tests` example
  harness) reproduce identically on the old pin — pre-existing, tracked
  separately (see #284).

## Estate propagation

Consumer repositories need **no changes**. On the next CI run,
whitaker-installer pulls the suite clone, reads the new pin, installs the
nightly via rustup, and downloads the rolling-release artefacts named for
the new toolchain. Installers that run in the window between this merge and
the rolling release completing fall back to a local suite build (slow but
correct). Consumer CI caches keyed on the installer version only cache the
installer binary, so no stale-library exposure exists there.

## Machine-local clean-up (operators)

- Re-run `whitaker-installer` so the `~/.local/bin/whitaker` wrapper points
  at the new staged toolchain directory (it embeds the toolchain path and
  stays stale until regenerated).
- Upgrade local tools: `cargo install --locked cargo-dylint dylint-link
  --version 6.0.1` (building cargo-dylint 6.0.1 from source needs
  rustc ≥ 1.91).
- Prune old nightlies (`rustup toolchain uninstall nightly-2025-09-18`,
  ~2.3 GB each) and stale staged libraries under
  `~/.local/share/dylint/lib/<old-toolchain>/` — nothing cleans these
  automatically.
- axinite can drop its `whitaker-installer --toolchain nightly-2025-12-10`
  override: rustc 1.98 satisfies the wasmtime ≥ 1.93 requirement.
