### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/adr-004-pin-only-mutation-testing-contract.md
+++ b/docs/adr-004-pin-only-mutation-testing-contract.md
@@ -1,0 +1,78 @@
+# Architectural decision record (ADR) 004: pin-only mutation-testing contract
+
+## Status
+
+Accepted (2026-07-23): Keep Whitaker's mutation-testing adoption pin-only and
+contract-test its declared configuration rather than claiming parity with the
+continuous integration (CI) test baseline.
+
+## Date
+
+2026-07-23.
+
+## Context and problem statement
+
+Whitaker delegates mutation testing to the shared
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml` workflow. The
+caller supplies workspace paths, exclusion globs, and `--all-features`, but the
+shared workflow cannot reproduce the per-invocation `RUSTFLAGS` used by the
+repository's `test` and `typecheck` Makefile targets.
+
+Those flags are required by the `whitaker`, `function_attrs_follow_docs`,
+`module_max_lines`, and `no_expect_outside_tests` crates when the
+`dylint-driver` feature enables `feature(rustc_private)`. Applying the flags
+workspace-wide is not viable because, as documented in `.cargo/config.toml`,
+they break `cargo install` for `whitaker-installer`.
+
+The decision is whether the mutation workflow should claim a workspace baseline
+equivalent to `make test`, or expose the closest safe mutation scope and test
+only that declared configuration.
+
+## Decision drivers
+
+- Keep the mutation workflow usable without breaking installer builds.
+- Describe the mutation scope honestly rather than imply CI parity.
+- Detect accidental caller drift while permitting automated commit-pin updates.
+- Keep mutation testing informational and independent of pull-request gates.
+
+## Options considered
+
+### Option A: require full CI-baseline parity
+
+Pass a workspace-testing argument and treat the mutation run as equivalent to
+`make test`. This is not implementable through the current shared workflow
+because it cannot inject the required flags per crate.
+
+### Option B: exclude every crate that needs dynamic-linking flags
+
+Remove the affected crates from mutation scope. This would make the workflow
+run reliably, but would deliberately omit important production code and make
+the reported scope less useful.
+
+### Option C: adopt a pin-only declared-configuration contract
+
+Run the closest safe approximation supported by the shared workflow and test
+the caller's security and configuration shape without asserting that a full
+workspace mutation baseline passes.
+
+## Decision outcome / proposed direction
+
+Adopt Option C.
+
+In the context of shared mutation testing, facing incompatible per-crate
+compiler-flag requirements, Whitaker chooses a pin-only declared-configuration
+contract over either claimed CI parity or excluding every affected crate, to
+retain useful informational mutation coverage while accepting that the run
+cannot reproduce `make test` crate-for-crate.
+
+The caller remains pinned to a full commit SHA. Its contract test validates the
+pin shape, permissions, concurrency, triggers, and declared inputs. It does not
+hard-code the pin value or assert successful full-workspace mutation testing.
+
+## Known risks and limitations
+
+- Mutation results do not certify the same crate scope as `make test`.
+- Crates needing the dynamic-linking flags may fail or provide incomplete
+  mutation results under the shared workflow.
+- The decision must be revisited if the shared workflow gains a safe per-crate
+  mechanism for supplying the required flags.

--- a/docs/adr-004-pin-only-mutation-testing-contract.md
+++ b/docs/adr-004-pin-only-mutation-testing-contract.md
@@ -2,13 +2,13 @@
 
 ## Status
 
-Accepted (2026-07-23): Keep Whitaker's mutation-testing adoption pin-only and
+Accepted (2026-07-22): Keep Whitaker's mutation-testing adoption pin-only and
 contract-test its declared configuration rather than claiming parity with the
 continuous integration (CI) test baseline.
 
 ## Date
 
-2026-07-23.
+2026-07-22.
 
 ## Context and problem statement
 
@@ -37,23 +37,13 @@ only that declared configuration.
 
 ## Options considered
 
-### Option A: require full CI-baseline parity
+| Option                                                  | Shared-workflow feasibility                                                                         | Mutation coverage                                                               | Operational risk                                                                   | CI-baseline claim / verification                                                                 | Rationale                                                                               |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| A: require full CI-baseline parity                      | Unsafe and unimplementable: the current shared workflow cannot inject the required flags per crate. | Aims for full workspace coverage equivalent to `make test`.                     | Applying the flags workspace-wide breaks `cargo install` for `whitaker-installer`. | Would claim parity, but cannot verify it through the shared workflow.                            | Missing per-crate flags make this option unsafe and unimplementable.                    |
+| B: exclude every crate that needs dynamic-linking flags | Runs reliably with the shared workflow by removing the affected crates.                             | Omits important production code, making the reported scope less useful.         | Lower run risk, but accepts the risk of untested affected crates.                  | Makes no full-baseline claim; verification covers only the reduced scope.                        | Reliable execution deliberately omits important affected crates.                        |
+| C: adopt a pin-only declared-configuration contract     | Closest safe approximation supported by the shared workflow.                                        | Retains useful informational coverage without claiming full workspace coverage. | Keeps mutation testing informational and independent of pull-request gates.        | Verifies the caller's declared security and configuration shape, not a full workspace assertion. | A declared-shape contract is the closest safe approximation, not full workspace parity. |
 
-Pass a workspace-testing argument and treat the mutation run as equivalent to
-`make test`. This is not implementable through the current shared workflow
-because it cannot inject the required flags per crate.
-
-### Option B: exclude every crate that needs dynamic-linking flags
-
-Remove the affected crates from mutation scope. This would make the workflow
-run reliably, but would deliberately omit important production code and make
-the reported scope less useful.
-
-### Option C: adopt a pin-only declared-configuration contract
-
-Run the closest safe approximation supported by the shared workflow and test
-the caller's security and configuration shape without asserting that a full
-workspace mutation baseline passes.
+_Table 1: Comparison of mutation-testing options._
 
 ## Decision outcome / proposed direction
 

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -79,6 +79,10 @@
   pipeline](adr-003-formal-proof-strategy-for-clone-detector-pipeline.md)
   records the formal verification direction for the clone detector pipeline and
   its proof boundaries.
+- [Architectural decision record (ADR) 004: pin-only mutation-testing
+  contract](adr-004-pin-only-mutation-testing-contract.md) records why the
+  shared mutation workflow tests its declared configuration without claiming
+  parity with the continuous integration test baseline.
 
 ## Requests for comments
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -341,14 +341,14 @@ adoption is **pin-only**: the caller declares the best approximation of the CI
 scope it safely can, rather than a `--test-workspace` run that mirrors
 `make test` crate-for-crate, and the contract test asserts only that this
 declared configuration holds — not that a full workspace mutation baseline
-passes.
+passes. [ADR 004](adr-004-pin-only-mutation-testing-contract.md) records this
+decision, its alternatives, and the accepted limitations.
 
 The `uses:` reference pins the shared workflow to a full 40-character commit
 SHA rather than a branch or tag, so a force-push upstream cannot silently
 change what runs here. The contract test asserts only that the pin is a full
 commit SHA, not a particular value, so Dependabot bumps it automatically
 without any accompanying test edit.
-
 
 ### Workflow contract tests
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -291,6 +291,92 @@ make check-fmt  # Verify formatting
 make fmt        # Apply formatting
 ```
 
+
+## Mutation-testing workflow contract tests
+
+Whitaker runs scheduled, informational mutation testing through a thin caller
+workflow, [`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy
+lifting — running `cargo-mutants`, sharding, and summarizing survivors — lives
+in `shared-actions`; this repository carries only declarative configuration.
+The run is **informational only**: it never gates a pull request. Survivors
+are reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check.
+
+The workflow runs in two modes. A **daily schedule** (04:50 UTC) fires a
+change-scoped run that mutates only the source files touched within the
+detection window, so quiet days are cheap no-ops. A **manual dispatch** (the
+Actions "Run workflow" control) mutates the whole workspace; select a branch
+in that control to exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `paths` — `src/,common/,crates/,installer/,suite/`, the workspace member
+  prefixes rooted at the repository root; there are no top-level `examples/`
+  or `benches/` directories to add.
+- `exclude-globs` — scaffolding whose surviving mutants would be noise rather
+  than genuine test gaps: the `rustc_*` proxy crates and the `clippy_utils`
+  stub (both re-export compiler internals), each lint's `ui/` and `examples/`
+  dylint fixtures, and the shared test infrastructure in `src/testing` and
+  `common/src/test_support`.
+- `extra-args` — `--all-features`, matching the feature baseline the
+  Makefile's `CARGO_FLAGS` uses for `make test`, so feature-gated code is not
+  reported as untested.
+
+Unlike the excludes applied by `make test`'s `TEST_EXCLUDES`, the mutation
+caller does **not** exclude the `whitaker` root crate or the
+`function_attrs_follow_docs`, `module_max_lines`, and `no_expect_outside_tests`
+lint crates from mutation scope (only their `ui/`/`examples/` fixtures are
+excluded). Those crates enable `feature(rustc_private)` under the
+`dylint-driver` feature and need the dynamic-linking `RUSTFLAGS`
+(`-C prefer-dynamic -Z force-unstable-if-unmarked`) that the `test` and
+`typecheck` Makefile targets inject per invocation — see the note in
+[`.cargo/config.toml`](../.cargo/config.toml), which deliberately keeps that
+flag out of workspace-wide configuration because it would break `cargo
+install` for `whitaker-installer`. The shared mutation workflow has no
+equivalent per-crate RUSTFLAGS step, so it cannot reproduce
+`TEST_CARGO_FLAGS` faithfully across the whole workspace. Consequently this
+adoption is **pin-only**: the caller declares the best approximation of the CI
+scope it safely can, rather than a `--test-workspace` run that mirrors
+`make test` crate-for-crate, and the contract test asserts only that this
+declared configuration holds — not that a full workspace mutation baseline
+passes.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit.
+
+
+### Workflow contract tests
+
+Because the caller is configuration rather than code, a contract test suite,
+[`tests/workflow_contracts/mutation_testing_test.py`](../tests/workflow_contracts/mutation_testing_test.py),
+pins the shape it must uphold, failing the pull request when the caller
+drifts — repointing the pin at a branch, widening the token scope, or
+dropping a configuration input — rather than letting the breakage surface
+only in a scheduled run. Run it locally with:
+
+```sh
+make test-workflow-contracts
+```
+
+which wraps `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest
+tests/workflow_contracts -q`. The suite validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to a full commit
+  SHA;
+- the `with:` block carries exactly the expected `paths`, `exclude-globs`,
+  and `extra-args` configuration described above;
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with no
+  legacy branch input.
+
 ## Proof workflows
 
 Whitaker now ships repository-managed proof tooling for the formal verification

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -291,7 +291,6 @@ make check-fmt  # Verify formatting
 make fmt        # Apply formatting
 ```
 
-
 ## Mutation-testing workflow contract tests
 
 Whitaker runs scheduled, informational mutation testing through a thin caller


### PR DESCRIPTION
## Summary

- Adds a "Mutation-testing workflow contract tests" section to
  `docs/developers-guide.md`, inserted between "Running Tests" and "Proof
  workflows" (the guide has no existing mutation-testing section and no
  table of contents/index to cross-link, so this is a new top-level `##`
  section with no TOC entry to add).
- Documents the actual caller,
  [`.github/workflows/mutation-testing.yml`](../../.github/workflows/mutation-testing.yml),
  which delegates to `leynos/shared-actions/.github/workflows/mutation-cargo.yml`
  pinned at `927edd45ae77be4251a8a18ca9eb5613a2e32cbd`, its real `with:`
  inputs (`paths`, `exclude-globs`, `extra-args: --all-features`), and the
  contract test at
  [`tests/workflow_contracts/mutation_testing_test.py`](../../tests/workflow_contracts/mutation_testing_test.py).
- Documents the **pin-only adoption** rationale specific to this repository:
  the mutation caller's `exclude-globs` does not (and cannot) fully mirror
  `make test`'s `TEST_EXCLUDES`, because the excluded crates
  (`whitaker`, `function_attrs_follow_docs`, `module_max_lines`,
  `no_expect_outside_tests`) use `feature(rustc_private)` under the
  `dylint-driver` feature and need the dynamic-linking `RUSTFLAGS`
  (`-C prefer-dynamic -Z force-unstable-if-unmarked`) injected only by the
  `test`/`typecheck` Makefile targets — see the note in
  `.cargo/config.toml`. The shared mutation workflow has no equivalent
  per-crate RUSTFLAGS step, so this repository does not (and cannot) run a
  full `--test-workspace` mutation baseline matching the CI test scope
  wholesale. The section states this honestly rather than claiming parity.

## Details

- Contract-test style: **shape-only** (`USES_RE` regex asserting a full
  40-hex commit SHA pin, not a hard-coded value), so Dependabot bumps the
  pin without an accompanying test edit. No `pytestmark`/`skipif` guard is
  present or needed — this is a Rust workspace, not a Python package whose
  tests run inside a mutmut sandbox.
- Local run command documented: `make test-workflow-contracts`, which wraps
  `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest
  tests/workflow_contracts -q`.
- Roadmap/execplan tracking: checked `docs/roadmap.md` and
  `docs/execplans/*` — no task references mutation testing or this doc
  work, so no roadmap/execplan tracking applies and none was
  annotated.
- Docs lint: ran `make markdownlint` (spelling via `typos`, then
  `markdownlint-cli2` across all 69 Markdown files in the repository).
  Both passed with zero errors after fixing two `-ise`/`-ize` spelling
  issues (`summarising` → `summarizing`, `serialises` → `serializes`) that
  the new section introduced.

## Deviations from the template

- The template's Permutation B assumed `extra-args` would carry a
  `--test-workspace`/`--workspace` flag; whitaker's caller instead uses
  `extra-args: --all-features` (matching the Makefile's `CARGO_FLAGS`
  feature baseline), with workspace-wide coverage coming from the `paths`
  input rather than a mutants flag. The section documents the real value
  and explains the pin-only reasoning instead.

Edited files: `docs/developers-guide.md`, `docs/contents.md`, and
`docs/adr-004-pin-only-mutation-testing-contract.md`.

## References

- https://lody.ai/leynos/sessions/966ada5a-3ef1-4b9b-b30b-2077b1a87bb4

## Summary by Sourcery

Document and formalize the pin-only mutation-testing workflow contract and its accepted scope limitations.

Enhancements:
- Document the mutation-testing workflow’s declared configuration, informational scope, contract-test coverage, and pin-only adoption rationale given its limitations relative to the Makefile test baseline.

Documentation:
- Add ADR 004 recording the decision to contract-test the pinned mutation workflow configuration without claiming full CI test-scope parity.
- Add the mutation-testing workflow contract-test guidance and local execution instructions to the developers guide.
- Link ADR 004 from the documentation contents page.