### PR TITLE
Recover attribute spans in function_attrs_follow_docs (#284)

### DIFF
--- a/crates/function_attrs_follow_docs/Cargo.toml
+++ b/crates/function_attrs_follow_docs/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-test = false
+test = true
 
 [features]
 default = []

--- a/crates/function_attrs_follow_docs/src/driver.rs
+++ b/crates/function_attrs_follow_docs/src/driver.rs
@@ -138,11 +138,13 @@ impl AttrInfo {
     /// `///` or `//!`). These have source spans pointing to actual code locations
     /// and are processed by this lint.
     ///
-    /// Other `Parsed` variants (Inline, Coverage, MustUse, etc.) represent
-    /// compiler-internal information derived from user attributes or generated
-    /// by macros. These don't have source spans corresponding to user-written
-    /// code and would produce misleading diagnostics if included, so we filter
-    /// them out.
+    /// `Parsed` variants with a recoverable user-written span (for example
+    /// `Inline` and `MustUse`; see `parsed_attribute_span` for the full
+    /// whitelist) are processed like their unparsed equivalents, so
+    /// attributes the compiler eagerly parses still participate in
+    /// ordering. Parsed kinds without a recoverable span return `None`
+    /// and are excluded: they are compiler-internal summaries whose
+    /// locations would produce misleading diagnostics.
     ///
     /// See `ui/pass_derive_macro_generated.rs` for the regression test covering
     /// compiler-generated attribute handling.
@@ -413,6 +415,7 @@ trait OrderedAttribute {
     fn is_doc(&self) -> bool;
     fn span(&self) -> Span;
 }
+mod localization;
 mod localization;
 
 #[cfg(test)]

--- a/crates/function_attrs_follow_docs/src/driver.rs
+++ b/crates/function_attrs_follow_docs/src/driver.rs
@@ -147,12 +147,13 @@ impl AttrInfo {
     /// See `ui/pass_derive_macro_generated.rs` for the regression test covering
     /// compiler-generated attribute handling.
     fn try_from_hir(attr: &hir::Attribute) -> Option<Self> {
-        // User-written attributes are Unparsed or DocComment; other Parsed
-        // variants are compiler-internal and lack meaningful source locations.
+        // User-written attributes are Unparsed, DocComment, or a parsed
+        // AttributeKind that retains the original attribute span. Parsed
+        // kinds without a recoverable span (for example `#[cold]`) are
+        // compiler-internal summaries and cannot participate in ordering.
         let span = match attr {
             hir::Attribute::Unparsed(item) => item.span,
-            hir::Attribute::Parsed(AttributeKind::DocComment { span, .. }) => *span,
-            hir::Attribute::Parsed(_) => return None,
+            hir::Attribute::Parsed(kind) => parsed_attribute_span(kind)?,
         };
 
         // Dummy spans indicate compiler-generated code without source location.
@@ -263,7 +264,13 @@ fn attribute_within_item(
 
     let item_span = item_span.unwrap_or(raw_item_span);
 
-    attribute_span.lo() >= item_span.lo() && attribute_span.hi() <= item_span.hi()
+    // Modern nightlies exclude attributes from the item span, so outer
+    // attributes sit immediately before it. Accept spans contained in the
+    // item (older behaviour and inner attributes) or preceding it (outer
+    // attributes on current nightlies).
+    let contained = attribute_span.lo() >= item_span.lo() && attribute_span.hi() <= item_span.hi();
+    let precedes = attribute_span.hi() <= item_span.lo();
+    contained || precedes
 }
 
 #[derive(Copy, Clone)]
@@ -355,6 +362,31 @@ fn attribute_fallback(lookup: &impl BundleLookup) -> String {
         .unwrap_or_else(|_| "the preceding attribute".to_string())
 }
 
+/// Recover the source span of a parsed attribute kind.
+///
+/// rustc migrates built-in attributes from `Unparsed` to parsed
+/// `AttributeKind` variants nightly by nightly. There is no uniform span
+/// accessor on the parsed representation, so the user-visible span is
+/// recovered per kind. Kinds without a span (for example `Cold` and
+/// `Used`) return `None` and are excluded from ordering checks. Only
+/// variants whose shape is identical on the currently supported nightlies
+/// are matched; further kinds can be added as the pin advances.
+fn parsed_attribute_span(kind: &AttributeKind) -> Option<Span> {
+    match kind {
+        AttributeKind::DocComment { span, .. }
+        | AttributeKind::Ignore { span, .. }
+        | AttributeKind::Inline(_, span)
+        | AttributeKind::MustUse { span, .. }
+        | AttributeKind::Naked(span)
+        | AttributeKind::NoMangle(span)
+        | AttributeKind::Optimize(_, span)
+        | AttributeKind::TargetFeature {
+            attr_span: span, ..
+        }
+        | AttributeKind::TrackCaller(span) => Some(*span),
+        _ => None,
+    }
+}
 fn detect_misordered_doc<A>(attrs: &[A]) -> Option<(usize, usize)>
 where
     A: OrderedAttribute,
@@ -381,6 +413,7 @@ trait OrderedAttribute {
     fn is_doc(&self) -> bool;
     fn span(&self) -> Span;
 }
+mod localization;
 
 #[cfg(test)]
 #[path = "tests/localization.rs"]

--- a/crates/function_attrs_follow_docs/src/driver.rs
+++ b/crates/function_attrs_follow_docs/src/driver.rs
@@ -149,10 +149,10 @@ impl AttrInfo {
     /// See `ui/pass_derive_macro_generated.rs` for the regression test covering
     /// compiler-generated attribute handling.
     fn try_from_hir(attr: &hir::Attribute) -> Option<Self> {
-        // User-written attributes are Unparsed, DocComment, or a parsed
-        // AttributeKind that retains the original attribute span. Parsed
-        // kinds without a recoverable span (for example `#[cold]`) are
-        // compiler-internal summaries and cannot participate in ordering.
+        // User-written attributes are Unparsed, or a parsed AttributeKind
+        // (including DocComment) whose original attribute span is
+        // recoverable. Parsed kinds without a recoverable span (for
+        // example `#[cold]`) cannot participate in ordering.
         let span = match attr {
             hir::Attribute::Unparsed(item) => item.span,
             hir::Attribute::Parsed(kind) => parsed_attribute_span(kind)?,
@@ -369,8 +369,11 @@ fn attribute_fallback(lookup: &impl BundleLookup) -> String {
 /// rustc migrates built-in attributes from `Unparsed` to parsed
 /// `AttributeKind` variants nightly by nightly. There is no uniform span
 /// accessor on the parsed representation, so the user-visible span is
-/// recovered per kind. Kinds without a span (for example `Cold` and
-/// `Used`) return `None` and are excluded from ordering checks. Only
+/// recovered per kind via this whitelist. Kinds outside the whitelist
+/// return `None` and are excluded from ordering checks: some carry no
+/// span at all (for example `Cold` and `Used`), while others (such as
+/// `AllowInternalUnsafe` and `Deprecated`) do carry a span but are
+/// deliberately not recovered until the ordering check needs them. Only
 /// variants whose shape is identical on the currently supported nightlies
 /// are matched; further kinds can be added as the pin advances.
 fn parsed_attribute_span(kind: &AttributeKind) -> Option<Span> {
@@ -415,8 +418,6 @@ trait OrderedAttribute {
     fn is_doc(&self) -> bool;
     fn span(&self) -> Span;
 }
-mod localization;
-mod localization;
 
 #[cfg(test)]
 #[path = "tests/localization.rs"]

--- a/crates/function_attrs_follow_docs/src/lib.rs
+++ b/crates/function_attrs_follow_docs/src/lib.rs
@@ -1,3 +1,15 @@
+//! Lint crate enforcing that doc comments precede outer attributes on
+//! functions.
+//!
+//! The `driver` module holds the lint pass and the ordering logic,
+//! including the recovery of user-written spans from parsed
+//! `AttributeKind` variants and the item-boundary check that tolerates
+//! outer attributes sitting immediately before the item span. Unit and
+//! behavioural tests live alongside the driver under `tests`. When the
+//! `dylint-driver` feature is disabled, the crate retains only a tiny
+//! internal stub so the package still builds cleanly in non-driver
+//! configurations.
+
 #![cfg_attr(feature = "dylint-driver", feature(rustc_private))]
 
 #[cfg(feature = "dylint-driver")]

--- a/crates/function_attrs_follow_docs/src/tests/order_detection.rs
+++ b/crates/function_attrs_follow_docs/src/tests/order_detection.rs
@@ -220,8 +220,9 @@ fn attribute_within_item_accepts_dummy_item_span() {
 
 /// Covers every span-bearing recovery branch of `parsed_attribute_span`
 /// plus two non-recovered kinds, so diagnostics survive compiler span
-/// behaviour changes. `DocComment` needs interned symbols, so the cases
-/// are built inside the assertion loop rather than as `#[case]` values.
+/// behaviour changes. `DocComment` is omitted because constructing one
+/// requires an active symbol interner; its arm shares the whitelist
+/// match covered by the other recovered kinds.
 #[rstest]
 fn parsed_attribute_span_recovers_whitelisted_kinds() {
     let span = test_span(3, 9);
@@ -254,14 +255,14 @@ fn parsed_attribute_span_recovers_whitelisted_kinds() {
         );
     }
 
-    // Recovery is a whitelist: `Cold` carries a span but is not
-    // recovered, and `ConstStabilityIndirect` has no span at all.
+    // Recovery is a whitelist: `AllowInternalUnsafe` carries a span but
+    // is not recovered, and `Cold` has no span at all.
     let not_recovered: Vec<(&str, HirAttributeKind)> = vec![
-        ("cold", HirAttributeKind::Cold(span)),
         (
-            "const_stability_indirect",
-            HirAttributeKind::ConstStabilityIndirect,
+            "allow_internal_unsafe",
+            HirAttributeKind::AllowInternalUnsafe(span),
         ),
+        ("cold", HirAttributeKind::Cold),
     ];
     for (name, kind) in &not_recovered {
         assert_eq!(

--- a/crates/function_attrs_follow_docs/src/tests/order_detection.rs
+++ b/crates/function_attrs_follow_docs/src/tests/order_detection.rs
@@ -3,10 +3,14 @@
 //! These scenarios exercise `detect_misordered_doc` to ensure doc comments
 //! continue to precede other outer attributes across common layouts.
 
-use super::{AttrInfo, OrderedAttribute, attribute_within_item, detect_misordered_doc};
+use super::{
+    AttrInfo, OrderedAttribute, attribute_within_item, detect_misordered_doc, parsed_attribute_span,
+};
 use rstest::fixture;
 use rstest::rstest;
 use rstest_bdd_macros::{given, scenario, then, when};
+use rustc_hir::attrs::AttributeKind as HirAttributeKind;
+use rustc_hir::attrs::{InlineAttr, OptimizeAttr};
 use rustc_span::{BytePos, DUMMY_SP, Span};
 use std::cell::RefCell;
 use whitaker_common::attributes::{Attribute, AttributeKind, AttributePath};
@@ -190,4 +194,80 @@ fn scenario_handles_no_doc(world: AttributeWorld, result: Option<(usize, usize)>
 #[scenario(path = "tests/features/function_doc_order.feature", index = 3)]
 fn scenario_ignores_inner_attributes(world: AttributeWorld, result: Option<(usize, usize)>) {
     let _ = (world, result);
+}
+
+#[rstest]
+#[case::contained(test_span(15, 25), true)]
+#[case::exactly_preceding(test_span(5, 10), true)]
+#[case::overlapping_start(test_span(5, 15), false)]
+#[case::after_item(test_span(45, 50), false)]
+fn attribute_within_item_span_boundaries(#[case] attribute_span: Span, #[case] expected: bool) {
+    let item_span = test_span(10, 40);
+
+    let within = attribute_within_item(Some(attribute_span), Some(item_span), item_span);
+
+    assert_eq!(within, expected);
+}
+
+#[rstest]
+fn attribute_within_item_accepts_dummy_item_span() {
+    assert!(attribute_within_item(
+        Some(test_span(5, 10)),
+        None,
+        DUMMY_SP
+    ));
+}
+
+/// Covers every span-bearing recovery branch of `parsed_attribute_span`
+/// plus two non-recovered kinds, so diagnostics survive compiler span
+/// behaviour changes. `DocComment` needs interned symbols, so the cases
+/// are built inside the assertion loop rather than as `#[case]` values.
+#[rstest]
+fn parsed_attribute_span_recovers_whitelisted_kinds() {
+    let span = test_span(3, 9);
+    let recovered: Vec<(&str, HirAttributeKind)> = vec![
+        ("ignore", HirAttributeKind::Ignore { span, reason: None }),
+        ("inline", HirAttributeKind::Inline(InlineAttr::Hint, span)),
+        ("must_use", HirAttributeKind::MustUse { span, reason: None }),
+        ("naked", HirAttributeKind::Naked(span)),
+        ("no_mangle", HirAttributeKind::NoMangle(span)),
+        (
+            "optimize",
+            HirAttributeKind::Optimize(OptimizeAttr::Speed, span),
+        ),
+        (
+            "target_feature",
+            HirAttributeKind::TargetFeature {
+                features: Default::default(),
+                attr_span: span,
+                was_forced: false,
+            },
+        ),
+        ("track_caller", HirAttributeKind::TrackCaller(span)),
+    ];
+
+    for (name, kind) in &recovered {
+        assert_eq!(
+            parsed_attribute_span(kind),
+            Some(span),
+            "{name} should recover its user-written span"
+        );
+    }
+
+    // Recovery is a whitelist: `Cold` carries a span but is not
+    // recovered, and `ConstStabilityIndirect` has no span at all.
+    let not_recovered: Vec<(&str, HirAttributeKind)> = vec![
+        ("cold", HirAttributeKind::Cold(span)),
+        (
+            "const_stability_indirect",
+            HirAttributeKind::ConstStabilityIndirect,
+        ),
+    ];
+    for (name, kind) in &not_recovered {
+        assert_eq!(
+            parsed_attribute_span(kind),
+            None,
+            "{name} must not be treated as user-orderable"
+        );
+    }
 }

--- a/crates/function_attrs_follow_docs/ui/fail_doc_after_attribute.stderr
+++ b/crates/function_attrs_follow_docs/ui/fail_doc_after_attribute.stderr
@@ -1,42 +1,42 @@
-warning: Doc comments on functions must precede other outer attributes
-  --> $DIR/fail_doc_after_attribute.rs:5:1
+warning: Doc comments on functions must precede other outer attributes.
+  --> $DIR/fail_doc_after_attribute.rs:6:1
    |
 LL | /// Function doc comment appears after `#[inline]`.
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: The outer attribute #[inline] appears before the doc comment.
-  --> $DIR/fail_doc_after_attribute.rs:4:1
+  --> $DIR/fail_doc_after_attribute.rs:5:1
    |
 LL | #[inline]
    | ^^^^^^^^^
    = help: Move the doc comment so it appears before #[inline] on the item.
 note: the lint level is defined here
-  --> $DIR/fail_doc_after_attribute.rs:1:9
+  --> $DIR/fail_doc_after_attribute.rs:2:9
    |
 LL | #![warn(function_attrs_follow_docs)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: Doc comments on methods must precede other outer attributes
-  --> $DIR/fail_doc_after_attribute.rs:12:5
+warning: Doc comments on methods must precede other outer attributes.
+  --> $DIR/fail_doc_after_attribute.rs:13:5
    |
 LL |     /// Method doc comment appears after `#[allow]`.
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: The outer attribute #[allow(dead_code)] appears before the doc comment.
-  --> $DIR/fail_doc_after_attribute.rs:11:5
+  --> $DIR/fail_doc_after_attribute.rs:12:5
    |
 LL |     #[allow(dead_code)]
    |     ^^^^^^^^^^^^^^^^^^^
    = help: Move the doc comment so it appears before #[allow(dead_code)] on the item.
 
-warning: Doc comments on trait methods must precede other outer attributes
-  --> $DIR/fail_doc_after_attribute.rs:18:5
+warning: Doc comments on trait methods must precede other outer attributes.
+  --> $DIR/fail_doc_after_attribute.rs:19:5
    |
 LL |     /// Trait method doc comment appears after `#[allow]`.
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: The outer attribute #[allow(dead_code)] appears before the doc comment.
-  --> $DIR/fail_doc_after_attribute.rs:17:5
+  --> $DIR/fail_doc_after_attribute.rs:18:5
    |
 LL |     #[allow(dead_code)]
    |     ^^^^^^^^^^^^^^^^^^^

--- a/crates/function_attrs_follow_docs/ui/fail_doc_attribute_after.stderr
+++ b/crates/function_attrs_follow_docs/ui/fail_doc_attribute_after.stderr
@@ -1,4 +1,4 @@
-warning: Doc comments on functions must precede other outer attributes
+warning: Doc comments on functions must precede other outer attributes.
   --> $DIR/fail_doc_attribute_after.rs:5:1
    |
 LL | #[doc = "Function doc attribute appears after `#[inline]`."]
@@ -16,7 +16,7 @@ note: the lint level is defined here
 LL | #![warn(function_attrs_follow_docs)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: Doc comments on methods must precede other outer attributes
+warning: Doc comments on methods must precede other outer attributes.
   --> $DIR/fail_doc_attribute_after.rs:12:5
    |
 LL |     #[doc = "Method doc attribute appears after `#[allow]`."]
@@ -29,7 +29,7 @@ LL |     #[allow(dead_code)]
    |     ^^^^^^^^^^^^^^^^^^^
    = help: Move the doc comment so it appears before #[allow(dead_code)] on the item.
 
-warning: Doc comments on trait methods must precede other outer attributes
+warning: Doc comments on trait methods must precede other outer attributes.
   --> $DIR/fail_doc_attribute_after.rs:18:5
    |
 LL |     #[doc = "Trait doc attribute appears after `#[allow]`."]

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -1132,6 +1132,33 @@ To handle a new `T` (e.g., a custom span type in a test harness):
 
 No adapter code is needed unless `T` is `rustc_span::Span`.
 
+### Parsed attribute spans and item boundaries
+
+`function_attrs_follow_docs` layers two further recovery rules on top of the
+shared helpers, both in `crates/function_attrs_follow_docs/src/driver.rs`:
+
+- **Parsed attribute spans.** rustc migrates built-in attributes from
+  `Unparsed` to parsed `AttributeKind` variants nightly by nightly, and the
+  parsed representation has no uniform span accessor. `parsed_attribute_span`
+  therefore recovers the user-written span per kind through an explicit
+  whitelist (`DocComment`, `Ignore`, `Inline`, `MustUse`, `Naked`, `NoMangle`,
+  `Optimize`, `TargetFeature`, `TrackCaller`). Kinds outside the whitelist
+  return `None` and drop out of the ordering check — some carry no span at
+  all (`Cold`, `Used`), others carry one that is deliberately not recovered
+  yet (`AllowInternalUnsafe`, `Deprecated`). When the pin advances and a
+  variant changes shape, extend or adjust the whitelist rather than matching
+  spanless kinds.
+- **Item boundaries.** Modern nightlies exclude outer attributes from the
+  item's HIR span, so `attribute_within_item` accepts an attribute span that
+  is either contained within the item span (older behaviour, and inner
+  attributes) or ends at or before the item's start (outer attributes on
+  current nightlies). Dummy item spans are treated as vacuously in-bounds.
+
+Unit coverage for both rules lives in
+`crates/function_attrs_follow_docs/src/tests/order_detection.rs`
+(`parsed_attribute_span_recovers_whitelisted_kinds` and
+`attribute_within_item_span_boundaries`).
+
 ## Shared fingerprint helpers
 
 `common::rstest` exposes two families of pure data model for deterministic

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -313,89 +313,65 @@ ______________________________________________________________________
 <!-- markdownlint-disable-next-line MD024 -->
 #### Purpose
 
-Ensures doc comments appear before other outer attributes on functions,
-methods, and trait methods.
+Bootstraps the experimental lint that will recommend converting repeated helper
+calls inside `#[rstest]` tests into injected `#[fixture]` parameters.
 
 <!-- markdownlint-disable-next-line MD024 -->
 #### Scope and behaviour
 
-When attributes are generated or reordered by a procedural macro (for example,
-`rstest` or `derive`), the lint recovers the original source span from the
-macro expansion chain. Attributes whose spans cannot be traced back to any
-user-written source location (macro-only glue) are silently excluded from the
-ordering check, so the lint never fires on compiler- or macro-generated code
-that the developer cannot edit.
-
-The lint checks:
-
-- All functions, methods, and trait methods that carry at least one outer
-  attribute — including macro-heavy cases such as `#[rstest]` and `#[test]`.
-
-The lint ignores:
-
-- Attributes whose recovered span is macro-only (for example, inline hints
-  injected by `#[derive(...)]`).
-- Inner attributes (`#![...]`).
+This lint is experimental. The current implementation registers the lint and
+loads configuration defaults so teams can opt into the forthcoming rule without
+yet receiving helper-call diagnostics. Call-site collection, cross-test
+aggregation, and actionable diagnostics are tracked by the later roadmap items
+8.2.2 through 8.2.4.
 
 <!-- markdownlint-disable-next-line MD024 -->
 #### Configuration
 
-`function_attrs_follow_docs` has no configuration knobs.
+```toml
+[rstest_helper_should_be_fixture]
+min_calls = 2
+min_distinct_tests = 2
+require_identical_fixture_arg_names = false
+provider_param_attributes = ["case", "values", "files", "future", "context"]
+use_source_callee_fallback = false
+```
+
+`provider_param_attributes` lists `rstest` parameter attributes that should be
+treated as data providers rather than fixture-local bindings. Entries may be
+written either as bare names such as `case` or qualified names such as
+`rstest::case`; Whitaker normalizes them to the shared detection policy.
 
 <!-- markdownlint-disable-next-line MD024 -->
 #### What is allowed
 
-- Doc comments that appear before every other outer attribute on the same
-  function, method, or trait method.
-- Macro-generated attributes whose spans are excluded because they are
-  macro-only.
-- Inner attributes, which are outside the lint's scope.
+- Single-use helper calls inside `#[rstest]` tests
+- Helper calls whose totals stay below `min_calls` or `min_distinct_tests`
+- Parameter-provider uses covered by `provider_param_attributes`, such as
+  `case`, `values`, `files`, `future`, and `context`
 
 <!-- markdownlint-disable-next-line MD024 -->
 #### What is denied
 
-- Outer attributes that appear before a doc comment on the same function,
-  method, or trait method.
-- Macro-expanded attributes that recover to a user-editable source span and
-  sort before the doc comment.
+When diagnostic phases are implemented, `rstest_helper_should_be_fixture` will
+deny repeated non-provider helper invocations across `#[rstest]` tests when
+they meet or exceed both `min_calls` and `min_distinct_tests`. The
+`require_identical_fixture_arg_names` setting controls whether candidate
+fixture arguments must use the same names, and `use_source_callee_fallback`
+controls whether source-callsite recovery may be used for macro-expanded
+callee locations.
 
 <!-- markdownlint-disable-next-line MD024 -->
 #### How to fix
 
-Move doc comments so they appear before other outer attributes:
-
-```rust
-// Wrong
-#[inline]
-/// This function does something.
-fn example() {}
-
-// Correct
-/// This function does something.
-#[inline]
-fn example() {}
-```
-
-With `rstest`, place the doc comment before all attributes, including the test
-annotation:
-
-```rust
-// Wrong
-#[rstest]
-#[case(1, 2, 3)]
-/// Verifies addition.
-fn adds(#[case] a: i32, #[case] b: i32, #[case] expected: i32) {
-    assert_eq!(a + b, expected);
-}
-
-// Correct
-/// Verifies addition.
-#[rstest]
-#[case(1, 2, 3)]
-fn adds(#[case] a: i32, #[case] b: i32, #[case] expected: i32) {
-    assert_eq!(a + b, expected);
-}
-```
+- Replace repeated helper calls with a shared `#[fixture]` parameter.
+- If `require_identical_fixture_arg_names` is enabled, rename helper arguments
+  so repeated calls use the same fixture argument names.
+- Prefer provider attributes listed in `provider_param_attributes` for
+  parameterized data inputs rather than modelling them as fixture-local helper
+  calls.
+- Tune `min_calls`, `min_distinct_tests`, and `use_source_callee_fallback` when
+  repository conventions need stricter or looser matching.
 
 ______________________________________________________________________
 
@@ -434,30 +410,34 @@ ______________________________________________________________________
 <!-- markdownlint-disable-next-line MD024 -->
 #### Purpose
 
-Detect test attributes correctly so `no_expect_outside_tests` can allow
-`.expect()` in recognized test-only code while still flagging production use.
+Bootstraps the experimental lint that will recommend converting repeated helper
+calls inside `#[rstest]` tests into injected `#[fixture]` parameters.
 
 <!-- markdownlint-disable-next-line MD024 -->
 #### Scope and behaviour
 
-Whitaker recognizes `#[test]`, prelude-qualified `#[test]` forms,
-`#[tokio::test]`, `#[async_std::test]`, `#[gpui::test]`, `#[rstest]`,
-`#[rstest::rstest]`, `#[rstest_parametrize]`, `#[rstest::rstest_parametrize]`,
-`#[case]`, and `#[rstest::case]` by default. The `additional_test_attributes`
-setting extends that matching list with project-specific markers, so the lint
-treats those annotated functions as tests too.
+This lint is experimental. The current implementation registers the lint and
+loads configuration defaults so teams can opt into the forthcoming rule without
+yet receiving helper-call diagnostics. Call-site collection, cross-test
+aggregation, and actionable diagnostics are tracked by the later roadmap items
+8.2.2 through 8.2.4.
 
 <!-- markdownlint-disable-next-line MD024 -->
 #### Configuration
 
 ```toml
-[no_expect_outside_tests]
-additional_test_attributes = ["my_framework::test", "wasm_bindgen_test"]
+[rstest_helper_should_be_fixture]
+min_calls = 2
+min_distinct_tests = 2
+require_identical_fixture_arg_names = false
+provider_param_attributes = ["case", "values", "files", "future", "context"]
+use_source_callee_fallback = false
 ```
 
-Set `additional_test_attributes` to an array of attribute paths written as
-strings. Each entry should match the path Whitaker sees on the test function,
-for example `my_framework::test` or `wasm_bindgen_test`.
+`provider_param_attributes` lists `rstest` parameter attributes that should be
+treated as data providers rather than fixture-local bindings. Entries may be
+written either as bare names such as `case` or qualified names such as
+`rstest::case`; Whitaker normalizes them to the shared detection policy.
 
 <!-- markdownlint-disable-next-line MD024 -->
 #### Ancestor context propagation
@@ -487,32 +467,33 @@ fn helper() {
 <!-- markdownlint-disable-next-line MD024 -->
 #### What is allowed
 
-- Default markers such as `#[test]`, `#[::test]`,
-  `#[::std::prelude::v1::test]`, `#[tokio::test]`, `#[async_std::test]`,
-  `#[gpui::test]`, `#[rstest]`, `#[rstest::rstest]`, `#[rstest_parametrize]`,
-  `#[rstest::rstest_parametrize]`, `#[case]`, and `#[rstest::case]`
-- Project-specific markers listed in `additional_test_attributes`, such as
-  `#[wasm_bindgen_test]`
+- Single-use helper calls inside `#[rstest]` tests
+- Helper calls whose totals stay below `min_calls` or `min_distinct_tests`
+- Parameter-provider uses covered by `provider_param_attributes`, such as
+  `case`, `values`, `files`, `future`, and `context`
 
 <!-- markdownlint-disable-next-line MD024 -->
 #### What is denied
 
-Functions using `.expect()` will still be flagged when their test attribute is
-not in Whitaker's default list and is not listed in
-`additional_test_attributes`.
+When diagnostic phases are implemented, `rstest_helper_should_be_fixture` will
+deny repeated non-provider helper invocations across `#[rstest]` tests when
+they meet or exceed both `min_calls` and `min_distinct_tests`. The
+`require_identical_fixture_arg_names` setting controls whether candidate
+fixture arguments must use the same names, and `use_source_callee_fallback`
+controls whether source-callsite recovery may be used for macro-expanded
+callee locations.
 
 <!-- markdownlint-disable-next-line MD024 -->
 #### How to fix
 
-- Add the missing test marker to `additional_test_attributes` if the function is
-  genuinely part of a supported test framework
-- Change the attribute usage to a recognized form such as `#[test]`,
-  `#[::test]`, `#[::std::prelude::v1::test]`, `#[tokio::test]`,
-  `#[async_std::test]`, `#[gpui::test]`, `#[rstest]`, `#[rstest::rstest]`,
-  `#[rstest_parametrize]`, `#[rstest::rstest_parametrize]`, `#[case]`, or
-  `#[rstest::case]` where appropriate
-- If the function is not test-only code, replace `.expect()` with explicit error
-  handling such as `?` or `map_err`
+- Replace repeated helper calls with a shared `#[fixture]` parameter.
+- If `require_identical_fixture_arg_names` is enabled, rename helper arguments
+  so repeated calls use the same fixture argument names.
+- Prefer provider attributes listed in `provider_param_attributes` for
+  parameterized data inputs rather than modelling them as fixture-local helper
+  calls.
+- Tune `min_calls`, `min_distinct_tests`, and `use_source_callee_fallback` when
+  repository conventions need stricter or looser matching.
 
 ______________________________________________________________________
 

--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -329,11 +329,23 @@ Implementation details:
 
 - The lint now maps `rustc_hir::Attribute` values into a small
   `OrderedAttribute` abstraction, so the ordering logic can be unit-tested
-  without depending on compiler types. `AttrInfo::from_hir` records the span,
-  whether the attribute is a doc comment (via `doc_str`), and whether it is
-  outer by reading the attribute style (`AttrStyle`). Inner attributes
-  therefore remain excluded from the ordering check in line with the
-  implementation.
+  without depending on compiler types. `AttrInfo::try_from_hir` records the
+  span, whether the attribute is a doc comment (via `doc_str`), and whether it
+  is outer by reading the attribute style (`AttrStyle`). It accepts `Unparsed`
+  and `DocComment` attributes directly, and also `Parsed` attribute kinds that
+  the compiler eagerly parses but that still carry a recoverable user-written
+  span (for example `Inline` and `MustUse`, via `parsed_attribute_span`'s
+  whitelist), so those attributes keep participating in ordering. `Parsed`
+  kinds without a recoverable span (compiler-internal summaries such as
+  `ConstStabilityIndirect`, and deliberately `Cold`) return `None` and are
+  excluded. Inner attributes remain excluded from the ordering check in line
+  with the implementation.
+- `attribute_within_item` decides whether an attribute belongs to the item
+  being checked. Because modern nightlies exclude outer attributes from the
+  item's HIR span — they sit immediately before it rather than inside it —
+  the check accepts a span either contained within the item span (older
+  compiler behaviour, and inner attributes) or preceding it (outer attributes
+  on current nightlies).
 - `FunctionKind` labels free functions, inherent methods, and trait methods so
   diagnostics mention the affected item type explicitly.
 - Diagnostics now rely on `LateContext::emit_spanned_lint`, highlighting the

--- a/docs/whitaker-dylint-suite-design.md
+++ b/docs/whitaker-dylint-suite-design.md
@@ -332,14 +332,14 @@ Implementation details:
   without depending on compiler types. `AttrInfo::try_from_hir` records the
   span, whether the attribute is a doc comment (via `doc_str`), and whether it
   is outer by reading the attribute style (`AttrStyle`). It accepts `Unparsed`
-  and `DocComment` attributes directly, and also `Parsed` attribute kinds that
-  the compiler eagerly parses but that still carry a recoverable user-written
-  span (for example `Inline` and `MustUse`, via `parsed_attribute_span`'s
-  whitelist), so those attributes keep participating in ordering. `Parsed`
-  kinds without a recoverable span (compiler-internal summaries such as
-  `ConstStabilityIndirect`, and deliberately `Cold`) return `None` and are
-  excluded. Inner attributes remain excluded from the ordering check in line
-  with the implementation.
+  attributes directly, and `Parsed` attribute kinds whose user-written span is
+  recoverable through `parsed_attribute_span`'s whitelist — `DocComment` is
+  one such parsed kind, handled the same way as `Inline` and `MustUse` — so
+  those attributes keep participating in ordering. `Parsed` kinds outside the
+  whitelist return `None` and are excluded, whether they carry no span at all
+  (such as `Cold`) or carry one that the ordering check deliberately does not
+  recover (such as `AllowInternalUnsafe`). Inner attributes remain excluded
+  from the ordering check in line with the implementation.
 - `attribute_within_item` decides whether an attribute belongs to the item
   being checked. Because modern nightlies exclude outer attributes from the
   item's HIR span — they sit immediately before it rather than inside it —


### PR DESCRIPTION
## Summary

Restores `function_attrs_follow_docs`, which had fallen entirely silent —
its fail fixtures produced no diagnostics on either supported nightly.
Addresses #284.

Two independent compiler changes caused the silence:

1. **Item spans no longer cover outer attributes (dominant cause).** rustc
   now starts the item span at the item header, so every outer attribute
   sits before `item_span.lo()`. The containment filter in
   `attribute_within_item` therefore discarded *all* attributes — doc
   comments and still-`Unparsed` attributes such as `#[allow]` included.
   This alone silenced the lint. Confirmed empirically with span dumps
   from the running lint: for the function case, `item_span` begins at the
   `fn` line while the attributes occupy the two preceding lines.
2. **Parsed-kind drops.** `AttrInfo::try_from_hir` discarded every
   `Attribute::Parsed(_)` except `DocComment`, hiding built-ins that rustc
   has migrated to parsed `AttributeKind` representations (`#[inline]`
   arrives as `Parsed(Inline(…, span))`). The exposure grows nightly by
   nightly as more attributes are parsed.

## Design (~40 lines in `driver.rs`)

- `attribute_within_item` additionally accepts attributes whose
  user-editable span *precedes* the item span, keeping the containment
  path for inner attributes, older span behaviour, and dummy-span
  handling.
- A new `parsed_attribute_span` helper recovers the source span per
  parsed kind (`DocComment`, `Ignore`, `Inline`, `MustUse`, `Naked`,
  `NoMangle`, `Optimize`, `TargetFeature`, `TrackCaller`). Only variants
  whose shape is identical on both supported nightlies are matched, so
  this branch compiles unchanged before and after the toolchain migration
  (#285); `Deprecation`/`Deprecated` is renamed across the pins and can
  be added once the pin settles. Span-less kinds (`#[cold]`, `#[used]`)
  remain excluded from ordering because nothing can place them in source
  order.

## Fixture results (nightly-2025-09-18, this base)

- `ui/fail_doc_after_attribute.rs` and `ui/fail_doc_attribute_after.rs`
  fire again and are re-blessed: after the original blessing, the fixture
  files gained a leading module doc line (shifting every line number) and
  the Fluent message gained a terminating full stop.
- All three plain pass fixtures remain clean — no false positives from
  the widened span policy.

## Explicitly out of scope (pre-existing failures, unchanged)

1. `ui/fail_doc_after_fixture.rs` — `#[fixture]` is consumed by
   proc-macro expansion and never reaches `hir_attrs`; unrecoverable in a
   late lint pass. Needs a redesign (pre-expansion check) or a fixture
   change.
2. `ui/pass_async_trait_trait.rs` — aux build compiles under edition
   2015 (`E0670`); UI harness defect.
3. `ui/pass_derive_macro_generated.rs` — unfulfilled `#[expect(dead_code)]`
   warnings under the UI harness.
4. `ui-cy/locale_smoke.rs` — `include!` of a fixture that starts with an
   inner doc comment is a hard `E0753`; the localisation BDD scenarios
   also panic on quoted step arguments.

These four (plus re-enabling the crate in CI, currently excluded via
`TEST_EXCLUDES`) are the remainder of #284, so this PR does not close it.

## Validation

- `env -u WHITAKER make check-fmt lint test markdownlint` at the current
  pin — all clean (the crate itself is CI-excluded; the full workspace
  gates still apply to the driver change).
- `cargo nextest run -p function_attrs_follow_docs --all-features --lib`
  — the two restored fixtures pass; remaining failures are exactly the
  pre-existing set listed above.
