### PR TITLE
Heal the release workflows' dependency-binary publication (#288)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,6 +274,16 @@ jobs:
           merge-multiple: true
           path: dist
 
+      - name: Require at least one build archive
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          archives=(dist/*.tgz dist/*.zip)
+          if [[ "${#archives[@]}" -eq 0 ]]; then
+            echo "::error::No build archives were produced; refusing to publish an empty release."
+            exit 1
+          fi
+
       - name: Generate dependency provenance asset
         run: |
           set -euxo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            cross: true
+            os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
@@ -47,14 +46,6 @@ jobs:
 
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@d3cbe87e745e07b3ad53ddcb87deb19ffa95c9b8
-
-      - name: Install cross-compilation tools (aarch64-linux)
-        if: matrix.cross
-        run: |
-          set -euxo pipefail
-          sudo apt-get update -y
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
 
       - name: Add target
         run: rustup target add "${{ matrix.target }}"
@@ -137,10 +128,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            cross: true
+            os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
@@ -155,16 +145,18 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@d3cbe87e745e07b3ad53ddcb87deb19ffa95c9b8
 
-      - name: Install cross-compilation tools (aarch64-linux)
-        if: matrix.cross
-        run: |
-          set -euxo pipefail
-          sudo apt-get update -y
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-
       - name: Add target
         run: rustup target add "${{ matrix.target }}"
+
+      # The dependency tools' locked dependencies can require a newer rustc
+      # than the repository's pinned nightly (cargo-dylint 6.0.1 locks
+      # cargo-util 0.2.28, which needs rustc 1.93), so host-tool installs run
+      # under a current stable toolchain.
+      - name: Install stable toolchain for host tools
+        run: |
+          set -euxo pipefail
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup target add --toolchain stable "${{ matrix.target }}"
 
       - name: Build dependency packaging tool
         run: cargo build --release -p whitaker-installer --bin whitaker-package-dependency-binary
@@ -181,7 +173,7 @@ jobs:
             PACKAGER="./target/release/whitaker-package-dependency-binary"
           fi
           while IFS=$'\t' read -r package binary version; do
-            cargo install \
+            cargo +stable install \
               --locked \
               --force \
               --root dependency-root \
@@ -223,7 +215,11 @@ jobs:
           retention-days: 5
 
   publish:
-    if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '')
+    # Publish whatever the build legs produced instead of discarding the
+    # successful legs when one fails: !cancelled() keeps this job running
+    # after a failed need, and the artefact downloads below tolerate absent
+    # legs. The job still fails when nothing at all was built.
+    if: ${{ !cancelled() && (github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '')) }}
     needs:
       - build-installer
       - build-dependency-binaries
@@ -263,6 +259,7 @@ jobs:
           fi
 
       - name: Download all artefacts
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: installer-*
@@ -270,6 +267,7 @@ jobs:
           path: dist
 
       - name: Download dependency artefacts
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: dependency-binaries-*
@@ -283,11 +281,20 @@ jobs:
 
       - name: List artefacts
         run: |
+          set -euo pipefail
           if [[ ! -d dist ]]; then
             echo "No artefacts were downloaded."
             exit 1
           fi
           ls -lh dist/
+          shopt -s nullglob
+          for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu \
+            x86_64-apple-darwin aarch64-apple-darwin x86_64-pc-windows-msvc; do
+            matches=(dist/*"${target}"*)
+            if [[ "${#matches[@]}" -eq 0 ]]; then
+              echo "::warning::No artefacts for ${target}; publishing without it."
+            fi
+          done
 
       - name: Create GitHub Release
         run: |

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d  # v7.1.0
+
       - name: Check whether dependency manifest changed
         id: check
         run: |
@@ -56,11 +59,17 @@ jobs:
             echo "should_build=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --quiet "$BEFORE" "${{ github.sha }}" -- installer/dependency-binaries.toml; then
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-          else
+          if ! git diff --quiet "$BEFORE" "${{ github.sha }}" -- installer/dependency-binaries.toml; then
             echo "should_build=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          # Self-heal: even when the manifest is unchanged, rebuild if any
+          # expected dependency archive is absent from the rolling release
+          # (for example after a build failure on the one push that changed
+          # the manifest). Without this probe the gate can never recover.
+          scripts/check_dependency_binary_assets.py --release rolling
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   build-lints:
     runs-on: ${{ matrix.os }}
@@ -74,10 +83,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            cross: true
+            os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
@@ -91,14 +99,6 @@ jobs:
 
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@d3cbe87e745e07b3ad53ddcb87deb19ffa95c9b8
-
-      - name: Install cross-compilation tools (aarch64-linux)
-        if: matrix.cross
-        run: |
-          set -euxo pipefail
-          sudo apt-get update -y
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
 
       - name: Read pinned toolchain
         id: toolchain
@@ -185,10 +185,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            cross: true
+            os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
@@ -201,16 +200,18 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@d3cbe87e745e07b3ad53ddcb87deb19ffa95c9b8
 
-      - name: Install cross-compilation tools (aarch64-linux)
-        if: matrix.cross
-        run: |
-          set -euxo pipefail
-          sudo apt-get update -y
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-
       - name: Add target
         run: rustup target add "${{ matrix.target }}"
+
+      # The dependency tools' locked dependencies can require a newer rustc
+      # than the repository's pinned nightly (cargo-dylint 6.0.1 locks
+      # cargo-util 0.2.28, which needs rustc 1.93), so host-tool installs run
+      # under a current stable toolchain.
+      - name: Install stable toolchain for host tools
+        run: |
+          set -euxo pipefail
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup target add --toolchain stable "${{ matrix.target }}"
 
       - name: Build dependency packaging tool
         run: cargo build --release -p whitaker-installer --bin whitaker-package-dependency-binary
@@ -227,7 +228,7 @@ jobs:
             PACKAGER="./target/release/whitaker-package-dependency-binary"
           fi
           while IFS=$'\t' read -r package binary version; do
-            cargo install \
+            cargo +stable install \
               --locked \
               --force \
               --root dependency-root \

--- a/docs/scripting-standards.md
+++ b/docs/scripting-standards.md
@@ -1,0 +1,497 @@
+# Scripting standards
+
+Project scripts must prioritize clarity, reproducibility, and testability. The
+baseline tooling is Python and the [`uv`](https://github.com/astral-sh/uv)
+launcher so that scripts remain dependency‑self‑contained and easy to execute
+in Continuous Integration (CI) or locally.
+
+Cyclopts is the default command‑line interface (CLI) framework for new and
+updated scripts. This document supersedes prior guidance that recommended Typer
+as a default.
+
+## Rationale for adopting Cyclopts
+
+- Environment‑first configuration without glue. Cyclopts reads environment
+  variables with a defined prefix (for example, `INPUT_`) and maps them to
+  parameters directly. Bash argument assembly, and bespoke parsing, can be
+  removed.
+- Typed lists and paths from env. Parameters annotated as `list[str]` or
+  `list[pathlib.Path]` are populated from whitespace‑ or delimiter‑separated
+  environment values. Custom split/trim helpers are unnecessary.
+- Clear precedence model. CLI flags override environment variables, which
+  override code defaults. Behaviour is predictable in both CI and local runs.
+- Small API surface. The API is explicit and integrates cleanly with type
+  hints, aiding readability and testing.
+- Backwards‑compatible migration. Option aliases and per‑parameter
+  environment variable names permit preservation of existing interfaces while
+  removing shell glue.
+
+## Language and runtime
+
+- Target Python 3.13 for all new scripts. Older versions may only be used when
+  integration constraints require them, and any exception must be documented
+  inline.
+- Each script starts with an `uv` script block, so runtime and dependency
+  expectations travel with the file. Prefer the shebang
+  `#!/usr/bin/env -S uv run python` followed by the metadata block shown in the
+  example below.
+- External processes are invoked via [`plumbum`](https://plumbum.readthedocs.io)
+  to provide structured command execution rather than ad‑hoc shell strings.
+- File‑system interactions use `pathlib.Path`. Higher‑level operations (for
+  example, copying or removing trees) go through the `shutil` standard library
+  module.
+
+### Minimal script (no CLI)
+
+```python
+#!/usr/bin/env -S uv run python
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["plumbum", "cmd-mox"]
+# ///
+
+from __future__ import annotations
+
+from pathlib import Path
+from plumbum import local
+from plumbum.cmd import tofu
+
+
+def main() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    cluster_dir = project_root / "infra" / "clusters" / "dev"
+    with local.cwd(cluster_dir):
+        tofu["plan"]()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+### Cyclopts CLI pattern (environment‑first)
+
+Employ Cyclopts when a script requires parameters, particularly under CI with
+`INPUT_*` variables.
+
+```python
+#!/usr/bin/env -S uv run python
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["cyclopts>=2.9", "plumbum", "cmd-mox"]
+# ///
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import cyclopts
+from cyclopts import App, Parameter
+from plumbum import local
+from plumbum.cmd import tofu
+
+# Map INPUT_<PARAM> → function parameter without additional glue
+app = App(config=cyclopts.config.Env("INPUT_", command=False))
+
+
+@app.default
+def main(
+    *,
+    # Required parameters
+    bin_name: Annotated[str, Parameter(required=True)],
+    version: Annotated[str, Parameter(required=True)],
+
+    # Optional scalars
+    package_name: str | None = None,
+    target: str | None = None,
+    outdir: Path | None = None,
+    dry_run: bool = False,
+
+    # Lists (whitespace/newline separated by default)
+    formats: list[str] | None = None,
+    man_paths: Annotated[list[Path] | None, Parameter(env_var="INPUT_MAN_PATHS")] = None,
+    deb_depends: list[str] | None = None,
+    rpm_depends: list[str] | None = None,
+):
+    name = package_name or bin_name
+
+    project_root = Path(__file__).resolve().parents[1]
+    build_dir = (outdir or (project_root / "dist")) / name
+
+    if dry_run:
+        print({
+            "name": name,
+            "version": version,
+            "target": target,
+            "formats": formats,
+            "man_paths": [str(p) for p in (man_paths or [])],
+            "deb_depends": deb_depends,
+            "rpm_depends": rpm_depends,
+            "build_dir": str(build_dir),
+        })
+        return
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+    with local.cwd(build_dir):
+        tofu["plan"]()  # replace with real build tooling
+
+
+if __name__ == "__main__":
+    app()
+```
+
+Guidance:
+
+- Parameter names should be descriptive and stable. Where a legacy flag name
+  must remain available, add an alias:
+
+  ```python
+  package_name: Annotated[str | None, Parameter(aliases=["--name"])] = None
+  ```
+
+- Where a specific delimiter is required for an environment list (for example,
+  comma‑separated `formats`), specify it per parameter:
+
+  ```python
+  formats: Annotated[list[str] | None, Parameter(env_var_split=",")] = None
+  ```
+
+- Per‑parameter environment names can be pinned for backwards compatibility:
+
+  ```python
+  config_out: Annotated[Path | None, Parameter(env_var="INPUT_CONFIG_PATH")] = None
+  ```
+
+## Plumbum: command calling and pipelines
+
+### Basics: command calls, capturing output, handling failures
+
+```python
+from __future__ import annotations  # Enables postponed annotation evaluation
+from plumbum import local
+from plumbum.cmd import git, grep
+
+# Capture stdout (raises ProcessExecutionError on non‑zero exit)
+last_commit = git["--no-pager", "log", "-1", "--pretty=%H"]().strip()
+
+# Obtain (rc, out, err) without raising
+rc, out, err = git["status"].run(retcode=None)
+if rc != 0:
+    # handle gracefully; err is available for logging
+    …
+
+# Pipelines via the | operator
+shortlog = (git["--no-pager", "log", "--oneline"] | grep["fix"])()
+```
+
+### Working directory and environment management
+
+```python
+from pathlib import Path
+from plumbum import local
+
+repo_dir = Path(__file__).resolve().parents[1]
+
+with local.cwd(repo_dir):
+    tags = local["git"]["tag", "--list"]()
+
+# Temporary env overrides
+with local.env(GIT_AUTHOR_NAME="CI", GIT_AUTHOR_EMAIL="ci@example.org"):
+    local["git"]["config", "user.name", "CI"]()
+```
+
+### Foreground execution and background jobs
+
+```python
+from plumbum import FG, BG
+from plumbum.cmd import make
+
+# Stream output to terminal
+make["-j4"] & FG
+
+# Background process
+proc = local["sleep"]["5"] & BG
+proc.wait()
+```
+
+### Piping stdin and redirecting
+
+```python
+from plumbum import local
+from plumbum.cmd import sed, git, grep, wc
+
+# Provide stdin explicitly
+_, out, _ = sed["-n", "s/^v//p"].run(stdin="v1.2.3\nv2.0.0\n")
+assert out.splitlines() == ["1.2.3", "2.0.0"]
+
+# Multi‑stage pipelines
+count = (git["--no-pager", "log", "--oneline"] | grep["chore"] | wc["-l"])().strip()
+```
+
+## Pathlib: robust path manipulation
+
+### Project roots, joins, and ensuring directories
+
+```python
+from __future__ import annotations  # Enables postponed annotation evaluation
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DIST = PROJECT_ROOT / "dist"
+(DIST / "artifacts").mkdir(parents=True, exist_ok=True)
+
+# Portable joins and normalization
+cfg = PROJECT_ROOT.joinpath("config", "release.toml").resolve()
+```
+
+### Reading and writing files and atomic updates
+
+```python
+from pathlib import Path
+import tempfile
+
+f = Path("./dist/version.txt")
+
+# Text I/O
+f.write_text("1.2.3\n", encoding="utf-8")
+version = f.read_text(encoding="utf-8").strip()
+
+# Atomic write pattern (tmp → replace)
+with tempfile.NamedTemporaryFile("w", delete=False, dir=f.parent, encoding="utf-8") as tmp:
+    tmp.write("new-contents\n")
+    tmp_path = Path(tmp.name)
+
+tmp_path.replace(f)  # atomic on POSIX
+```
+
+### Globbing, filtering, and safe deletion
+
+```python
+from pathlib import Path
+
+# Recursive glob
+md_files = sorted(Path("docs").glob("**/*.md"))
+
+# Filter by suffix / size
+small_md = [p for p in md_files if p.stat().st_size < 4096 and p.suffix == ".md"]
+
+# Safe deletion (ignore missing)
+try:
+    (Path("build") / "temp.bin").unlink()
+except FileNotFoundError:
+    pass
+```
+
+## Cyclopts + Plumbum + Pathlib together (reference script)
+
+```python
+#!/usr/bin/env -S uv run python
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["cyclopts>=2.9", "plumbum", "cmd-mox"]
+# ///
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Annotated
+
+import cyclopts
+from cyclopts import App, Parameter
+from plumbum import local, FG
+from plumbum.cmd import git
+
+app = App(config=cyclopts.config.Env("INPUT_", command=False))
+
+@app.default
+def main(
+    *,
+    bin_name: Annotated[str, Parameter(required=True)],
+    version: Annotated[str, Parameter(required=True)],
+    formats: list[str] | None = None,
+    outdir: Path | None = None,
+    dry_run: bool = False,
+):
+    project_root = Path(__file__).resolve().parents[1]
+    dist = (outdir or (project_root / "dist")) / bin_name
+    dist.mkdir(parents=True, exist_ok=True)
+
+    if not dry_run:
+        with local.cwd(project_root):
+            (git["tag", f"v{version}"] & FG)
+
+    print({
+        "bin_name": bin_name,
+        "version": version,
+        "formats": formats or [],
+        "dist": str(dist),
+    })
+
+if __name__ == "__main__":
+    app()
+```
+
+## Testing expectations
+
+- Automated coverage via `pytest` is required for every script. Fixtures from
+  `pytest-mock` support Python‑level mocking; `cmd-mox` simulates external
+  executables without touching the host system.
+- Behavioural flows that map cleanly to scenarios should adopt Behaviour‑Driven
+  Development (BDD) via `pytest-bdd` so that intent is captured in
+  human‑readable Given/When/Then narratives.
+- Tests reside in `scripts/tests/`, mirroring script names. For example,
+  `scripts/bootstrap_doks.py` pairs with `scripts/tests/test_bootstrap_doks.py`.
+- Where scripts rely on environment variables, both happy paths and failure
+  modes must be asserted; tests should demonstrate graceful error handling
+  rather than opaque stack traces.
+
+### Mocking Python dependencies (pytest-mock) and environment (monkeypatch)
+
+```python
+import os
+from pathlib import Path
+from cyclopts.testing import invoke
+from scripts.package import app
+
+
+def test_reads_env_and_defaults(monkeypatch, tmp_path):
+    # Arrange env for Cyclopts
+    monkeypatch.setenv("INPUT_BIN_NAME", "demo")
+    monkeypatch.setenv("INPUT_VERSION", "1.2.3")
+    monkeypatch.setenv("INPUT_FORMATS", "deb rpm")  # whitespace or newlines
+
+    # Exercise
+    result = invoke(app, [])
+
+    # Assert
+    assert result.exit_code == 0
+    assert '"version": "1.2.3"' in result.stdout
+
+
+def test_patch_python_dependency(mocker):
+    # Example: patch a helper function used by the script
+    from scripts import helpers
+
+    mocker.patch_object(helpers, "compute_checksum", return_value="deadbeef")
+    assert helpers.compute_checksum(b"abc") == "deadbeef"
+```
+
+### Mocking external executables with cmd-mox (record → replay → verify)
+
+Enable the plugin in `conftest.py`:
+
+```python
+pytest_plugins = ("cmd_mox.pytest_plugin",)
+```
+
+```python
+from plumbum import local
+
+
+def test_git_tag_happy_path(cmd_mox, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    # Mock external command behaviour
+    cmd_mox.mock("git").with_args("tag", "v1.2.3").returns(exit_code=0)
+
+    # Run the code under test while shims are active
+    cmd_mox.replay()
+    local["git"]["tag", "v1.2.3"]()
+    cmd_mox.verify()
+
+
+def test_git_tag_failure_surface_error(cmd_mox, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    cmd_mox.mock("git").with_args("tag", "v1.2.3").returns(exit_code=1, stderr="denied")
+
+    cmd_mox.replay()
+    try:
+        local["git"]["tag", "v1.2.3"]()  # raises due to non‑zero rc
+        assert False, "expected ProcessExecutionError"
+    except Exception as exc:
+        assert "Command exited with code" in str(exc)
+    finally:
+        cmd_mox.verify()
+```
+
+### Spies and passthrough capture (turn real calls into fixtures)
+
+```python
+from plumbum import local
+
+
+def test_spy_and_record(cmd_mox, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    # Spy records actual usage; passthrough runs the real command
+    spy = cmd_mox.spy("echo").passthrough()
+
+    cmd_mox.replay()
+    (local["echo"]["hello world"])()
+    cmd_mox.verify()
+
+    # Inspect what happened
+    spy.assert_called()
+    assert spy.call_count == 1
+    args = spy.invocations[0].argv[1:]
+    assert args == ["hello world"]
+```
+
+## Operational guidelines
+
+- Scripts must be idempotent. Re‑running should converge state without
+  destructive side effects. Guard conditions (for example, checking the secrets
+  manager to confirm existing secrets) should precede writes or rotations.
+- Pure functions that accept configuration objects are preferred over global
+  state, so tests can exercise logic deterministically.
+- Exit codes should follow Portable Operating System Interface (POSIX)
+  conventions: `0` for success, non-zero for actionable failures.
+  Human-friendly error messages should highlight remediation steps.
+- Dependencies must remain minimal. Any new package should be added to the `uv`
+  block and the rationale documented within the script or companion tests.
+
+## Migration guidance (Typer → Cyclopts)
+
+1. Dependencies: replace Typer with Cyclopts in the script’s `uv` block.
+2. Entry point: replace `app = typer.Typer(…)` with `app = App(…)` and
+   configure `Env("INPUT_", command=False)` where environment variables are
+   authoritative in CI.
+3. Parameters: replace `typer.Option(…)` with annotations and
+   `Parameter(…)`. Mark required options with `required=True`. Map any
+   non‑matching environment names via `env_var=…`.
+4. Lists: remove custom split/trim code. Use list‑typed parameters; add
+   `env_var_split=","` where a non‑whitespace delimiter is required.
+5. Compatibility: retain legacy flag names using `aliases=["--old-name"]`.
+6. Bash glue: delete argument arrays and conditional appends in GitHub
+   Actions. Export `INPUT_*` environment variables and call `uv run` on the
+   script.
+
+## CI wiring: GitHub Actions (Cyclopts‑first)
+
+```yaml
+- name: Build
+  shell: bash
+  working-directory: ${{ inputs.project-dir }}
+  env:
+    INPUT_BIN_NAME: ${{ inputs.bin-name }}
+    INPUT_VERSION: ${{ inputs.version }}
+    INPUT_FORMATS: ${{ inputs.formats }}               # multiline or space‑sep
+    INPUT_OUTDIR: ${{ inputs.outdir }}
+  run: |
+    set -euo pipefail
+    uv run "${GITHUB_ACTION_PATH}/scripts/package.py"
+```
+
+## Notes and gotchas
+
+- Newline‑separated lists are preferred for CI inputs to avoid shell quoting
+  issues across platforms.
+- `Command.run(retcode=None)` permits inspection of non‑zero exits without
+  raising.
+- Production code should present friendly error messages; tests may assert raw
+  behaviours (non‑zero exits, stderr contents) via `cmd-mox`.
+- On Windows, newline‑separated lists are recommended for `list[Path]` to
+  sidestep `;`/`:` semantics.
+
+This document should be referenced when introducing or updating automation
+scripts to maintain a consistent developer experience across the repository.

--- a/scripts/check_dependency_binary_assets.py
+++ b/scripts/check_dependency_binary_assets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = ["cyclopts>=2.9", "plumbum"]
@@ -43,7 +43,12 @@ ARCHIVE_TARGETS: tuple[str, ...] = (
 def expected_assets(
     manifest_path: Path, targets: typ.Sequence[str] = ARCHIVE_TARGETS
 ) -> list[str]:
-    """Return every archive name the manifest implies for the targets."""
+    """Return every asset name the manifest implies for the targets.
+
+    Each archive is accompanied by its ``.sha256`` sidecar: the installer
+    downloads and verifies the checksum before accepting an archive, so a
+    release missing a sidecar is as broken as one missing the archive.
+    """
     manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
     assets: list[str] = []
     for entry in manifest.get("dependency_binaries", []):
@@ -51,7 +56,9 @@ def expected_assets(
         version = entry["version"]
         for target in targets:
             extension = "zip" if "windows" in target else "tgz"
-            assets.append(f"{package}-{target}-v{version}.{extension}")
+            archive = f"{package}-{target}-v{version}.{extension}"
+            assets.append(archive)
+            assets.append(f"{archive}.sha256")
     return assets
 
 

--- a/scripts/check_dependency_binary_assets.py
+++ b/scripts/check_dependency_binary_assets.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env -S uv run python
+# /// script
+# requires-python = ">=3.13"
+# dependencies = ["cyclopts>=2.9", "plumbum"]
+# ///
+"""Decide whether the rolling dependency binaries need rebuilding.
+
+The rolling-release gate builds dependency binaries only when the manifest
+changes in the triggering push. That alone cannot recover from a failed
+publish, so this probe compares the release's asset list against every
+archive the manifest implies and requests a rebuild when any is absent
+(issue #288). The result is written as ``should_build=true|false`` to the
+GitHub Actions output file, or to stdout when run outside Actions.
+
+Run it from the repository root:
+
+    scripts/check_dependency_binary_assets.py --release rolling
+"""
+
+from __future__ import annotations
+
+import tomllib
+import typing as typ
+from pathlib import Path
+
+import cyclopts
+from cyclopts import App, Parameter
+from plumbum import local
+
+app = App(config=cyclopts.config.Env("INPUT_", command=False))
+
+#: Targets whose archives the release workflows publish. Windows targets
+#: package as ``.zip``; every other target packages as ``.tgz``.
+ARCHIVE_TARGETS: tuple[str, ...] = (
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+)
+
+
+def expected_assets(
+    manifest_path: Path, targets: typ.Sequence[str] = ARCHIVE_TARGETS
+) -> list[str]:
+    """Return every archive name the manifest implies for the targets."""
+    manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+    assets: list[str] = []
+    for entry in manifest.get("dependency_binaries", []):
+        package = entry["package"]
+        version = entry["version"]
+        for target in targets:
+            extension = "zip" if "windows" in target else "tgz"
+            assets.append(f"{package}-{target}-v{version}.{extension}")
+    return assets
+
+
+def release_asset_names(release: str) -> list[str] | None:
+    """Return the release's asset names, or ``None`` when unreadable."""
+    gh = local["gh"]
+    return_code, stdout, _stderr = gh[
+        "release", "view", release, "--json", "assets", "--jq", ".assets[].name"
+    ].run(retcode=None)
+    if return_code != 0:
+        return None
+    return [line for line in stdout.splitlines() if line]
+
+
+def missing_assets(expected: typ.Sequence[str], present: typ.Sequence[str]) -> list[str]:
+    """Return the expected assets absent from the present asset names."""
+    present_set = set(present)
+    return [asset for asset in expected if asset not in present_set]
+
+
+def write_should_build(output_path: Path | None, *, should_build: bool) -> None:
+    """Record the decision for the workflow, or stdout outside Actions."""
+    line = f"should_build={'true' if should_build else 'false'}"
+    if output_path is None:
+        print(line)
+        return
+    with output_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{line}\n")
+
+
+@app.default
+def main(
+    *,
+    manifest: Path = Path("installer/dependency-binaries.toml"),
+    release: str = "rolling",
+    github_output: typ.Annotated[
+        Path | None, Parameter(env_var="GITHUB_OUTPUT")
+    ] = None,
+) -> None:
+    """Probe the release for the manifest's archives and record the verdict."""
+    present = release_asset_names(release)
+    if present is None:
+        print(f"Release {release} not readable; rebuilding dependency binaries.")
+        write_should_build(github_output, should_build=True)
+        return
+    missing = missing_assets(expected_assets(manifest), present)
+    for asset in missing:
+        print(f"Missing {release} asset: {asset}")
+    write_should_build(github_output, should_build=bool(missing))
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/tests/test_check_dependency_binary_assets.py
+++ b/scripts/tests/test_check_dependency_binary_assets.py
@@ -1,0 +1,105 @@
+"""Test the rolling-release dependency-asset probe.
+
+This suite imports ``check_dependency_binary_assets.py`` and validates the
+asset-name derivation, the missing-asset computation, and the decision
+output across its pure boundaries. Run it with
+``uv run --with cyclopts --with plumbum pytest
+scripts/tests/test_check_dependency_binary_assets.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+
+MANIFEST = """\
+[[dependency_binaries]]
+package = "cargo-dylint"
+binary = "cargo-dylint"
+version = "6.0.1"
+
+[[dependency_binaries]]
+package = "dylint-link"
+binary = "dylint-link"
+version = "6.0.1"
+"""
+
+
+@pytest.fixture(scope="module")
+def probe():
+    """Import the probe script as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "check_dependency_binary_assets",
+        SCRIPTS / "check_dependency_binary_assets.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def manifest_path(tmp_path: Path) -> Path:
+    """Write a two-tool manifest and return its path."""
+    path = tmp_path / "dependency-binaries.toml"
+    path.write_text(MANIFEST, encoding="utf-8")
+    return path
+
+
+def test_expected_assets_cover_every_tool_and_target(probe, manifest_path) -> None:
+    """Every tool gains one archive per target with the right extension."""
+    assets = probe.expected_assets(manifest_path)
+
+    assert len(assets) == 2 * len(probe.ARCHIVE_TARGETS)
+    assert "cargo-dylint-x86_64-unknown-linux-gnu-v6.0.1.tgz" in assets
+    assert "dylint-link-x86_64-pc-windows-msvc-v6.0.1.zip" in assets
+    assert not [a for a in assets if "windows" in a and a.endswith(".tgz")]
+
+
+def test_expected_assets_respects_target_override(probe, manifest_path) -> None:
+    """A caller-supplied target list narrows the derived assets."""
+    assets = probe.expected_assets(manifest_path, ["x86_64-unknown-linux-gnu"])
+
+    assert assets == [
+        "cargo-dylint-x86_64-unknown-linux-gnu-v6.0.1.tgz",
+        "dylint-link-x86_64-unknown-linux-gnu-v6.0.1.tgz",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("present", "expected_missing"),
+    [
+        (["a.tgz", "b.tgz"], []),
+        (["a.tgz"], ["b.tgz"]),
+        ([], ["a.tgz", "b.tgz"]),
+    ],
+    ids=["complete", "partial", "empty"],
+)
+def test_missing_assets(probe, present, expected_missing) -> None:
+    """Missing assets are exactly the expected names not present."""
+    assert probe.missing_assets(["a.tgz", "b.tgz"], present) == expected_missing
+
+
+def test_write_should_build_appends_to_output_file(probe, tmp_path: Path) -> None:
+    """The decision appends to the Actions output file without clobbering."""
+    output = tmp_path / "github-output"
+    output.write_text("earlier=value\n", encoding="utf-8")
+
+    probe.write_should_build(output, should_build=True)
+    probe.write_should_build(output, should_build=False)
+
+    assert output.read_text(encoding="utf-8").splitlines() == [
+        "earlier=value",
+        "should_build=true",
+        "should_build=false",
+    ]
+
+
+def test_write_should_build_prints_without_output_file(probe, capsys) -> None:
+    """Outside Actions the decision goes to stdout."""
+    probe.write_should_build(None, should_build=True)
+
+    assert capsys.readouterr().out.strip() == "should_build=true"

--- a/scripts/tests/test_check_dependency_binary_assets.py
+++ b/scripts/tests/test_check_dependency_binary_assets.py
@@ -50,12 +50,14 @@ def manifest_path(tmp_path: Path) -> Path:
 
 
 def test_expected_assets_cover_every_tool_and_target(probe, manifest_path) -> None:
-    """Every tool gains one archive per target with the right extension."""
+    """Every tool gains an archive and checksum sidecar per target."""
     assets = probe.expected_assets(manifest_path)
 
-    assert len(assets) == 2 * len(probe.ARCHIVE_TARGETS)
+    assert len(assets) == 2 * 2 * len(probe.ARCHIVE_TARGETS)
     assert "cargo-dylint-x86_64-unknown-linux-gnu-v6.0.1.tgz" in assets
+    assert "cargo-dylint-x86_64-unknown-linux-gnu-v6.0.1.tgz.sha256" in assets
     assert "dylint-link-x86_64-pc-windows-msvc-v6.0.1.zip" in assets
+    assert "dylint-link-x86_64-pc-windows-msvc-v6.0.1.zip.sha256" in assets
     assert not [a for a in assets if "windows" in a and a.endswith(".tgz")]
 
 
@@ -65,7 +67,9 @@ def test_expected_assets_respects_target_override(probe, manifest_path) -> None:
 
     assert assets == [
         "cargo-dylint-x86_64-unknown-linux-gnu-v6.0.1.tgz",
+        "cargo-dylint-x86_64-unknown-linux-gnu-v6.0.1.tgz.sha256",
         "dylint-link-x86_64-unknown-linux-gnu-v6.0.1.tgz",
+        "dylint-link-x86_64-unknown-linux-gnu-v6.0.1.tgz.sha256",
     ]
 
 

--- a/tests/workflows/test_release_workflow_healing.py
+++ b/tests/workflows/test_release_workflow_healing.py
@@ -1,0 +1,149 @@
+"""Contract tests for the release-pipeline healing changes (issue #288).
+
+These checks lock in the behaviours that restore dependency-binary
+publication after the failures documented in issue #288:
+
+1. Every build leg runs on a native runner — no ``cross: true`` legs remain
+   in either workflow, so ``openssl-sys`` cross builds and cross-architecture
+   ``rustc-dev`` installs cannot recur.
+2. Dependency tools install under an explicit stable toolchain
+   (``cargo +stable install``), so the repository's pinned nightly can never
+   reimpose a rustc floor on host-tool builds.
+3. The rolling gate self-heals: when the manifest is unchanged it probes the
+   rolling release for every expected dependency archive and rebuilds on any
+   absence.
+4. The tagged release's ``publish`` job runs after partial build failures
+   (``!cancelled()``) and tolerates absent per-leg artefacts, so successful
+   legs are never discarded.
+
+Examples
+--------
+Run these checks:
+`python3 -m pytest tests/workflows/test_release_workflow_healing.py`
+"""
+
+from __future__ import annotations
+
+from tests.workflows.rolling_release_workflow_test_support import (
+    _find_step_by_name,
+    _get_job_dict,
+    _load_workflow_mapping,
+)
+from tests.workflows.workflow_test_helpers import REPO_ROOT, WORKFLOW_PATH
+
+RELEASE_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/release.yml"
+
+DEPENDENCY_TARGETS = {
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+}
+
+NATIVE_RUNNERS = {
+    "aarch64-unknown-linux-gnu": "ubuntu-24.04-arm",
+    "x86_64-apple-darwin": "macos-15-intel",
+}
+
+
+def _job_from(workflow_path, job_name):
+    """Return a job mapping from a workflow file."""
+    workflow = _load_workflow_mapping(workflow_path.read_text(encoding="utf-8"))
+    jobs = _get_job_dict(workflow, "jobs")
+    return _get_job_dict(jobs, job_name)
+
+
+def _matrix_entries(workflow_path, job_name):
+    """Return the include-matrix entries for a job."""
+    job = _job_from(workflow_path, job_name)
+    return job["strategy"]["matrix"]["include"]
+
+
+def _assert_native_runners(workflow_path, job_name):
+    entries = _matrix_entries(workflow_path, job_name)
+    targets = {entry["target"] for entry in entries}
+    assert targets == DEPENDENCY_TARGETS, (
+        f"{workflow_path.name}:{job_name} must cover the published target set"
+    )
+    for entry in entries:
+        assert "cross" not in entry, (
+            f"{workflow_path.name}:{job_name} must not cross-compile "
+            f"{entry['target']}; cross builds broke openssl-sys and "
+            "rustc-dev installs (issue #288)"
+        )
+        expected = NATIVE_RUNNERS.get(entry["target"])
+        if expected is not None:
+            assert entry["os"] == expected, (
+                f"{workflow_path.name}:{job_name} must build "
+                f"{entry['target']} natively on {expected}"
+            )
+
+
+def test_all_build_legs_run_on_native_runners() -> None:
+    """No workflow leg cross-compiles; former cross legs use native runners."""
+    for job_name in ("build-installer", "build-dependency-binaries"):
+        _assert_native_runners(RELEASE_WORKFLOW_PATH, job_name)
+    for job_name in ("build-lints", "build-dependency-binaries"):
+        _assert_native_runners(WORKFLOW_PATH, job_name)
+
+
+def _dependency_install_script(workflow_path):
+    job = _job_from(workflow_path, "build-dependency-binaries")
+    step = _find_step_by_name(job["steps"], "Build and package dependency binaries")
+    assert step is not None, (
+        f"{workflow_path.name} is missing the dependency install step"
+    )
+    return step["run"]
+
+
+def test_dependency_installs_use_stable_toolchain() -> None:
+    """Host tools install under stable so the nightly pin imposes no floor."""
+    for workflow_path in (RELEASE_WORKFLOW_PATH, WORKFLOW_PATH):
+        script = _dependency_install_script(workflow_path)
+        assert "cargo +stable install" in script, (
+            f"{workflow_path.name} must install dependency tools with "
+            "`cargo +stable install`; the pinned nightly can be older than "
+            "the tools' locked rustc floor (issue #288)"
+        )
+        job = _job_from(workflow_path, "build-dependency-binaries")
+        toolchain_step = _find_step_by_name(
+            job["steps"], "Install stable toolchain for host tools"
+        )
+        assert toolchain_step is not None, (
+            f"{workflow_path.name} must install the stable toolchain before "
+            "dependency installs"
+        )
+        assert "rustup toolchain install stable" in toolchain_step["run"]
+
+
+def test_rolling_gate_probes_release_assets() -> None:
+    """The gate rebuilds when expected rolling assets are missing."""
+    job = _job_from(WORKFLOW_PATH, "dependency-manifest-changes")
+    step = _find_step_by_name(job["steps"], "Check whether dependency manifest changed")
+    assert step is not None
+    script = step["run"]
+    assert "scripts/check_dependency_binary_assets.py" in script, (
+        "the gate must probe the rolling release via the asset-check script "
+        "so it can self-heal after a failed publish (issue #288)"
+    )
+    env = step.get("env", {})
+    assert "GH_TOKEN" in env, "the asset probe needs GH_TOKEN to query gh"
+    probe_script = REPO_ROOT / "scripts/check_dependency_binary_assets.py"
+    assert probe_script.exists(), "the asset-check script must exist"
+
+
+def test_release_publish_tolerates_partial_build_failures() -> None:
+    """publish runs after failed legs and downloads tolerate absences."""
+    job = _job_from(RELEASE_WORKFLOW_PATH, "publish")
+    condition = str(job.get("if", ""))
+    assert "!cancelled()" in condition, (
+        "publish must run even when a build leg fails, so successful legs "
+        "are not discarded (issue #288)"
+    )
+    for step_name in ("Download all artefacts", "Download dependency artefacts"):
+        step = _find_step_by_name(job["steps"], step_name)
+        assert step is not None, f"publish is missing the step '{step_name}'"
+        assert step.get("continue-on-error") is True, (
+            f"'{step_name}' must tolerate absent artefacts from failed legs"
+        )


### PR DESCRIPTION
## Summary

This branch restores the release pipeline that publishes prebuilt `cargo-dylint` and `dylint-link` archives, repairing the four compounding defects documented in #288.

Closes #288.

- **Toolchain floor.** Host-tool installs ran under the repository's pinned nightly, so cargo-dylint 6.0.1's locked rustc 1.93 requirement failed the only run whose manifest change would have published archives. Dependency installs now run under an explicit stable toolchain (`cargo +stable install`), installed by a dedicated step.
- **Cross-compilation breakage.** The aarch64-linux and x86_64-darwin legs cross-compiled, breaking on `openssl-sys` (dependency binaries) and cross-architecture `rustc-dev` installs (lints — the cause of weeks of chronically red rolling runs). Every leg now builds natively: `ubuntu-24.04-arm` and `macos-15-intel` runners replace the cross legs, and the cross-tooling steps are removed.
- **All-or-nothing publish.** The tagged release's `publish` job needed every build leg, so one failure discarded all artefacts. It now runs unless cancelled, tolerates absent per-leg artefacts, and emits a warning per missing target while still failing when nothing was built.
- **Non-self-healing gate.** The rolling gate rebuilt dependency binaries only when the triggering push changed the manifest, so it could never recover from a failed publish. When the manifest is unchanged, it now probes the rolling release for every archive the manifest implies and rebuilds on any absence.

The probe is implemented as a uv-run Cyclopts script per the newly imported [docs/scripting-standards.md](https://github.com/leynos/whitaker/blob/heal-release-workflows/docs/scripting-standards.md), rather than inline workflow shell.

## Review walkthrough

- Start with [.github/workflows/rolling-release.yml](https://github.com/leynos/whitaker/blob/heal-release-workflows/.github/workflows/rolling-release.yml) — the self-healing gate (now delegating to the probe script), native runners, and the stable-toolchain install step.
- Then [.github/workflows/release.yml](https://github.com/leynos/whitaker/blob/heal-release-workflows/.github/workflows/release.yml) — the same runner and toolchain changes, plus the tolerant `publish` job (`!cancelled()`, `continue-on-error` downloads, per-target warnings).
- [scripts/check_dependency_binary_assets.py](https://github.com/leynos/whitaker/blob/heal-release-workflows/scripts/check_dependency_binary_assets.py) — the probe: derives expected archive names from `installer/dependency-binaries.toml`, queries the release via `gh`, and writes `should_build` to the Actions output.
- Finish with the tests: [tests/workflows/test_release_workflow_healing.py](https://github.com/leynos/whitaker/blob/heal-release-workflows/tests/workflows/test_release_workflow_healing.py) (contract checks over both workflows) and [scripts/tests/test_check_dependency_binary_assets.py](https://github.com/leynos/whitaker/blob/heal-release-workflows/scripts/tests/test_check_dependency_binary_assets.py) (asset derivation, missing-asset computation, output writing).

## Validation

- `make check-fmt`, `make lint`, `make typecheck`, `make test` (1459 passed, 3 skipped), `make markdownlint`, `make nixie`: all pass.
- Workflow contract tests: 108 passed, 1 skipped; the two failures in `test_publish_check_provisioning.py` reproduce identically on a clean `origin/main` checkout in this environment (they pass in CI) and are unrelated.
- Probe script tests: 7 passed.

## Notes

- After merge, a `workflow_dispatch` of Rolling Release (or any push) exercises the self-healing gate; the manually uploaded x86_64-linux tarballs on `rolling` and `v0.2.6` should then be superseded by CI-built archives for all five targets.
- `docs/scripting-standards.md` is imported verbatim from the shared standard.
