### PR TITLE
Correct the uv script shebang in the standard and scripts

### DIFF
--- a/docs/scripting-standards.md
+++ b/docs/scripting-standards.md
@@ -33,8 +33,11 @@ as a default.
   inline.
 - Each script starts with an `uv` script block, so runtime and dependency
   expectations travel with the file. Prefer the shebang
-  `#!/usr/bin/env -S uv run python` followed by the metadata block shown in the
-  example below.
+  `#!/usr/bin/env -S uv run --script` followed by the metadata block shown in
+  the example below. The `--script` flag is required: `uv run python` executes
+  the interpreter directly and ignores the inline metadata block, so a script
+  invoked that way fails at import time on any machine without its
+  dependencies preinstalled.
 - External processes are invoked via [`plumbum`](https://plumbum.readthedocs.io)
   to provide structured command execution rather than ad‑hoc shell strings.
 - File‑system interactions use `pathlib.Path`. Higher‑level operations (for
@@ -44,7 +47,7 @@ as a default.
 ### Minimal script (no CLI)
 
 ```python
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = ["plumbum", "cmd-mox"]
@@ -74,7 +77,7 @@ Employ Cyclopts when a script requires parameters, particularly under CI with
 `INPUT_*` variables.
 
 ```python
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = ["cyclopts>=2.9", "plumbum", "cmd-mox"]
@@ -285,7 +288,7 @@ except FileNotFoundError:
 ## Cyclopts + Plumbum + Pathlib together (reference script)
 
 ```python
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = ["cyclopts>=2.9", "plumbum", "cmd-mox"]

--- a/scripts/typos_rollout_check.py
+++ b/scripts/typos_rollout_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S uv run python
+#!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
 # dependencies = ["pathspec==1.1.1"]


### PR DESCRIPTION
## Summary

This branch corrects the uv script shebang prescribed by [docs/scripting-standards.md](https://github.com/leynos/whitaker/blob/fix-uv-script-shebang/docs/scripting-standards.md) and used by [scripts/typos_rollout_check.py](https://github.com/leynos/whitaker/blob/fix-uv-script-shebang/scripts/typos_rollout_check.py). The previous form, `#!/usr/bin/env -S uv run python`, executes the interpreter directly and ignores the PEP 723 metadata block, so a directly invoked script fails at import time wherever its dependencies are not preinstalled — verified empirically during the #291 review round. The standard now prescribes `#!/usr/bin/env -S uv run --script` and explains why.

## Validation

- `make markdownlint`: 0 errors.
- `uv run scripts/typos_rollout_check.py`: exit 0 with the corrected shebang.
- Behavioural proof from the #291 round: a script with an inline dependency fails at import under the old shebang and resolves it under `--script` mode.
