### PR TITLE
Probe extracted binary to verify dylint-link repository installs (#294)

### DIFF
--- a/installer/src/deps/install.rs
+++ b/installer/src/deps/install.rs
@@ -8,8 +8,9 @@ use std::process::Output;
 
 use super::{
     CARGO_DYLINT_TOOL, CommandExecutor, DEPENDENCY_TOOLS, DYLINT_LINK_TOOL, DependencyTool,
-    DylintToolStatus, is_binstall_available, is_tool_installed,
+    DylintToolStatus, dylint_link_probe_succeeds, is_binstall_available, is_tool_installed,
 };
+use std::path::Path;
 
 pub(super) struct RepositoryInstallContext<'a> {
     pub(super) dirs: &'a dyn crate::dirs::BaseDirs,
@@ -103,7 +104,7 @@ pub(super) fn install_tool(
         cargo_install_plan = cargo_install_plan.with_version(dependency.version());
 
         match repo.installer.install(dependency, repo.target, repo.dirs) {
-            Ok(_) if is_tool_installed(executor, tool) => {
+            Ok(installed_path) if repository_install_verified(executor, tool, &installed_path) => {
                 write_message(
                     stderr,
                     context.quiet,
@@ -290,6 +291,26 @@ fn run_cargo_install(
 
     write_message(stderr, quiet, success_message);
     Ok(InstallOutcome::CargoInstall)
+}
+
+/// Verify a repository-release install of `tool`.
+///
+/// `dylint-link` forwards every argument to the underlying linker and can
+/// never report its own version, and Cargo's registry of installed binaries
+/// never records repository extractions, so the generic version check would
+/// reject every repository install. The extracted binary is probed directly
+/// instead: the release asset name pins the version and the download has
+/// already been verified, so a successful probe is sufficient evidence.
+fn repository_install_verified(
+    executor: &dyn CommandExecutor,
+    tool: &DependencyTool,
+    installed_path: &Path,
+) -> bool {
+    if tool == &DYLINT_LINK_TOOL {
+        dylint_link_probe_succeeds(installed_path)
+    } else {
+        is_tool_installed(executor, tool)
+    }
 }
 
 pub(super) fn command_error_message(output: &Output) -> String {

--- a/installer/src/deps/tests.rs
+++ b/installer/src/deps/tests.rs
@@ -281,6 +281,84 @@ fn install_dylint_tools_skips_dylint_link_when_cargo_dylint_source_build_install
     executor.assert_finished();
 }
 
+/// Writes a fake `dylint-link` into a temporary directory and returns the
+/// directory guard alongside the binary path.
+fn staged_dylint_link(exit_code: i32) -> std::io::Result<(tempfile::TempDir, PathBuf)> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("dylint-link");
+    crate::test_utils::dependency_binary_helpers::write_fake_binary_with_status(
+        &path, true, exit_code,
+    );
+    Ok((dir, path))
+}
+
+#[test]
+fn install_dylint_tools_uses_repository_release_for_dylint_link() {
+    // `dylint-link` cannot report a version, and Cargo's registry never
+    // records repository extractions, so verification must probe the
+    // extracted binary directly rather than consult the executor.
+    let (_dir, binary_path) = staged_dylint_link(0).expect("stage fake dylint-link");
+    let mut repository_installer = MockDependencyBinaryInstaller::new();
+    repository_installer
+        .expect_install()
+        .returning(move |_, _, _| Ok(binary_path.clone()));
+    let executor = StubExecutor::new(vec![binstall_version_check_with_result(Ok(
+        success_output(),
+    ))]);
+    let mut stderr = Vec::new();
+
+    install_dylint_tools_with_options(
+        &executor,
+        &DylintToolStatus {
+            cargo_dylint: true,
+            dylint_link: false,
+        },
+        &mut stderr,
+        install_options(&repository_installer, false),
+    )
+    .expect("repository install should satisfy dylint-link");
+
+    let output = String::from_utf8(stderr).expect("stderr should be UTF-8");
+    assert!(output.contains("Installed dylint-link from repository release."));
+    assert!(!output.contains("failed verification"));
+    executor.assert_finished();
+}
+
+#[test]
+fn install_dylint_tools_falls_back_when_dylint_link_probe_fails() {
+    let (_dir, binary_path) = staged_dylint_link(1).expect("stage fake dylint-link");
+    let mut repository_installer = MockDependencyBinaryInstaller::new();
+    repository_installer
+        .expect_install()
+        .returning(move |_, _, _| Ok(binary_path.clone()));
+    let executor = StubExecutor::new(vec![
+        binstall_version_check_with_result(Ok(success_output())),
+        binstall_install("dylint-link", Ok(success_output())),
+        // The post-binstall check probes the PATH binary and then confirms
+        // the version against Cargo's installed-binary registry.
+        dylint_link_install_list_check(),
+    ]);
+    let mut stderr = Vec::new();
+
+    with_fake_binary_on_path("dylint-link", || {
+        install_dylint_tools_with_options(
+            &executor,
+            &DylintToolStatus {
+                cargo_dylint: true,
+                dylint_link: false,
+            },
+            &mut stderr,
+            install_options(&repository_installer, false),
+        )
+        .expect("binstall fallback should succeed");
+    });
+
+    let output = String::from_utf8(stderr).expect("stderr should be UTF-8");
+    assert!(output.contains("Repository install for dylint-link failed verification"));
+    assert!(output.contains("Installed dylint-link with cargo binstall."));
+    executor.assert_finished();
+}
+
 #[test]
 fn install_tool_errors_when_dependency_manifest_entry_is_missing() {
     let missing_tool = DependencyTool {

--- a/installer/src/deps/tests.rs
+++ b/installer/src/deps/tests.rs
@@ -285,7 +285,10 @@ fn install_dylint_tools_skips_dylint_link_when_cargo_dylint_source_build_install
 /// directory guard alongside the binary path.
 fn staged_dylint_link(exit_code: i32) -> std::io::Result<(tempfile::TempDir, PathBuf)> {
     let dir = tempfile::tempdir()?;
-    let path = dir.path().join("dylint-link");
+    let path = crate::test_utils::dependency_binary_helpers::path_binary_location(
+        dir.path(),
+        "dylint-link",
+    );
     crate::test_utils::dependency_binary_helpers::write_fake_binary_with_status(
         &path, true, exit_code,
     );

--- a/installer/src/test_utils/dependency_binary_helpers.rs
+++ b/installer/src/test_utils/dependency_binary_helpers.rs
@@ -239,11 +239,13 @@ pub fn repository_verification_call(tool: &str, verification_fails: bool) -> Opt
                 Ok(cargo_dylint_version_output())
             },
         }),
-        // Successful verification consults Cargo's installed-binary registry
-        // once the PATH existence probe passes. A failing verification is
-        // modelled as the binary being absent from PATH, which short-circuits
-        // before the executor is consulted.
-        "dylint-link" => (!verification_fails).then(dylint_link_install_list_check),
+        // Repository installs of dylint-link are verified by probing the
+        // extracted binary directly, so neither outcome consults the
+        // executor.
+        "dylint-link" => {
+            let _ = verification_fails;
+            None
+        }
         other => panic!("unexpected tool: {other}"),
     }
 }

--- a/installer/src/test_utils/dependency_binary_helpers.rs
+++ b/installer/src/test_utils/dependency_binary_helpers.rs
@@ -106,8 +106,10 @@ pub fn with_fake_binary_on_path<T>(binary_name: &str, run: impl FnOnce() -> T) -
     )
 }
 
+/// Joins `binary_name` onto `directory` with the platform executable suffix,
+/// so directly probed fakes are runnable on Windows as well as Unix.
 #[cfg(any(test, feature = "test-support"))]
-fn path_binary_location(directory: &Path, binary_name: &str) -> PathBuf {
+pub fn path_binary_location(directory: &Path, binary_name: &str) -> PathBuf {
     #[cfg(windows)]
     {
         directory.join(format!("{binary_name}.cmd"))

--- a/installer/src/test_utils/dependency_binary_helpers_tests.rs
+++ b/installer/src/test_utils/dependency_binary_helpers_tests.rs
@@ -22,27 +22,13 @@ fn repository_verification_call_returns_probe_for_cargo_dylint() {
     );
 }
 
-#[test]
-fn repository_verification_call_consults_install_list_for_dylint_link() {
-    let call = repository_verification_call("dylint-link", false)
-        .expect("successful dylint-link verification should query the install list");
-
-    assert_eq!(call.cmd, "cargo");
-    assert_eq!(call.args, vec!["install", "--list"]);
-    let output = call.result.expect("install list query should succeed");
-    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
-    assert!(
-        stdout.contains(&format!(
-            "dylint-link v{}:",
-            dependency_version("dylint-link")
-        )),
-        "expected stdout to list the manifest version, got {stdout:?}"
-    );
-}
-
-#[test]
-fn repository_verification_call_skips_executor_for_failed_dylint_link() {
-    assert!(repository_verification_call("dylint-link", true).is_none());
+#[rstest::rstest]
+#[case::successful_verification(false)]
+#[case::failed_verification(true)]
+fn repository_verification_call_skips_executor_for_dylint_link(#[case] verification_fails: bool) {
+    // Repository installs of dylint-link are verified by probing the
+    // extracted binary directly, so no executor call is expected either way.
+    assert!(repository_verification_call("dylint-link", verification_fails).is_none());
 }
 
 #[test]
@@ -66,7 +52,7 @@ fn expected_calls_include_repository_probe_for_cargo_dylint() {
 }
 
 #[test]
-fn expected_calls_include_install_list_probe_for_dylint_link() {
+fn expected_calls_omit_executor_verification_for_dylint_link() {
     let calls = expected_calls(
         "dylint-link",
         ExpectedCallConfig {
@@ -80,9 +66,7 @@ fn expected_calls_include_install_list_probe_for_dylint_link() {
         },
     );
 
-    assert_eq!(calls.len(), 2);
+    assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].cmd, "cargo");
     assert_eq!(calls[0].args, vec!["binstall", "--version"]);
-    assert_eq!(calls[1].cmd, "cargo");
-    assert_eq!(calls[1].args, vec!["install", "--list"]);
 }

--- a/installer/tests/behaviour_dependency_binaries.rs
+++ b/installer/tests/behaviour_dependency_binaries.rs
@@ -18,7 +18,9 @@ use whitaker_installer::installer_packaging::TargetTriple;
 use whitaker_installer::test_support::env_test_guard;
 use whitaker_installer::test_utils::{
     StubDirs, StubExecutor,
-    dependency_binary_helpers::{ExpectedCallConfig, expected_calls, write_fake_binary},
+    dependency_binary_helpers::{
+        ExpectedCallConfig, expected_calls, path_binary_location, write_fake_binary,
+    },
 };
 
 enum RepositoryInstallerBehaviour {
@@ -43,9 +45,12 @@ impl DependencyBinaryInstaller for StubRepositoryInstaller {
                 || Err(DependencyBinaryInstallError::MissingBinDir),
                 |bin_dir| {
                     // Stage a runnable fake at the returned path: dylint-link
-                    // verification probes the extracted binary directly.
-                    let installed_path =
-                        bin_dir.join(format!("{}-{}", dependency.package(), target));
+                    // verification probes the extracted binary directly. The
+                    // platform suffix keeps the fake executable on Windows.
+                    let installed_path = path_binary_location(
+                        &bin_dir,
+                        &format!("{}-{}", dependency.package(), target),
+                    );
                     write_fake_binary(&installed_path, true);
                     Ok(installed_path)
                 },

--- a/installer/tests/behaviour_dependency_binaries.rs
+++ b/installer/tests/behaviour_dependency_binaries.rs
@@ -41,7 +41,14 @@ impl DependencyBinaryInstaller for StubRepositoryInstaller {
         match &self.behaviour {
             RepositoryInstallerBehaviour::Success => dirs.bin_dir().map_or_else(
                 || Err(DependencyBinaryInstallError::MissingBinDir),
-                |bin_dir| Ok(bin_dir.join(format!("{}-{}", dependency.package(), target))),
+                |bin_dir| {
+                    // Stage a runnable fake at the returned path: dylint-link
+                    // verification probes the extracted binary directly.
+                    let installed_path =
+                        bin_dir.join(format!("{}-{}", dependency.package(), target));
+                    write_fake_binary(&installed_path, true);
+                    Ok(installed_path)
+                },
             ),
             RepositoryInstallerBehaviour::NotFound => Err(DependencyBinaryInstallError::NotFound {
                 url: format!(


### PR DESCRIPTION
## Summary

This branch fixes the repository-release verification for `dylint-link`, which failed unconditionally in installer 0.2.6 and defeated the dependency-binary assets restored by #291.

Closes #294.

The generic post-install check requires `cargo install --list` to record the tool at the manifest-pinned version, but repository extractions into the user bin directory never appear in Cargo's installed-binary registry, so every repository install of `dylint-link` was rejected. Each estate CI run then recompiled `dylint-link` from source (roughly twenty-five seconds per run), and repositories whose pinned toolchain predates rustc 1.93 (evert, lag-complexity, podbot, lille) hard-failed on the crate's rustc floor. The branch verifies repository installs by probing the freshly extracted binary path directly: the release asset name pins the version and the download has already been verified, so a successful probe is sufficient evidence. The registry-backed gate still governs pre-install staleness detection, where it exists to force upgrades of stale cargo-installed tools. `cargo-dylint` keeps the generic check because it reports its own version and must be discoverable by Cargo as a subcommand.

## Review walkthrough

- Start with [installer/src/deps/install.rs](https://github.com/leynos/whitaker/blob/fix-dylint-link-verification/installer/src/deps/install.rs) for the new `repository_install_verified` helper and the match-arm change that routes `dylint-link` through a direct probe of the extracted binary.
- Then review [installer/src/deps/tests.rs](https://github.com/leynos/whitaker/blob/fix-dylint-link-verification/installer/src/deps/tests.rs) for the two new unit tests: a repository-release success that stages a runnable fake `dylint-link`, and a probe-failure case that exercises the binstall fallback.
- [installer/src/test_utils/dependency_binary_helpers.rs](https://github.com/leynos/whitaker/blob/fix-dylint-link-verification/installer/src/test_utils/dependency_binary_helpers.rs) and [installer/src/test_utils/dependency_binary_helpers_tests.rs](https://github.com/leynos/whitaker/blob/fix-dylint-link-verification/installer/src/test_utils/dependency_binary_helpers_tests.rs) drop the now-obsolete `cargo install --list` expectation from the dylint-link verification helpers.
- Finish with [installer/tests/behaviour_dependency_binaries.rs](https://github.com/leynos/whitaker/blob/fix-dylint-link-verification/installer/tests/behaviour_dependency_binaries.rs), where the stub repository installer now stages a runnable fake at the path it returns so the behaviour scenario exercises the real probe.

## Validation

- `make check-fmt`, `make lint`, `make typecheck`, `make test`, `make markdownlint`, `make nixie`: all pass (1461 tests passed, 3 skipped).
- Local end-to-end reproduction: a sandboxed `whitaker-installer` run with a scratch `XDG_BIN_HOME` reproduced the estate failure on 0.2.6 and reports `Installed dylint-link from repository release.` with this branch.
- Diagnosis evidence on `ubuntu-latest` is recorded in #294: the extracted release binary probes successfully by hand while 0.2.6 still reports failed verification, isolating the fault to the registry gate.

## Notes

A follow-up installer release is needed before the four blocked estate repositories can go green; their pinned toolchains cannot compile `dylint-link` 6.0.1 from source.
