### PR TITLE
Trust the install pipeline for repository dylint-link artefacts (#299)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -842,7 +842,7 @@ The dependency-install path is split into focused modules under
 each dependency tool was satisfied. `install_tool()` returns
 `RepositoryRelease`, `CargoBinstall`, or `CargoInstall`, and
 `update_status_after_install()` uses that outcome to decide whether it should
-probe for `dylint-link` after installing `cargo-dylint`.
+re-check for `dylint-link` after installing `cargo-dylint`.
 
 The HTTP download layers in
 `installer/src/dependency_binaries/install/downloader.rs` and
@@ -867,8 +867,8 @@ fallback, including the direct missing-asset path, invokes
 recorded in `installer/dependency-binaries.toml` instead of silently using the
 latest upstream release.
 
-`update_status_after_install()` delegates the local-install probe decision to
-`should_refresh_companions()`. That helper returns `true` only when the install
+`update_status_after_install()` delegates the local-install re-check decision
+to `should_refresh_companions()`. That helper returns `true` only when the install
 outcome was not `RepositoryRelease` and `dylint-link` is still missing, so the
 code checks for a resolvable `dylint-link` binary only after local
 `cargo-dylint` installs and does not re-check it when the pre-built repository

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -828,11 +828,9 @@ The dependency-install path is split into focused modules under
 
 1. Attempt the repository-hosted dependency archive for the current target.
 2. Verify the installed tool is now usable. `cargo-dylint` is checked by
-   running `cargo dylint --version`, while `dylint-link` is checked by
-   resolving the executable on `PATH` and invoking it with `--help`. The probe
-   synthesizes `RUSTUP_TOOLCHAIN` from the host target when the environment
-   variable is unset, because upstream reads that variable before processing
-   CLI flags.
+   running `cargo dylint --version`. A repository-release `dylint-link` is
+   accepted on the strength of its install pipeline and is never executed;
+   see "Why `dylint-link` is never probed" below.
 3. If the repository download reports `NotFound`, skip `cargo binstall` and
    fall back directly to `cargo install`.
 4. For other repository failures, fall back to `cargo binstall` when available
@@ -876,8 +874,32 @@ code checks for a resolvable `dylint-link` binary only after local
 `cargo-dylint` installs and does not re-check it when the pre-built repository
 artefact was used or when `dylint-link` was already present.
 
+#### Why `dylint-link` is never probed
+
+`dylint-link` is a linker wrapper: it forwards its entire argument list to the
+underlying linker. It therefore has no reliable self-reporting subcommand.
+`--version` exits early, and `--help` succeeds only when a usable linker and
+toolchain are present in the ambient environment, so it reports on the
+environment rather than on the artefact. Executing it as a health check
+rejected valid, checksum-verified release artefacts and forced a
+`cargo install --locked --version 6.0.1 dylint-link` fallback that cannot
+compile on toolchains below the crate's rustc floor, breaking consumers pinned
+to older toolchains.
+
+The trust boundary for a repository-release install is the install pipeline:
+the release asset name pins the package and version, the `.sha256` sidecar
+establishes integrity, extraction confirms the expected archive member, and the
+permission step establishes launch eligibility. `repository_install_verified()`
+in `installer/src/deps/install.rs` therefore accepts `dylint-link` as soon as
+that pipeline reports success, and retains the generic version check for
+`cargo-dylint`. Genuine pipeline failures still fall back to Cargo.
+
+A Cargo-managed `dylint-link` already on `PATH` is checked by resolving an
+executable file and comparing the version Cargo recorded for it, which needs no
+execution either.
+
 The `dylint-link` verification in `installer/src/deps.rs` is implemented by
-seven small private helpers:
+five small private helpers:
 
 - `find_binary_on_path(binary_name)` returns the first executable candidate so
   the installation check can validate the exact path it found.
@@ -885,12 +907,6 @@ seven small private helpers:
   search that `find_binary_on_path()` uses while walking `PATH`.
 - `binary_candidates(directory, binary_name)` builds the ordered set of
   candidate paths that each directory contributes to the lookup.
-- `dylint_link_probe_toolchain()` preserves an existing `RUSTUP_TOOLCHAIN`
-  value or synthesizes `stable-<host-target>` so `dylint-link --help` can run
-  in the same environments where `dylint-link --version` exits early.
-- `dylint_link_probe_succeeds(path)` runs the resolved binary with `--help` and
-  requires a successful exit status before Whitaker treats the tool as
-  installed.
 - `is_executable_file(path)` applies the platform-specific file test:
   executable-bit plus regular-file checks on Unix, and `path.is_file()` on
   non-Unix targets where the executable suffix carries the meaning.

--- a/docs/execplans/install-dependency-binaries.md
+++ b/docs/execplans/install-dependency-binaries.md
@@ -238,10 +238,10 @@ Relevant existing files:
   A repository-release `dylint-link` is accepted once the verified install
   pipeline succeeds: pinned asset naming, checksum verification, expected-member
   extraction, and executable-permission (launch-eligibility) setup. A
-  Cargo-managed `dylint-link` is instead verified by resolving an executable on
-  `PATH` (honouring Windows `PATHEXT`) and comparing its version with Cargo's
-  recorded installed version. Missing tools are installed with `cargo binstall`
-  or `cargo install`.
+  Cargo-managed `dylint-link` is instead verified by two independent checks: an
+  executable resolves on `PATH` (honouring Windows `PATHEXT`), and Cargo's
+  recorded installed version for the package matches the expected version.
+  Missing tools are installed with `cargo binstall` or `cargo install`.
 - `installer/src/cli.rs`
   Existing installer flags. No new user-facing flag is required by the task,
   but this file may need a small addition only if implementation decides to

--- a/docs/execplans/install-dependency-binaries.md
+++ b/docs/execplans/install-dependency-binaries.md
@@ -233,9 +233,15 @@ The repository root is `/home/user/project`.
 Relevant existing files:
 
 - `installer/src/deps.rs`
-  Current dependency-check/install orchestration. Today it checks whether
-  `cargo dylint --version` and `dylint-link --version` succeed, then installs
-  missing tools with `cargo binstall` or `cargo install`.
+  Dependency-check/install orchestration. It verifies `cargo-dylint` by running
+  `cargo dylint --version` and never executes `dylint-link` as a health check.
+  A repository-release `dylint-link` is accepted once the verified install
+  pipeline succeeds: pinned asset naming, checksum verification, expected-member
+  extraction, and executable-permission (launch-eligibility) setup. A
+  Cargo-managed `dylint-link` is instead verified by resolving an executable on
+  `PATH` (honouring Windows `PATHEXT`) and comparing its version with Cargo's
+  recorded installed version. Missing tools are installed with `cargo binstall`
+  or `cargo install`.
 - `installer/src/cli.rs`
   Existing installer flags. No new user-facing flag is required by the task,
   but this file may need a small addition only if implementation decides to
@@ -448,7 +454,9 @@ Recommended implementation details:
    - looks up the tool in the committed manifest;
    - attempts repository download and installation;
    - verifies the installed binary by rerunning the same version command used by
-     the existing detection path;
+     the existing detection path (superseded for `dylint-link` by #299: a
+     repository-release `dylint-link` is trusted on its verified install
+     pipeline and is never executed as a health check);
    - falls back to Cargo if any repository step fails.
 3. Preserve the existing non-fatal behaviour: inability to use the repository
    path is not itself a hard installer error if Cargo fallback succeeds.
@@ -579,10 +587,12 @@ Outcomes:
    `installer/dependency-binaries.toml` manifest.
 2. Release assets now include a generated provenance/licence Markdown sidecar
    describing package names, versions, licences, and upstream repositories.
-3. The installer now attempts repository-hosted dependency binaries first,
-   verifies the installed tool command, and falls back to `cargo binstall` or
-   `cargo install` when the repository path is unavailable, verification fails,
-   or when `cargo binstall` is absent or fails.
+3. The installer now attempts repository-hosted dependency binaries first. It
+   verifies an installed `cargo-dylint` with `cargo dylint --version` but never
+   executes `dylint-link` as a health check, trusting a repository-release
+   `dylint-link` on its verified install pipeline. It falls back to
+   `cargo binstall` or `cargo install` when the repository path is unavailable,
+   verification fails, or when `cargo binstall` is absent or fails.
 4. Coverage includes unit tests for manifest parsing, packaging, and install
    orchestration plus `rstest-bdd` behavioural scenarios for repository
    success, fallback, verification failure, unsupported targets, and provenance

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -40,11 +40,12 @@ This:
    source-build path is taken, the installer reports that it is falling back to
    Cargo, and on success it prints
    `Installed <tool> from source with cargo install.`. After installation,
-   `cargo-dylint` is verified by running `cargo dylint --version`, while
-   `dylint-link` is verified by resolving the executable on `PATH` and then
-   invoking it with `--help`. The installer sets `RUSTUP_TOOLCHAIN` for that
-   probe when needed, which avoids false failures from upstream
-   `dylint-link --version` while still rejecting stale shims and broken scripts.
+   `cargo-dylint` is verified by running `cargo dylint --version`.
+   `dylint-link` is never executed: it is a linker wrapper that forwards its
+   arguments to the underlying linker, so it has no reliable self-reporting
+   subcommand. A release artefact is trusted once its checksum, extraction, and
+   executable permissions have been established, and a Cargo-managed copy is
+   checked by resolving it on `PATH` and comparing the version Cargo recorded.
 2. Clones the Whitaker repository to a platform-specific data directory
 3. Builds the lint libraries
 4. Creates `whitaker` and `whitaker-ls` wrapper scripts. `whitaker` invokes

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -59,8 +59,8 @@ After installation, run `whitaker --all` in any Rust project to lint it. Use
 On Windows, the installer's `PATH` check honours `PATHEXT` and falls back to
 the usual executable suffixes when `PATHEXT` is unset, so a normal
 Cargo-installed executable such as `dylint-link.exe` in
-`%USERPROFILE%\.cargo\bin` is located correctly and then verified with the same
-invocation-based probe without needing a separate wrapper or manual
+`%USERPROFILE%\.cargo\bin` is located correctly and then matched against the
+version Cargo recorded for it, without needing a separate wrapper or manual
 environment-variable workaround.
 
 **Options:**

--- a/installer/README.md
+++ b/installer/README.md
@@ -124,8 +124,9 @@ Dependency-tool verification is asymmetric by design:
   self-reporting subcommand: `--version` exits early, and `--help` depends on
   a usable linker and toolchain in the ambient environment. Executing it as a
   health check rejects valid artefacts. A Cargo-managed `dylint-link` is
-  instead checked by resolving an executable file on `PATH` and confirming the
-  version Cargo recorded for it, while a repository-release `dylint-link` is
+  instead checked by two independent conditions: an executable file resolves on
+  `PATH`, and Cargo's recorded installed version for the `dylint-link` package
+  matches the expected version. A repository-release `dylint-link` is
   trusted after its install pipeline succeeds (see below).
 
 For repository-release installs, the trust boundary is the pipeline itself: the

--- a/installer/README.md
+++ b/installer/README.md
@@ -119,14 +119,25 @@ snippets to simplify this setup.
 Dependency-tool verification is asymmetric by design:
 
 - `cargo-dylint` is checked by running `cargo dylint --version`.
-- `dylint-link` is checked by resolving the executable on `PATH` and then
-  invoking it with `--help`. The probe injects `RUSTUP_TOOLCHAIN` when the
-  caller has not already set it, which avoids the false negatives from
-  `dylint-link --version` while still rejecting stale shims and broken scripts.
+- `dylint-link` is never executed. It is a linker wrapper that forwards its
+  entire argument list to the underlying linker, so it has no reliable
+  self-reporting subcommand: `--version` exits early, and `--help` depends on
+  a usable linker and toolchain in the ambient environment. Executing it as a
+  health check rejects valid artefacts. A Cargo-managed `dylint-link` is
+  instead checked by resolving an executable file on `PATH` and confirming the
+  version Cargo recorded for it, while a repository-release `dylint-link` is
+  trusted on the strength of its install pipeline (see below).
+
+For repository-release installs the trust boundary is the pipeline itself: the
+release asset name pins the package and version, the `.sha256` sidecar
+establishes integrity, extraction confirms the expected archive member, and the
+permission step establishes launch eligibility. Genuine failures in any of
+those steps — a missing asset, checksum mismatch, failed download or
+extraction, or an unwritable executable — still fall back to Cargo.
 
 On Windows, the installer honours `PATHEXT` while scanning `PATH`, so the
 normal Cargo-installed `dylint-link.exe` and other shell-resolved executable
-suffixes are recognized and then verified with the same invocation-based probe.
+suffixes are recognized.
 
 The wrappers are:
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -126,9 +126,9 @@ Dependency-tool verification is asymmetric by design:
   health check rejects valid artefacts. A Cargo-managed `dylint-link` is
   instead checked by resolving an executable file on `PATH` and confirming the
   version Cargo recorded for it, while a repository-release `dylint-link` is
-  trusted on the strength of its install pipeline (see below).
+  trusted after its install pipeline succeeds (see below).
 
-For repository-release installs the trust boundary is the pipeline itself: the
+For repository-release installs, the trust boundary is the pipeline itself: the
 release asset name pins the package and version, the `.sha256` sidecar
 establishes integrity, extraction confirms the expected archive member, and the
 permission step establishes launch eligibility. Genuine failures in any of

--- a/installer/src/deps.rs
+++ b/installer/src/deps.rs
@@ -186,13 +186,10 @@ fn is_dylint_link_installed(
     executor: &dyn CommandExecutor,
     expected_version: Option<&str>,
 ) -> bool {
-    // The existence probe runs first so that a missing binary never consults
-    // the executor.
-    let is_present = match find_binary_on_path(DYLINT_LINK_TOOL.command) {
-        Some(binary_path) => dylint_link_probe_succeeds(&binary_path),
-        None => false,
-    };
-    if !is_present {
+    // Presence is established by resolving an executable file on PATH.
+    // `dylint-link` is a linker wrapper with no reliable self-reporting
+    // subcommand, so it is never executed to prove it works.
+    if find_binary_on_path(DYLINT_LINK_TOOL.command).is_none() {
         return false;
     }
     let Some(expected_version) = expected_version else {
@@ -279,31 +276,6 @@ fn find_binary_in_directory(directory: &Path, binary_name: &str) -> Option<std::
     binary_candidates(directory, binary_name)
         .into_iter()
         .find(|candidate| is_executable_file(candidate))
-}
-
-fn dylint_link_probe_succeeds(binary_path: &Path) -> bool {
-    let mut command = Command::new(binary_path);
-    command.arg("--help");
-
-    if let Some(toolchain) = dylint_link_probe_toolchain() {
-        command.env("RUSTUP_TOOLCHAIN", toolchain);
-    }
-
-    command.output().is_ok_and(|output| output.status.success())
-}
-
-fn dylint_link_probe_toolchain() -> Option<String> {
-    std::env::var("RUSTUP_TOOLCHAIN")
-        .ok()
-        .filter(|toolchain| !toolchain.trim().is_empty())
-        .or_else(|| {
-            host_target().map(|target| {
-                // `dylint-link` reads `RUSTUP_TOOLCHAIN` before it inspects CLI
-                // arguments, so the probe synthesizes a stable host toolchain
-                // when the caller did not provide one.
-                format!("stable-{}", target.as_str())
-            })
-        })
 }
 
 fn binary_candidates(directory: &Path, binary_name: &str) -> Vec<std::path::PathBuf> {

--- a/installer/src/deps/install.rs
+++ b/installer/src/deps/install.rs
@@ -8,9 +8,8 @@ use std::process::Output;
 
 use super::{
     CARGO_DYLINT_TOOL, CommandExecutor, DEPENDENCY_TOOLS, DYLINT_LINK_TOOL, DependencyTool,
-    DylintToolStatus, dylint_link_probe_succeeds, is_binstall_available, is_tool_installed,
+    DylintToolStatus, is_binstall_available, is_tool_installed,
 };
-use std::path::Path;
 
 pub(super) struct RepositoryInstallContext<'a> {
     pub(super) dirs: &'a dyn crate::dirs::BaseDirs,
@@ -104,7 +103,7 @@ pub(super) fn install_tool(
         cargo_install_plan = cargo_install_plan.with_version(dependency.version());
 
         match repo.installer.install(dependency, repo.target, repo.dirs) {
-            Ok(installed_path) if repository_install_verified(executor, tool, &installed_path) => {
+            Ok(_) if repository_install_verified(executor, tool) => {
                 write_message(
                     stderr,
                     context.quiet,
@@ -295,22 +294,28 @@ fn run_cargo_install(
 
 /// Verify a repository-release install of `tool`.
 ///
-/// `dylint-link` forwards every argument to the underlying linker and can
-/// never report its own version, and Cargo's registry of installed binaries
-/// never records repository extractions, so the generic version check would
-/// reject every repository install. The extracted binary is probed directly
-/// instead: the release asset name pins the version and the download has
-/// already been verified, so a successful probe is sufficient evidence.
-fn repository_install_verified(
-    executor: &dyn CommandExecutor,
-    tool: &DependencyTool,
-    installed_path: &Path,
-) -> bool {
+/// The trust boundary for a repository install is established entirely by the
+/// installer pipeline: the release asset name pins the package and version,
+/// the `.sha256` sidecar establishes integrity, extraction confirms the
+/// expected archive member, and the permission step establishes launch
+/// eligibility. A successful install is therefore sufficient evidence on its
+/// own.
+///
+/// `dylint-link` is additionally never executed as a health check. It is a
+/// linker wrapper that forwards its entire argument list to the underlying
+/// linker, so it has no reliable self-reporting subcommand: `--version` exits
+/// early and `--help` depends on a usable linker and toolchain in the ambient
+/// environment. Probing it rejects valid, verified artefacts and forces a
+/// source build that cannot succeed on toolchains older than the crate's
+/// rustc floor.
+///
+/// `cargo-dylint` keeps the generic check because it reports its own version
+/// and must additionally be discoverable by Cargo as a subcommand.
+fn repository_install_verified(executor: &dyn CommandExecutor, tool: &DependencyTool) -> bool {
     if tool == &DYLINT_LINK_TOOL {
-        dylint_link_probe_succeeds(installed_path)
-    } else {
-        is_tool_installed(executor, tool)
+        return true;
     }
+    is_tool_installed(executor, tool)
 }
 
 pub(super) fn command_error_message(output: &Output) -> String {

--- a/installer/src/deps/tests.rs
+++ b/installer/src/deps/tests.rs
@@ -283,27 +283,33 @@ fn install_dylint_tools_skips_dylint_link_when_cargo_dylint_source_build_install
 
 /// Writes a fake `dylint-link` into a temporary directory and returns the
 /// directory guard alongside the binary path.
-fn staged_dylint_link(exit_code: i32) -> std::io::Result<(tempfile::TempDir, PathBuf)> {
+///
+/// The fake is staged with a failing exit status so that any attempt to
+/// execute it as a health check would be observable as a verification
+/// failure.
+fn staged_unrunnable_dylint_link() -> std::io::Result<(tempfile::TempDir, PathBuf)> {
     let dir = tempfile::tempdir()?;
     let path = crate::test_utils::dependency_binary_helpers::path_binary_location(
         dir.path(),
         "dylint-link",
     );
-    crate::test_utils::dependency_binary_helpers::write_fake_binary_with_status(
-        &path, true, exit_code,
-    );
+    crate::test_utils::dependency_binary_helpers::write_fake_binary_with_status(&path, true, 1);
     Ok((dir, path))
 }
 
 #[test]
-fn install_dylint_tools_uses_repository_release_for_dylint_link() {
-    // `dylint-link` cannot report a version, and Cargo's registry never
-    // records repository extractions, so verification must probe the
-    // extracted binary directly rather than consult the executor.
-    let (_dir, binary_path) = staged_dylint_link(0).expect("stage fake dylint-link");
+fn install_dylint_tools_accepts_repository_dylint_link_without_executing_it() {
+    // `dylint-link` forwards its argument list to the underlying linker and
+    // has no reliable self-reporting subcommand, so a successful repository
+    // install is accepted on the strength of the download, checksum,
+    // extraction, and permission steps alone. Staging a fake that exits
+    // non-zero proves the binary is never executed as a health check: any
+    // such probe would reject it and fall back to Cargo.
+    let (_dir, binary_path) = staged_unrunnable_dylint_link().expect("stage fake dylint-link");
     let mut repository_installer = MockDependencyBinaryInstaller::new();
     repository_installer
         .expect_install()
+        .once()
         .returning(move |_, _, _| Ok(binary_path.clone()));
     let executor = StubExecutor::new(vec![binstall_version_check_with_result(Ok(
         success_output(),
@@ -324,20 +330,28 @@ fn install_dylint_tools_uses_repository_release_for_dylint_link() {
     let output = String::from_utf8(stderr).expect("stderr should be UTF-8");
     assert!(output.contains("Installed dylint-link from repository release."));
     assert!(!output.contains("failed verification"));
+    // No Cargo command beyond the binstall-availability probe may run: a
+    // source build of dylint-link cannot succeed on toolchains below the
+    // crate's rustc floor.
     executor.assert_finished();
 }
 
 #[test]
-fn install_dylint_tools_falls_back_when_dylint_link_probe_fails() {
-    let (_dir, binary_path) = staged_dylint_link(1).expect("stage fake dylint-link");
+fn install_dylint_tools_falls_back_when_repository_dylint_link_install_fails() {
+    // Genuine repository failures — missing asset, checksum mismatch,
+    // extraction failure, or an unwritable executable — must still fall back
+    // to Cargo.
     let mut repository_installer = MockDependencyBinaryInstaller::new();
-    repository_installer
-        .expect_install()
-        .returning(move |_, _, _| Ok(binary_path.clone()));
+    repository_installer.expect_install().returning(|_, _, _| {
+        Err(DependencyBinaryInstallError::Install {
+            binary: "dylint-link".to_owned(),
+            reason: "checksum mismatch".to_owned(),
+        })
+    });
     let executor = StubExecutor::new(vec![
         binstall_version_check_with_result(Ok(success_output())),
         binstall_install("dylint-link", Ok(success_output())),
-        // The post-binstall check probes the PATH binary and then confirms
+        // The post-binstall check resolves the PATH binary and then confirms
         // the version against Cargo's installed-binary registry.
         dylint_link_install_list_check(),
     ]);
@@ -357,7 +371,7 @@ fn install_dylint_tools_falls_back_when_dylint_link_probe_fails() {
     });
 
     let output = String::from_utf8(stderr).expect("stderr should be UTF-8");
-    assert!(output.contains("Repository install for dylint-link failed verification"));
+    assert!(output.contains("Repository install for dylint-link unavailable"));
     assert!(output.contains("Installed dylint-link with cargo binstall."));
     executor.assert_finished();
 }


### PR DESCRIPTION
## Summary

This branch stops the installer from executing `dylint-link` as a health check, so a valid, checksum-verified repository artefact is no longer rejected and no longer forces an impossible source build on consumers pinned to older toolchains.

Closes #299.

`dylint-link` is a linker wrapper: it forwards its entire argument list to the underlying linker, so it has no reliable self-reporting subcommand. `--version` exits early, and `--help` succeeds only when a usable linker and toolchain are present in the ambient environment, which means it reports on the environment rather than on the artefact. When that probe failed, verification fell back to `cargo install --locked --version 6.0.1 dylint-link`, which cannot compile Dylint 6.0.1's resolved dependency graph on older toolchains (`cargo-platform` 0.3.3 requires Rust 1.91, `cargo_metadata` 0.23.1 requires 1.86, and `home` 0.5.12 requires 1.88). A consumer pinned to Rust 1.85.0 therefore failed its lint gate outright despite the correct artefact having been downloaded and verified, as seen in [leynos/cuprum#158](https://github.com/leynos/cuprum/pull/158).

A repository-release install is now accepted as soon as the install pipeline reports success. That pipeline is the trust boundary: the release asset name pins the package and version, the `.sha256` sidecar establishes integrity, extraction confirms the expected archive member, and the permission step establishes launch eligibility. Genuine failures in any of those steps still fall back to Cargo, the pinned 6.0.1 version is unchanged, and `cargo-dylint` keeps its version check because it reports its own version and must be discoverable by Cargo as a subcommand.

This is a follow-on to #294, which fixed verification consulting Cargo's install registry; the direct-probe replacement introduced there is what this branch removes.

## Review walkthrough

- Start with [installer/src/deps/install.rs](https://github.com/leynos/whitaker/blob/fix-dylint-link-probe-removal/installer/src/deps/install.rs) for `repository_install_verified()`, which now accepts `dylint-link` on a successful install and documents the trust boundary.
- Then review [installer/src/deps.rs](https://github.com/leynos/whitaker/blob/fix-dylint-link-probe-removal/installer/src/deps.rs), where `dylint_link_probe_succeeds()` and `dylint_link_probe_toolchain()` are removed and the `PATH` presence check resolves an executable file without running it. A Cargo-managed `dylint-link` is still matched against the version Cargo recorded for it.
- [installer/src/deps/tests.rs](https://github.com/leynos/whitaker/blob/fix-dylint-link-probe-removal/installer/src/deps/tests.rs) carries the regression coverage: `install_dylint_tools_accepts_repository_dylint_link_without_executing_it` stages a fake that exits non-zero, so any execution-based probe would reject it, and asserts the executor sees no Cargo command beyond the binstall-availability check. `install_dylint_tools_falls_back_when_repository_dylint_link_install_fails` proves a genuine pipeline failure still falls back to Cargo.
- Finish with the documentation corrections in [installer/README.md](https://github.com/leynos/whitaker/blob/fix-dylint-link-probe-removal/installer/README.md), [docs/developers-guide.md](https://github.com/leynos/whitaker/blob/fix-dylint-link-probe-removal/docs/developers-guide.md), and [docs/users-guide.md](https://github.com/leynos/whitaker/blob/fix-dylint-link-probe-removal/docs/users-guide.md), which replace the stale claim that the installer verifies `dylint-link` by invoking `--help`.
- Finally, [docs/execplans/install-dependency-binaries.md](https://github.com/leynos/whitaker/blob/fix-dylint-link-probe-removal/docs/execplans/install-dependency-binaries.md) brings the living execplan into line with the no-execution model: its "Context and orientation" and Outcomes summaries now describe the asymmetric verification, and the superseded Stage F command-verification recommendation is labelled with a pointer to #299 rather than left reading as current behaviour.

## Validation

- `make check-fmt`, `make lint`, `make typecheck`, `make test`, `make markdownlint`, `make nixie`: all pass. The suite reports 1461 passed, 3 skipped.
- The new regression test was falsified before being accepted: temporarily reinstating an execution-based probe makes `install_dylint_tools_accepts_repository_dylint_link_without_executing_it` fail, and removing it again makes it pass. The test therefore cannot silently stop guarding the behaviour.

## Notes

A new `whitaker-installer` release is required before consumers can take the fix. Once it is published, `leynos/cuprum/.github/workflows/ci.yml` needs `WHITAKER_INSTALLER_VERSION` set to the released version and its Whitaker cache key bumped from `whitaker-v4-` so stale cached installer state cannot mask the upgrade, after which the `lint-test` job should get past `whitaker-installer --cranelift` under Rust 1.85.0 with no Cargo source installation of `dylint-link`. No consumer toolchain pin is altered and the lint gate is unchanged.


## References

- Lody session: https://lody.ai/leynos/sessions/2023fd27-9c1f-4ba1-9a90-fab1ed65783b
