### PR TITLE
Exclude macro-inserted attributes from ordering checks (#289)

### DIFF
--- a/crates/function_attrs_follow_docs/src/driver.rs
+++ b/crates/function_attrs_follow_docs/src/driver.rs
@@ -163,6 +163,15 @@ impl AttrInfo {
             return None;
         }
 
+        // Attributes whose span carries an expansion context were inserted by
+        // a macro rather than written at that position; the user cannot
+        // reorder them, and their recovered call-site span would misattribute
+        // an enclosing item's attribute (for example `#[async_trait]`) to
+        // every item the macro emits.
+        if span.from_expansion() {
+            return None;
+        }
+
         let is_doc = attr.doc_str().is_some();
         let is_outer = attr
             .doc_resolution_scope()


### PR DESCRIPTION
## Summary

This branch stops `function_attrs_follow_docs` from misattributing macro-inserted attributes to the items a macro emits, fixing the `async-trait` false positive that is blocking the installer 0.2.6 pin-bump PRs on dear-diary (#61) and wireframe (#613).

Closes #289.

The widened item-boundary rule from #286 accepts attribute spans preceding the item (modern nightlies exclude outer attributes from item spans). Attributes inserted by macro expansion resolve, via call-site recovery, to the macro attribute on an enclosing item — so a trait's `#[async_trait]` was reported as a misordered outer attribute on every method, with correctly ordered source. The fix drops attributes whose span carries an expansion context before the ordering comparison: the user did not write them at that position and cannot reorder them.

## Review walkthrough

- The whole change is one guard in [crates/function_attrs_follow_docs/src/driver.rs](https://github.com/leynos/whitaker/blob/fix-function-attrs-async-trait/crates/function_attrs_follow_docs/src/driver.rs): `AttrInfo::try_from_hir` now returns `None` for spans with an expansion context, alongside the existing dummy-span rejection.

## Validation

Live validation against the real `async-trait` crate (not the mock UI fixture):

- a correctly ordered documented trait produces no findings (previously two false positives citing the trait's own attribute);
- a genuinely misordered attribute inside the `#[async_trait]` body still fires (pass-through tokens keep their original spans);
- a misordered attribute outside any macro still fires;
- `#[allow(function_attrs_follow_docs)]` and `#[expect(...)]` suppress at item, module, and crate scope — the suppression failures reported in #289 were downstream of the expansion-anchored false positive.

Gates: check-fmt, lint (clippy `-D warnings`), typecheck, test (1459/1459, 3 skipped), markdownlint, and nixie all pass. The crate's own suite holds exact failure parity with `main` (the seven documented pre-existing localization/UI failures, tracked under #284).

## Notes

The `ui/pass_async_trait_trait.rs` fixture's mock macro already inserts a call-site-spanned attribute — the exact poison shape — so it serves as the in-tree regression fixture once the UI harness (currently among the documented pre-existing failures) is re-enabled.
