### PR TITLE
Plan: Implement `string_continuation_style` as a post-expansion early lint (2.4.1)

### DIFF
--- a/docs/execplans/2-2-10-string-continuation-style-post-expansion-early-lint.md
+++ b/docs/execplans/2-2-10-string-continuation-style-post-expansion-early-lint.md
@@ -5,7 +5,9 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision log`, `Outcomes & retrospective`, `Conformance basis`, and
 `Verification plan` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: DRAFT — awaiting approval. Three decisions need the approver's
+answer before implementation starts: `DEC-009` (scope), `DEC-013` (release
+applicability default), and `DEC-014` (one lint name or two).
 
 ## Purpose / big picture
 
@@ -22,8 +24,8 @@ let text = "alpha \
 ```
 
 and runs `cargo whitaker` (or `cargo dylint --lib string_continuation_style`)
-sees a warning offering a machine-applicable fix that rewrites the expression
-to `concat!("alpha ", "beta")`, byte-for-byte equivalent at runtime. The same
+sees a warning offering a fix that rewrites the expression to
+`concat!("alpha ", "beta")`, byte-for-byte equivalent at runtime. The same
 author who writes
 
 ```rust
@@ -40,13 +42,16 @@ asymmetric: it fires only when the replacement is proven safe.
 
 Observable success:
 
-1. `cargo test -p string_continuation_style` passes, including a UI matrix
-   that pins both the firing and non-firing cases.
+1. `cargo nextest run -p string_continuation_style` passes, including a UI
+   matrix that pins both the firing and the non-firing cases, and in which
+   every machine-applicable suggestion is actually applied by `rustfix`,
+   recompiled, and asserted to preserve the evaluated string.
 2. The suite library reports the new lint:
    `cargo dylint list` includes `string_continuation_style`.
-3. `docs/users-guide.md` documents the rule and its exemptions.
+3. `docs/users-guide.md` documents the rule, its exemptions, its
+   configuration, and how to ask it why it did or did not fire.
 4. Running the lint over Whitaker itself produces no findings on the
-   pull-request-296 fixture reproduced in `crates/string_continuation_style/ui/`.
+   pull-request-296 fixture reproduced in the crate's `ui/` directory.
 
 ## Constraints
 
@@ -55,390 +60,654 @@ Hard invariants. Violating one requires escalation, not a workaround.
 - **Evaluated-value preservation.** A suggested rewrite must produce a string
   whose evaluated bytes are identical to the original literal's. There is no
   acceptable margin here.
+- **Never emit a suggestion that has not been checked at run time.** Before
+  attaching any applicability above `MaybeIncorrect`, the lint must itself
+  compare the original literal's evaluated bytes against the replacement's.
+  On mismatch it emits nothing. See `LEM-EMIT-1`.
 - **Near-zero false positives.** When the lint cannot prove safety it must be
-  silent. It must never emit an unfixable style complaint. Prefer
-  `Ignore`/`RequireContinuation` over a speculative diagnostic.
+  silent. Prefer `Ignore`/`RequireContinuation` over a speculative diagnostic.
+- **The adapter never panics.** A panicking `EarlyLintPass` aborts the user's
+  build with an internal-compiler-error-shaped message that looks like a
+  compiler bug. Every fallible recovery maps to a `RequireContinuation` or
+  `Ignore` disposition. No `#[expect]` of a panic-class lint
+  (`unwrap_used`, `expect_used`, `indexing_slicing`, `string_slice`,
+  `panic_in_result_fn`, `unreachable`) is permitted anywhere in either new
+  crate. All offset arithmetic uses `checked_*`; `None` means
+  `UnrecoverableSourceSpan`.
 - **No macro-argument surgery.** The lint must not add explicit format
   arguments (`status_line = status_line`) to unlock a rewrite. See RFC 0002
   §Non-goals.
 - **Module size.** No source file added by this work may exceed 400 lines
-  (`AGENTS.md` §Code style, enforced by Whitaker's own `module_max_lines`).
-- **British English.** Comments and documentation use en-GB-oxendict spelling
-  (`AGENTS.md`), except where quoting an external API.
-- **Domain purity.** The pure classification, scanning, and rewrite-construction
-  logic must not import `rustc_*` types. It must be unit-testable without a
-  compiler session. See §Interfaces and dependencies.
+  (`AGENTS.md` §Code style).
+- **British English.** Comments and documentation use en-GB-oxendict spelling,
+  except where quoting an external API.
+- **Domain purity.** The pure scanning, classification, and
+  rewrite-construction logic lives in a crate that has no `rustc_*`
+  dependency at all. See `DEC-010`.
 - **No changes to existing lints' behaviour.** This plan adds a lint; it must
-  not alter the diagnostics of the nine existing standard lints.
+  not alter the diagnostics of the nine existing standard lints. The one
+  exception is `bumpy_road_function`, which migrates onto the shared label
+  helper of `DEC-012` with identical output, pinned by its existing fixtures.
 - **Suite structure.** Do not force an early pass into
-  `rustc_lint::late_lint_methods!`/`declare_combined_late_lint_pass!`. Register
-  it separately (RFC 0002 §Suite integration).
-- **Toolchain.** `rust-toolchain.toml` pins `nightly-2026-05-28`. Do not bump it.
+  `rustc_lint::late_lint_methods!`/`declare_combined_late_lint_pass!`.
+  Register it separately (RFC 0002 §Suite integration).
+- **Toolchain.** `rust-toolchain.toml` pins `nightly-2026-05-28`. Do not bump
+  it.
 
 ## Tolerances (exception triggers)
 
-- **Scope.** If implementation requires touching more than 45 files, or more
-  than 3500 net lines outside `crates/string_continuation_style/`, stop and
-  escalate.
-- **Dependencies.** Three dependency additions are pre-authorized (see
-  `DEC-006`): `googletest`, `pretty_assertions`, and promoting `serial_test`
-  into `[workspace.dependencies]`. A fourth (`rustc-literal-escaper`, see
-  `DEC-007`) is proposed but **requires approval before use**. Any dependency
-  beyond these four: stop and escalate.
-- **Public interface.** If `whitaker-common`'s public API must change in a way
-  that is not purely additive, stop and escalate.
-- **Architecture.** If milestone `EP-M0` concludes that a pure early pass
-  cannot soundly prove macro identity for the `log`/`tracing` families, stop at
-  the `EP-M0` go/no-go and present the options in `DEC-002` before continuing.
+- **Scope.** If implementation requires touching more than 30 files, or more
+  than 1800 net lines outside the two new crates, stop and escalate. The new
+  crates themselves are bounded by their milestone contents; if
+  `crates/string_continuation_style/src/` exceeds 900 lines in total, stop and
+  escalate, because the adapter was meant to be thin.
+- **Dependencies.** Four changes are pre-authorized (`DEC-006`): add
+  `googletest`, add `pretty_assertions`, promote `serial_test`, and add
+  `log`/`tracing` dev-dependency edges to workspace pins that already exist.
+  Any other dependency: stop and escalate. Note that `rustc_lexer` is already
+  a workspace dependency and needs no authorization (`SURP-011`).
+- **Public interface.** `whitaker-common` gains two additive functions
+  (`DEC-012`). Any non-additive change to its public API: stop and escalate.
+- **Time.** If any milestone exceeds two working days, stop and escalate with
+  the current state. `EP-M0a` is boxed at two hours: if the transcript is not
+  producible in that time, escalate with partial evidence and proceed on the
+  `DEC-002` default.
+- **Verification.** Kani: if the harness does not discharge within 20 minutes
+  at its starting bound, shrink the bound rather than waiting, and record the
+  reduced bound as a stated limit. If it does not discharge at the smallest
+  meaningful bound after one working day, stop and escalate. Verus: if
+  `LEM-REWRITE-1` is not discharged after one working day, stop and escalate
+  with the open goals — do not weaken the lemma. (Both figures are calibrated
+  against `docs/execplans/7-2-7-kani-verification-of-bounded-min-hasher-sketch-invariants.md`,
+  which records two days for a comparable obligation.)
+- **Test wall-clock.** `make test` wall-clock is measured before Step 1 and
+  recorded as `EV-BASELINE`. If it grows by more than 40 per cent, stop and
+  escalate with the measurement; the likely response is to move this crate
+  into its own CI job, as the Makefile already does for three other lint
+  crates via `TEST_EXCLUDES`.
 - **Iterations.** If a UI fixture's `.stderr` cannot be made stable after 4
   attempts, stop and escalate; unstable diagnostic output usually means the
   span recovery is wrong, not that the fixture needs another nudge.
-- **Verification.** If a planned Verus lemma or Kani harness cannot be
-  discharged after 6 hours of work on that single obligation, stop and
-  escalate with the current proof state rather than weakening the obligation.
 - **Ambiguity.** If a decision materially changes which source shapes the lint
   fires on, stop and present options with trade-offs.
 
 ## Risks
 
-- **Risk: macro identity cannot be proven from an `EarlyContext`.**
+- **Risk: a literal captured by a `$l:literal` macro matcher looks
+  root-context and is not.**
   Severity: high. Likelihood: high.
-  `rustc_lint::EarlyContext` exposes only `sess()`; it has no `TyCtxt`, so
-  `DefId → crate name / definition path` resolution is not directly available.
-  RFC 0002 §Detection architecture requires "resolved definition identifier,
-  defining crate, and canonical definition path" to match an allowlist entry.
-  Mitigation: `EP-M0` spike determines empirically what `ExpnData` yields;
-  `DEC-002` records the three candidate architectures and the decision.
+  This is the soundness hole `SURP-012` documents. It is the reason
+  `DEC-002` adopts a wrapper-depth gate rather than RFC 0002's
+  root-syntax-context test.
+  Mitigation: the depth counter, plus `NV-DEPTH-1`, plus a
+  `pass_literal_macro_capture` fixture that must be silent and whose
+  gate-inversion control must make it fire.
 
-- **Risk: duplicate diagnostics from facade macros.**
+- **Risk: wrapper-depth accounting misses an abstract-syntax-tree node kind.**
+  Severity: high. Likelihood: medium.
+  The counter must be maintained across every node kind that can contain an
+  expression. Miss one and an expanded literal slips through with a
+  suggestion. This is the one part of the design that is not pure-domain, so
+  `proptest`, Kani, and Verus cannot reach it.
+  Mitigation: `LEM-DEPTH-1` enumerates the enclosing node kinds and pairs each
+  with a fixture; the run-time value gate of `LEM-EMIT-1` catches the
+  consequence even when the cause slips through; the release applicability
+  default of `DEC-013` means the first release cannot write to source.
+
+- **Risk: the suggestion applies incorrectly under `cargo fix`.**
+  Severity: high. Likelihood: low after mitigation.
+  Mitigation: three independent layers. First, `LEM-EMIT-1`'s run-time value
+  comparison inside the lint. Second, `// run-rustfix` fixtures that apply the
+  suggestion, diff it against a checked-in `.fixed` file, recompile the result,
+  and require it to produce no diagnostics (`SURP-014`). Third,
+  `DEC-013`'s configuration default, which withholds `MachineApplicable`
+  entirely in the first release.
+
+- **Risk: release builds have overflow checks off; tests have them on.**
+  Severity: high. Likelihood: medium.
+  `installer/src/builder.rs:87` builds lint libraries with `--release`, and
+  the workspace declares no `[profile.release]`, so `overflow-checks = false`.
+  UI tests build with a plain `cargo build`, so checks are on. For a lint whose
+  correctness is byte-offset arithmetic, a subtraction underflow panics in
+  tests and wraps silently in the shipped artefact.
+  Mitigation: `checked_*` arithmetic everywhere (a Constraint),
+  `arithmetic_side_effects = "deny"` for both new crates, and
+  `overflow-checks = true` added to `[profile.release]`.
+
+- **Risk: the Kani harness is intractable.**
   Severity: medium. Likelihood: medium.
-  `tracing` with the `log` feature can emit the message through two paths, and
-  each may lower to its own `ExprKind::FormatArgs` node carrying the same
-  source literal span. Mitigation: deduplicate emitted diagnostics by the
-  recovered literal span within one pass instance; assert this with a UI
-  fixture that enables `tracing/log`.
-
-- **Risk: `concat!()` rewrite changes the type in a coercion site.**
-  Severity: medium. Likelihood: low.
-  `"a"` and `concat!("a", "b")` are both `&'static str`, so the type is
-  preserved, but a literal in a `const` pattern position or a `#[doc = "..."]`
-  meta item is not an expression. Mitigation: the lint visits `check_expr`
-  only, never patterns, attributes, or meta items (RFC 0002 §AST entry points).
-  A UI fixture pins that a literal in a pattern is untouched.
-
-- **Risk: suggestion applies incorrectly under `cargo fix`.**
-  Severity: medium. Likelihood: low.
-  A machine-applicable suggestion whose span is off by one quote character
-  silently corrupts source. Mitigation: the applicability gate in
-  `EP-M2`/`EP-M3` requires the recovered snippet to re-lex as exactly one
-  cooked string token *and* the generated replacement to re-lex as exactly one
-  `concat!` expression, before `MachineApplicable` is used. Non-vacuity control
-  `NV-REWRITE-1` seeds a deliberate off-by-one and requires the check to reject
-  it.
-
-- **Risk: no existing lint in this repository emits a suggestion.**
-  Severity: low. Likelihood: high (it is already true).
-  Every current lint uses `cx.emit_span_lint(..., DiagDecorator(|lint| ...))`
-  with `primary_message`/`span_note`/`span_label`/`help` only. `span_suggestion`
-  exists on `rustc_errors::Diag` (verified, see `SURP-004`), but this lint will
-  be the first user. Mitigation: `EP-M2` lands the suggestion path first, on
-  the simplest possible case (a plain literal), so the mechanics are proven
-  before the format-string complexity arrives.
-
-- **Risk: `insta` snapshots of diagnostics duplicate the UI `.stderr` files.**
-  Severity: low. Likelihood: medium.
-  Mitigation: snapshots are used only for the *pure* rewrite output
-  (fragment lists and the generated `concat!()` text across locales and
-  multi-join shapes), not for rendered rustc diagnostics, which `.stderr`
-  fixtures already pin.
+  A symbolic-length heap container driven through a nested loop is the exact
+  shape that stalled the clone-detector proofs.
+  Mitigation: start at a body length of 5 over a three-symbol alphabet, use a
+  fixed-capacity `cfg(kani)` sink instead of a `Vec`, derive the unwind bound
+  from that capacity with a `const` assertion, and keep `INV-SCAN-2` out of the
+  Kani harness (proptest covers it). Escalation budget is in `Tolerances`.
 
 - **Risk: Verus proof drifts from the production scanner.**
   Severity: medium. Likelihood: medium.
-  Verus compiles its own files and mirrors production types
-  (`docs/developers-guide.md` §Verus scope and trust boundary; existing proofs
-  in `verus/` use `#[path = "../crates/..."]` includes where possible).
-  Mitigation: include the production `continuation` domain module by `#[path]`
-  where its dependencies allow, exactly as
-  `verus/clone_detector_candidate_pair.rs` includes `fragment_id.rs`; where a
-  spec mirror is unavoidable, state the trust boundary in the proof's module
-  doc comment.
+  `LEM-REWRITE-1` reasons about `Seq<u8>`, which cannot be `#[path]`-included
+  from a `&str`-based production module, so it is a spec mirror.
+  Mitigation: state the trust boundary in the proof's module doc comment, as
+  `docs/developers-guide.md` §Verus scope and trust boundary requires; add the
+  proof to a CI job (`DEC-011`) so it cannot rot silently; and note that
+  `LEM-REWRITE-2` and `LEM-EMIT-1`, which are what actually protect users, are
+  discharged against real compiler behaviour rather than against the mirror.
+
+- **Risk: the user cannot silence a correct-but-unwanted finding.**
+  Severity: medium. Likelihood: medium.
+  A build script that writes a generated file containing wrapped literals
+  produces warnings on a file the user does not own and cannot annotate.
+  Mitigation: `DEC-013`'s configuration table ships in the first release, with
+  `excluded_crates`, `excluded_paths`, and an unconditional skip for literals
+  whose source file lies outside the workspace root or under the target
+  directory.
+
+- **Risk: the fixture matrix doubles the serialized test critical path.**
+  Severity: medium. Likelihood: high without mitigation.
+  Every dylint UI test runs in the `serial-dylint-ui` nextest group at
+  `max-threads = 1` with a 10-minute `terminate-after`.
+  Mitigation: `DEC-009` removes 14 fixtures from this plan; `EV-BASELINE` makes
+  the growth measurable; a crate-specific `slow-timeout` override is in the
+  Step 5 edit list; and the `Tolerances` entry names moving the crate into its
+  own CI job as the prepared response.
 
 ## Progress
 
-- [x] (2026-08-21) Branch `2-2-10-string-continuation-style-post-expansion-early-lint.md`
-      created from `harden-lint-config` and pushed with upstream tracking.
+- [x] (2026-08-21) Branch created from `harden-lint-config` and pushed with
+      upstream tracking.
 - [x] (2026-08-21) Reconnaissance of crate template, suite integration, i18n,
-      and testing conventions completed; recorded in §Context and orientation.
-- [x] (2026-08-21) Compiler API assumptions in RFC 0002 verified against
-      `nightly-2026-05-28`; recorded in §Surprises & discoveries.
-- [x] (2026-08-21) ExecPlan drafted.
-- [ ] Plan approved by the user (required before any implementation).
-- [ ] EP-M0 spike: pass architecture go/no-go.
-- [ ] EP-M1 pure domain core.
-- [ ] EP-M2 plain cooked string literals.
-- [ ] EP-M3 source-authored format strings (compiler built-ins).
-- [ ] EP-M4 `log` and `tracing` facade allowlist.
-- [ ] EP-M5 suite, installer, and documentation integration.
+      and testing conventions completed.
+- [x] (2026-08-21) RFC 0002's compiler-API assumptions verified against
+      `nightly-2026-05-28`.
+- [x] (2026-08-21) First draft written.
+- [x] (2026-08-21) Six-lens design review completed; fourteen further findings
+      recorded in §Surprises & discoveries and eight decisions revised.
+- [ ] Plan approved, and `DEC-009`, `DEC-013`, `DEC-014` answered.
+- [ ] EP-M0a: expansion-shape probe.
+- [ ] EP-M1: pure domain crate.
+- [ ] EP-M2: plain cooked string literals.
+- [ ] EP-M3: source-authored format strings from compiler built-ins.
+- [ ] EP-M5: suite, installer, tooling, and documentation integration.
 - [ ] Roadmap item 2.2.10 marked done.
 
 ## Surprises & discoveries
 
-These were found while validating RFC 0002 against the pinned toolchain,
-before implementation started. They materially change parts of the RFC's
-prescribed approach.
+`SURP-001` to `SURP-010` were found while validating RFC 0002 against the
+pinned toolchain. `SURP-011` to `SURP-016` came out of the design review.
+Compiler citations are to
+`~/.rustup/toolchains/nightly-2026-05-28-x86_64-unknown-linux-gnu/lib/rustlib/rustc-src/rust/compiler/`.
+Note that this is the `rustc-src` component, not the `rust-src` component at
+`lib/rustlib/src/rust/`, which contains only `library/`.
 
 - **SURP-001: rustc already proves "the format string was written in source".**
-  Observation: `rustc_ast::FormatArgs::is_source_literal` is computed by
+  `rustc_ast::FormatArgs::is_source_literal` is computed by
   `rustc_parse_format::Parser::new`, which compares the recovered source
   snippet against the parsed input and returns `false` when a proc macro has
   respanned the literal (the fix for rust-lang/rust#114865).
-  Evidence: `compiler/rustc_parse_format/src/lib.rs:302-345` and
-  `compiler/rustc_builtin_macros/src/format.rs:290` in the
-  `nightly-2026-05-28` `rustc-src` component.
-  Impact: RFC 0002 §Format strings steps 3 and 4 ("recover an exact source
-  literal span", "reject spans attributable only to an external or proc-macro
-  expansion") are largely discharged by checking `is_source_literal`. The lint
-  still re-lexes the snippet as a belt-and-braces check, but this is now
-  defence in depth rather than the primary proof.
+  Evidence: `rustc_parse_format/src/lib.rs:302-345`;
+  `rustc_builtin_macros/src/format.rs:290`.
+  Impact: RFC 0002 §Format strings steps 3 and 4 are largely discharged by
+  checking this one flag.
 
-- **SURP-002: `FormatArgs::span` is the format-string literal token span.**
-  Observation: `make_format_args` constructs `FormatArgs { span: fmt_span, .. }`
-  where `fmt_span` comes from `expr_to_spanned_string`, which returns
-  `span: expr.span` of the fully-expanded format-string expression — that is,
-  the literal token including its quotes when `is_source_literal` holds.
-  `Span::from_inner(InnerSpan)` maps a byte offset within that token to a
-  source span (`compiler/rustc_span/src/lib.rs:1256`).
-  Evidence: `compiler/rustc_builtin_macros/src/format.rs:170-181, 675-681`;
-  `compiler/rustc_builtin_macros/src/util.rs:61-101`.
-  Impact: per-continuation secondary labels and the whole-literal replacement
-  span come directly from `FormatArgs::span`, offset by one for the opening
-  quote. No bespoke span arithmetic over the enclosing macro call is needed.
+- **SURP-002: `FormatArgs::span` is the format-string literal token's span.**
+  `make_format_args` constructs `FormatArgs { span: fmt_span, .. }` where
+  `fmt_span` comes from `expr_to_spanned_string`, which returns `expr.span` of
+  the fully-expanded format-string expression — the literal token including
+  its quotes when `is_source_literal` holds. `Span::from_inner(InnerSpan)` maps
+  a byte offset within that token to a source span.
+  Evidence: `rustc_builtin_macros/src/format.rs:170-181, 675-681`;
+  `rustc_builtin_macros/src/util.rs:61-101`; `rustc_span/src/lib.rs:1256`.
+  Impact: no bespoke span arithmetic over the enclosing macro call is needed.
+  See also `SURP-013`, which draws a further consequence.
 
-- **SURP-003: `uncooked_fmt_str` carries the raw source body and is *not*
+- **SURP-003: `uncooked_fmt_str` carries the raw source body and is not
   newline-appended.**
-  Observation: `FormatArgs::uncooked_fmt_str: (token::LitKind, Symbol)`, where
-  the `Symbol` is `token_lit.symbol` — the raw, unescaped source text between
-  the quotes. `println!`-family macros append `\n` to the *cooked* symbol
-  (`fmt.symbol`) but leave `uncooked_symbol` untouched.
-  Evidence: `compiler/rustc_ast/src/format.rs:44-59`;
-  `compiler/rustc_builtin_macros/src/util.rs:61-101`;
-  `compiler/rustc_builtin_macros/src/format.rs:190-192`.
+  The `Symbol` in `FormatArgs::uncooked_fmt_str: (token::LitKind, Symbol)` is
+  `token_lit.symbol` — the raw, unescaped source text between the quotes.
+  `println!`-family macros append `\n` to the cooked symbol (`fmt.symbol`) but
+  leave `uncooked_symbol` untouched.
+  Evidence: `rustc_ast/src/format.rs:44-59`;
+  `rustc_builtin_macros/src/util.rs:61-101`;
+  `rustc_builtin_macros/src/format.rs:190-192`.
   Impact: the scanner's input is `uncooked_fmt_str.1.as_str()` for format
-  strings and `token::Lit::symbol` for plain literals. The
-  `token::LitKind` discriminant (`Str` / `StrRaw(_)` / `ByteStr` / `CStr` /
-  `CStrRaw(_)`) is exactly the cooked-versus-raw and type discriminator RFC
-  0002 §Decision matrix needs.
+  strings and `token::Lit::symbol` for plain literals. The `token::LitKind`
+  discriminant is the cooked-versus-raw and type discriminator RFC 0002
+  §Decision matrix needs.
 
 - **SURP-004: `EarlyContext` implements `LintContext`; `Diag::span_suggestion`
   exists.**
-  Observation: `impl LintContext for EarlyContext<'_>`
-  (`compiler/rustc_lint/src/context.rs:619`) provides `sess()` and
-  `emit_span_lint`. `Diag::span_suggestion(sp, msg, suggestion, applicability)`
-  is available (`compiler/rustc_errors/src/diagnostic.rs:918`).
+  Evidence: `rustc_lint/src/context.rs:619`;
+  `rustc_errors/src/diagnostic.rs:918`.
   Impact: the diagnostic path mirrors `bumpy_road_function`'s
   `cx.emit_span_lint(LINT, span, DiagDecorator(|lint| { ... }))`, adding
-  `lint.span_suggestion(...)`. Source text comes from
-  `cx.sess().source_map().span_to_snippet(span)`.
+  `lint.span_suggestion(...)`.
 
-- **SURP-005: `LintStore::register_early_pass` exists and takes a
-  `TyCtxt`-free factory.**
-  Observation: `register_early_pass` takes
-  `impl Fn() -> EarlyLintPassObject`
-  (`compiler/rustc_lint/src/context.rs:168`), alongside the public
-  `early_passes` / `late_passes` fields.
-  Impact: RFC 0002 §Suite integration's snippet compiles as written. The suite's
-  existing behavioural assertion `then_late_pass_count` reads
-  `store.late_passes.len()` and is unaffected; a new assertion on
-  `store.early_passes.len()` is possible and should be added.
+- **SURP-005: `register_early_pass` exists, and the factory runs once per
+  crate.**
+  `register_early_pass` takes `impl Fn() -> EarlyLintPassObject`
+  (`rustc_lint/src/context.rs:168`). The only site that instantiates
+  `early_passes` is `rustc_interface/src/passes.rs:469`, inside the
+  `early_lint_checks` query, called once per crate; the pre-expansion site at
+  `passes.rs:97` uses the separate `pre_expansion_passes` list.
+  Impact: per-crate state in the pass is sound *today*. `SURP-015` records why
+  the plan does not rely on that.
 
-- **SURP-006: `EarlyContext` has no `TyCtxt`, so macro identity is not directly
-  resolvable.**
-  Observation: `ExpnData` gives `kind: ExpnKind::Macro(MacroKind, Symbol)`,
+- **SURP-006: `EarlyContext` has no `TyCtxt`.**
+  `ExpnData` gives `kind: ExpnKind::Macro(MacroKind, Symbol)`,
   `macro_def_id: Option<DefId>`, `def_site: Span`, `allow_internal_unstable`,
-  and `parent_module` (`compiler/rustc_span/src/hygiene.rs:969-1015`), but
-  turning a `DefId` into a crate name or definition path needs `TyCtxt`, which
-  `EarlyContext` does not hold.
-  Countervailing observation: early lints run inside a query —
-  `fn early_lint_checks(tcx: TyCtxt<'_>, (): ())`
-  (`compiler/rustc_interface/src/passes.rs:400`) — so a `TyCtxt` *does* exist
-  on the thread, reachable via `rustc_middle::ty::tls`.
-  Impact: this is the single largest open design question. See `DEC-002` and
-  milestone `EP-M0`.
+  and `parent_module` (`rustc_span/src/hygiene.rs:969-1015`), but turning a
+  `DefId` into a crate name or definition path needs `TyCtxt`, which
+  `EarlyContext` does not hold. Early lints do run inside a query
+  (`rustc_interface/src/passes.rs:400`), so a `TyCtxt` exists on the thread,
+  reachable through `rustc_middle::ty::tls`.
+  Impact: this drove the first draft's open architecture question. `DEC-002`
+  now closes it without needing `TyCtxt` at all.
 
 - **SURP-007: rustc normalizes CRLF out of source before lexing.**
-  Observation: `normalize_src` calls `normalize_newlines`
-  (`compiler/rustc_span/src/lib.rs:2510-2528`), so a `SourceFile`'s contents —
-  and therefore every literal `Symbol` and every `span_to_snippet` result —
-  contain LF only.
-  Impact: RFC 0002 §Continuation scanner's CRLF and lone-CR branches are
-  unreachable from the rustc adapter. Keep them in the *pure* scanner (they are
-  cheap, they make the domain module self-contained, and the domain tests
-  exercise them directly), but do not claim adapter-level coverage for them,
-  and do not write a UI fixture that pretends to.
+  `normalize_src` calls `normalize_newlines` (`rustc_span/src/lib.rs:2510-2528`),
+  so every literal `Symbol` and every `span_to_snippet` result contains LF
+  only.
+  Impact: RFC 0002 §Continuation scanner's CRLF branch is unreachable from the
+  rustc adapter. See `DEC-004` and `SURP-016`.
 
-- **SURP-008: `googletest` and `pretty_assertions` are not yet dependencies.**
-  Observation: neither appears in any `Cargo.toml` in the workspace nor in
-  `[workspace.dependencies]`. Every existing test uses bare `assert_eq!`.
-  `serial_test` is used pervasively for locale UI tests but is pinned
-  per-crate, not in `[workspace.dependencies]`.
+- **SURP-008: `googletest` and `pretty_assertions` are not yet dependencies,
+  and `serial_test` is pinned per-crate.**
+  Neither appears in any manifest. `serial_test = "4.0.1"` is pinned
+  identically in four crates: `conditional_max_n_branches`,
+  `function_attrs_follow_docs`, `module_must_have_inner_docs`, and
+  `no_std_fs_operations`.
   Impact: see `DEC-006`.
 
-- **SURP-009: `rustc-literal-escaper` is already in `Cargo.lock`.**
-  Observation: `rustc-literal-escaper 0.0.4` is present transitively (pulled in
-  by `ra_ap_syntax`). This is the crate rustc itself now uses for unescaping;
-  it is no longer vendored inside `rustc_lexer`.
-  Impact: it is the natural differential oracle for "the rewrite preserves the
-  evaluated value". See `DEC-007`.
+- **SURP-009: `rustc-literal-escaper` is already in `Cargo.lock`, and
+  `ra_ap_syntax` re-exports it.**
+  Version 0.0.4 is present transitively;
+  `ra_ap_syntax-0.0.334/src/lib.rs:65` has
+  `pub use rustc_literal_escaper as unescape;`.
+  Impact: `DEC-007` originally proposed adding it as a direct oracle
+  dependency. That decision is now withdrawn — see `SURP-014`.
 
-- **SURP-010: `log 0.4.33`'s facade macros capture `$($arg:tt)+`.**
-  Observation: `log::info!` matches
+- **SURP-010: `log 0.4.33`'s facade macros capture `$($arg:tt)+`, and have
+  grown a `logger:` control.**
+  `log::info!` matches
   `(logger: $logger:expr, target: $target:expr, $($arg:tt)+)`,
-  `(target: $target:expr, $($arg:tt)+)`, `(logger: $logger:expr, $($arg:tt)+)`,
-  and `($($arg:tt)+)`, forwarding to `log!` and then `__log!`; key-value fields
-  are separated from the message by `;`
-  (`~/.cargo/registry/src/*/log-0.4.33/src/macros.rs:75-115, 252-270`).
-  Impact: RFC 0002's `log` allowlist omits the newer `logger:` control. The
-  allowlist must either add it or explicitly reject invocations carrying it.
-  Because the captures are `tt`, a `concat!(...)` expression in the message
-  position is grammatically accepted — but the lint must still *prove* it is
-  looking at `log`'s macro, not a same-named local macro (`SURP-006`).
+  `(target: $target:expr, $($arg:tt)+)`,
+  `(logger: $logger:expr, $($arg:tt)+)`, and `($($arg:tt)+)`, forwarding to
+  `log!` and then `__log!`; key-value fields are separated from the message
+  by `;`. Evidence: `~/.cargo/registry/src/*/log-0.4.33/src/macros.rs:75-115,
+  252-270`.
+  Impact: RFC 0002's `log` allowlist is already stale, roughly one year after
+  it was written, over a single new control. That is the empirical basis for
+  `DEC-009`.
+
+- **SURP-011: `rustc_lexer` is already a workspace dependency and is pure.**
+  `Cargo.toml:44` pins `rustc_lexer = "0.1.0"`, the crates.io mirror, used by
+  `crates/whitaker_clones_core` (see `src/token/normalize.rs`). It needs no
+  `rustc_private` plumbing and it vendors an `unescape` module.
+  Impact: the re-lex check that `LEM-APPLY-1` needs, and the unescaper that
+  `LEM-EMIT-1` needs, are both available inside a pure crate at zero
+  dependency cost. The first draft treated the lexer as an unmet need and the
+  escaper as requiring approval; both were wrong.
+
+- **SURP-012: root syntax context does not prove the literal is unwrapped.**
+  In `rustc_expand/src/mbe/transcribe.rs`, `maybe_use_metavar_location`
+  returns either the original token or one respanned with the call-site
+  context. Either way a `$l:literal`-captured token reaches `check_expr` with
+  `span.ctxt().is_root() == true`. So for
+
+  ```rust
+  macro_rules! shout { ($l:literal) => { let _x = $l; } }
+  shout!("alpha \
+          beta");
+  ```
+
+  every gate in RFC 0002 §Ordinary string expressions passes, and the lint
+  would emit a machine-applicable suggestion that does not compile — the exact
+  failure the Constraints forbid. The *container* of the substituted literal
+  does carry the macro definition's marked context
+  (`Marker::mark_span`, `transcribe.rs:92-103`), so tracking enclosing
+  expanded nodes is the discriminator that `is_root()` is not.
+  `EarlyLintPass` provides the needed hooks: `check_expr`/`check_expr_post`,
+  `check_item`/`check_item_post`, `check_stmt`, and `check_mac_def`
+  (`rustc_lint/src/passes.rs:143-172`).
+  Impact: this is a soundness defect in RFC 0002, not in the plan's reading of
+  it. It drives `DEC-002` and requires an RFC amendment.
+
+- **SURP-013: `SURP-002` deletes half of RFC 0002's allowlist specification.**
+  RFC 0002 §Detection architecture asks the lint to "parse the
+  source-authored token tree and prove that the selected literal occupies the
+  stated position" — argument 0 for `format!`, 1 for `write!`, 2 for
+  `assert_eq!`. Since `FormatArgs::span` *is* the format-string literal token's
+  span, there is nothing to count and no token tree to parse. RFC 0002
+  §Non-goals separately forbids "inspecting arbitrary macro token trees whose
+  grammar Whitaker cannot prove", so the RFC contradicts itself here.
+  Impact: the position-proving machinery is dropped. Only the question "is the
+  enclosing macro one whose matcher accepts an expression here" remains, and
+  for compiler built-ins there is no macro-by-example matcher to break —
+  `format_args!` parses an expression, and `write!`/`writeln!` forward through
+  `$($arg:tt)*`.
+
+- **SURP-014: `compiletest_rs` supports `// run-rustfix`, and
+  `dylint_testing` does not support `TRYBUILD=overwrite`.**
+  `dylint_testing 6.0.4` depends on `compiletest_rs 0.11.2`, not `trybuild`
+  (`Cargo.lock:784-799`), and builds a `compiletest::Config` with
+  `..Config::default()`, so `bless` is always `false`. The documented way to
+  update a `.stderr` is to read the "Actual stderr saved to PATH" line from
+  the report and copy that file
+  (`~/.cargo/registry/src/*/dylint_testing-6.0.4/src/lib.rs:90-92`).
+  Far more valuable: `compiletest_rs` in `Mode::Ui` honours a `// run-rustfix`
+  header. When present it applies the machine-applicable suggestions with
+  `rustfix`, diffs the result against a checked-in `.fixed` file, **compiles
+  the fixed code**, and fails if it either does not compile or still produces
+  diagnostics (`compiletest_rs-0.11.2/src/runtest.rs:2627-2645`).
+  Impact: three things the first draft treated as unsolved come free. Applying
+  the fix is verified. Recompiling it is verified. Idempotence — the fixed code
+  producing no further diagnostics — is verified. And because the fixed code is
+  *compiled*, a `const _: () = assert!(...)` inside the `.fixed` file makes
+  **rustc itself** the value-preservation oracle, with no dependency and no
+  shared lineage with our own unescaper. This is why `DEC-007` is withdrawn.
+
+- **SURP-015: dylint UI fixtures needing dev-dependencies live in `examples/`,
+  not `ui/`.**
+  `Makefile:14-19` states it: "`dylint_testing::Test::example` builds them with
+  each lint crate's dev-dependencies (tokio, rstest); `ui/` fixtures are
+  standalone and cannot carry those." `crates/no_unwrap_or_else_panic`,
+  `no_expect_outside_tests`, and `rstest_helper_should_be_fixture` all have
+  `examples/` directories driven through `Test::example` and one rstest case
+  per fixture, each spawning a cargo subprocess.
+  Impact: any fixture needing `log` or `tracing` in scope must live in
+  `examples/` and costs a cargo build, not a bare `rustc` invocation. It also
+  means a `tracing/log`-feature fixture cannot coexist with a
+  `tracing`-without-`log` fixture in one crate, because Cargo unifies
+  dev-dependency features. This is a further argument for `DEC-009`.
+
+- **SURP-016: the real continuation whitespace rule is not what RFC 0002
+  says.**
+  RFC 0002 §Continuation scanner specifies "spaces and tabs, plus complete LF
+  or CRLF sequences" and says a lone carriage return makes the span
+  unrecoverable. Both escapers disagree.
+  `rustc-literal-escaper-0.0.4/src/lib.rs:442-472` and the vendored
+  `rustc_lexer-0.1.0/src/unescape.rs:260-267` both skip every byte in
+  `{b' ', b'\t', b'\n', b'\r'}`, in any order, until the first byte outside
+  that set. A bare carriage return is skipped, not rejected, and CRLF has no
+  special status. The current escaper additionally excludes the formfeed
+  character (rust-lang/rust#136600) and warns on a skipped blank line and on
+  a following non-ASCII whitespace character.
+  Impact: `INV-SCAN-3` as first stated would have verified the scanner against
+  a wrong specification. The corrected rule is now normative, and RFC 0002
+  §Continuation scanner must be amended.
 
 ## Decision log
 
 - **DEC-001: Implement as a post-expansion early lint, per RFC 0002.**
-  Rationale: pre-expansion cannot see `FormatArgumentKind::Captured`; late HIR
-  has lost the source spelling that distinguishes an escaped newline from an
-  equivalent evaluated string. RFC 0002 §Alternatives considered records both
-  rejections and this plan adopts them unchanged.
+  Rationale (corrected after review): pre-expansion cannot see
+  `FormatArgumentKind::Captured`. A late high-level intermediate
+  representation pass cannot see `ExprKind::FormatArgs` at all, because format
+  arguments are lowered away — that, not loss of source spelling, is the real
+  disqualifier. Source spelling *is* recoverable at any phase through
+  `span_to_snippet`, so RFC 0002 §Alternatives considered's stated reason for
+  rejecting a late pass is imprecise and should be amended.
   Date/Author: 2026-08-21, planning agent.
 
-- **DEC-002: Pass architecture for macro identity — OPEN, resolved at `EP-M0`.**
-  Context: `SURP-006`. Three candidates:
-  1. *Pure early pass, narrowed allowlist.* Prove identity only from
-     `ExpnData` (`macro_def_id.is_local()`, `def_site` file, `ExpnKind`
-     symbol, `allow_internal_unstable`). Cheapest; cannot satisfy RFC 0002's
-     "defining crate and canonical definition path" clause; would force
-     `log`/`tracing` out of the initial allowlist.
-  2. *Early pass reaching `TyCtxt` through `rustc_middle::ty::tls::with_opt`.*
-     Satisfies the RFC clause exactly, at the cost of a hidden global and a
-     `rustc_middle` dependency. Must degrade to "no diagnostic" when the
-     `TyCtxt` is absent.
-  3. *Early collector plus late emitter*, mirroring Clippy's
-     `FormatArgsStorage`: an `EarlyLintPass` records `FormatArgs` nodes keyed by
-     span into shared storage; a `LateLintPass` (which has `TyCtxt`) resolves
-     identity, handles plain literals from HIR, and emits every diagnostic.
-     Most faithful to the RFC and to established prior art; costs a handwritten
-     two-pass registration in the lint crate and in the suite.
-  Recommendation to the reviewer: option 3 if `EP-M0` shows that
-  `log`/`tracing` invocations reach the AST as `ExprKind::FormatArgs` with
-  `is_source_literal == true`; otherwise option 1 with `log`/`tracing` deferred.
-  Do not adopt option 2 without an explicit decision: reaching into thread-local
-  compiler state is exactly the kind of hidden coupling this repository's
-  hexagonal boundaries exist to prevent.
-  Date/Author: 2026-08-21, planning agent. **Requires user decision or `EP-M0`
-  evidence before `EP-M3` starts.**
+- **DEC-002: Prove the *position*, not the macro's identity. RESOLVED.**
+  The first draft left three options open, all of which existed only to answer
+  "which macro produced this literal". The lint does not need that answer. It
+  needs "is anything standing between this literal and the compiler", which is
+  answerable from `EarlyContext` alone. The adopted design:
+  1. **Wrapper depth.** Maintain a counter incremented in `check_item`,
+     `check_stmt`, and `check_expr` when the node's span `from_expansion()`,
+     and decremented in the matching `_post` hooks. Fire only at depth zero.
+     This closes `SURP-012`, which `is_root()` alone does not.
+  2. **Built-in name set.** For `ExprKind::FormatArgs`, require the outermost
+     non-root frame of the literal span's expansion chain to be
+     `ExpnKind::Macro(MacroKind::Bang, sym)` with `sym` in a fixed set:
+     `format_args`, `format`, `print`, `println`, `eprint`, `eprintln`,
+     `write`, `writeln`, `panic`, `todo`, `unimplemented`, `unreachable`,
+     `assert`, `debug_assert`, `assert_eq`, `assert_ne`, `debug_assert_eq`,
+     `debug_assert_ne`. The outermost frame is the invocation the user typed.
+  3. **Crate-scoped shadow kill switch.** A bare name check is only sound if
+     the name cannot be shadowed. Using `check_mac_def` and `check_item`, if
+     the crate under compilation defines a `macro_rules!`/`macro` with any
+     name in the set, or contains a `use` whose terminal segment is one, or a
+     `#[macro_use] extern crate`, the lint disables itself for that crate.
+     Blunt, and biased entirely towards silence.
+  Consequences: no `TyCtxt`, no `rustc_middle`, no thread-local reach-through,
+  no two-pass registration, no shared storage, and no allowlist table. `log`
+  and `tracing` fail the outermost-frame check and produce silence by
+  construction rather than by policy — which is what `DEC-009` wants.
+  Costs accepted: the residual hole is a crate reaching a same-named macro by
+  a path none of the three switches observes; the failure mode is silence, so
+  it is undetectable from inside the lint. And wrapper-depth accounting is a
+  new correctness surface that the pure-domain verification cannot reach; it
+  gets `LEM-DEPTH-1` and its own fixture matrix instead.
+  Date/Author: 2026-08-21, planning agent, on the design review's alternatives
+  finding.
 
 - **DEC-003: Hexagonal split — domain modules take no rustc types.**
-  The scanner (`continuation`), the policy (`classification`), and the
-  rewriter (`rewrite`) are pure over `&str` and `Range<usize>`. The rustc
-  adapter (`driver`) converts AST nodes into a `LiteralFacts` value and
-  converts a `ContinuationDisposition` back into spans. The diagnostic adapter
-  (`diagnostics`) converts a disposition into localized Fluent output.
-  Rationale: `hexagonal-architecture` skill §Domain purity, and the practical
-  benefit that the invariants worth proving (`INV-SCAN-*`, `LEM-REWRITE-1`) all
-  live in the pure half, where `proptest`, Kani, and Verus can reach them
-  without a compiler session.
+  The scanner, the policy, and the rewriter are pure over `&str` and byte
+  offsets. The rustc adapter converts abstract-syntax-tree nodes into a
+  `LiteralFacts` value and converts a disposition back into spans. The
+  diagnostic adapter converts a disposition into localized output.
+  Rationale: the `hexagonal-architecture` skill's dependency rule, and the
+  practical benefit that every provable invariant lives in the pure half.
+  Note the review's caution, accepted: the adapter is where the byte offsets
+  are, and byte offsets are the whole risk. `DEC-003` must not aim the
+  verification effort away from the danger. That is what `LEM-EMIT-1`,
+  `LEM-SPAN-1`, and `LEM-DEPTH-1` exist for.
   Date/Author: 2026-08-21, planning agent.
 
-- **DEC-004: Keep CRLF handling in the pure scanner; do not claim adapter
-  coverage.**
-  Rationale: `SURP-007`. The pure scanner is a reusable byte-level component
-  with a documented contract; the contract should be complete. But a UI fixture
-  claiming to exercise CRLF would be theatre, since rustc normalizes it away.
-  The verification plan records this as an explicit reachability bound.
-  Date/Author: 2026-08-21, planning agent.
+- **DEC-004: Keep the whitespace rule complete in the pure scanner; do not
+  claim adapter coverage for carriage returns.**
+  Rationale: `SURP-007` and `SURP-016`. The pure scanner is a reusable
+  component whose contract should be complete and *correct*; the adapter never
+  feeds it a carriage return. The verification plan records this as an explicit
+  reachability bound rather than pretending to cover it.
+  Date/Author: 2026-08-21, revised 2026-08-21 after `SURP-016`.
 
 - **DEC-005: One diagnostic per literal, with one whole-literal replacement.**
   Rationale: RFC 0002 §Decision matrix, final row. Cascaded per-continuation
-  suggestions would conflict under `cargo fix`.
+  suggestions would overlap under `rustfix`, which reports that it could not
+  apply the fixes and can leave a file partially rewritten.
   Date/Author: 2026-08-21, planning agent.
 
-- **DEC-006: Add `googletest` and `pretty_assertions` to
-  `[workspace.dependencies]`; promote `serial_test` there too.**
-  Rationale: the task brief explicitly authorizes `googletest` and
-  `pretty_assertions` and requires their use for clear test semantics; neither
-  is present today (`SURP-008`). `serial_test` is already used by three lint
-  crates with per-crate pins, and this crate needs it for locale UI tests, so
-  promoting it removes a version-skew hazard. This is additive and touches only
-  the workspace manifest and the new crate's manifest.
+- **DEC-006: Dependency changes.**
+  Add `googletest` and `pretty_assertions` to `[workspace.dependencies]`; the
+  task brief authorizes both and neither is present. Promote `serial_test`
+  from four identical per-crate `4.0.1` pins to a workspace pin and migrate
+  all four crates. Add `log` and `tracing` as dev-dependency edges only if
+  `DEC-009` is declined; both are already workspace-pinned.
   Date/Author: 2026-08-21, planning agent.
 
-- **DEC-007: Use `rustc-literal-escaper` as the value-preservation oracle —
-  PROPOSED, requires approval.**
-  Rationale: the central constraint is "the rewrite preserves the evaluated
-  bytes". A property test asserting that against a reference unescaper written
-  in the same pull request is weak — a shared misunderstanding of the escaping
-  rules passes both. `rustc-literal-escaper` is the crate rustc itself uses and
-  is already resolved in `Cargo.lock` (`SURP-009`), so this is a new direct
-  edge, not a new subtree.
-  Alternative if declined: write a spec-derived reference unescaper in the test
-  module from the Rust Reference §String literals, and add three
-  compile-and-run UI fixtures that `assert_eq!` the original literal against its
-  rewritten form at runtime, which grounds the property in real compiler
-  behaviour at a handful of points.
-  Date/Author: 2026-08-21, planning agent. **Requires user decision before
-  `EP-M1` starts.**
+- **DEC-007: WITHDRAWN.** The first draft proposed adding
+  `rustc-literal-escaper` as a differential oracle. `SURP-014` supplies a
+  strictly better one at zero cost: the compiler under test. A
+  `const _: () = assert!(...)` inside a `.fixed` file is adjudicated by rustc's
+  own escaping implementation during the run-rustfix recompile, with no
+  possibility of shared misunderstanding. `SURP-011` supplies the in-process
+  unescaper for `LEM-EMIT-1` from an existing workspace dependency.
+  Date/Author: 2026-08-21, withdrawn 2026-08-21 after review.
 
-- **DEC-008: Add `logger:` to the `log` allowlist grammar, or reject it.**
-  Rationale: `SURP-010`. RFC 0002 was written against an older `log` surface.
-  Recommendation: reject invocations carrying `logger:` in the initial
-  allowlist (they are rare, and rejecting is the conservative direction), and
-  add a `pass_log_logger_control.rs` fixture asserting silence. Record the
-  divergence from RFC 0002 §Detection architecture in the RFC itself at
-  `EP-M4`.
+- **DEC-008: SUPERSEDED by `DEC-009`.** The first draft proposed rejecting
+  `log`'s `logger:` control. `DEC-009` removes the `log` allowlist entirely.
+
+- **DEC-009: Move `log` and `tracing` support out of this roadmap item.
+  REQUIRES APPROVAL.**
+  Recommendation: cut them, and cut them by construction (which `DEC-002`
+  already does), not by deferral.
+  For: `docs/roadmap.md:81` scopes 2.2.10 as "source-preserving `concat!()`
+  suggestions, format-capture and literal-context exemptions, localized
+  diagnostics, and suite integration" — it does not mention either crate. They
+  are the sole driver of the whole `TyCtxt` question. The allowlist is a policy
+  table over third-party macro grammars that change between versions, and
+  `SURP-010` shows RFC 0002's is already stale. `SURP-015` shows the fixtures
+  cannot all live in one crate anyway. They account for 14 of roughly 34
+  fixtures on a serialized test path.
+  Against: in service codebases long strings disproportionately live in log
+  messages, which is where the reviewers' hand-application that motivates this
+  work actually happens. RFC 0002 §Rollout step 3's payoff is estate-wide
+  machine fixes, and logging is where the volume is. Cutting requires amending
+  the RFC, not annotating it.
+  If approved: file roadmap item 2.2.11 for the facade allowlist, to be
+  designed against a shipped baseline. If declined: reinstate `EP-M4` from the
+  first draft, restore the `EP-M0` spike to its blocking position, and expect
+  the `Tolerances` scope and wall-clock figures to need roughly doubling.
+  Date/Author: 2026-08-21, planning agent. **Approver's call.**
+
+- **DEC-010: Put the pure domain in its own plain-library crate.**
+  Create `crates/whitaker_string_literals/` as an ordinary `rlib` with no
+  `crate-type` override and no rustc dependency, following
+  `crates/whitaker_clones_core/` exactly.
+  `crates/string_continuation_style/` becomes a thin `cdylib` adapter that
+  depends on it.
+  Rationale: five problems collapse into one fix. Kani has never run inside a
+  `cdylib` lint crate in this repository, and `whitaker_clones_core` proves it
+  works in a plain crate. Verus proofs `#[path]`-include production modules
+  from plain crates. Doctests on the pure functions actually run, because the
+  crate is not in `LINT_CRATES` and therefore not in `DOCTEST_EXCLUDES`.
+  `make lint-whitaker` can cover it, because `WHITAKER_PACKAGES` can include a
+  crate that builds as an ordinary library — which means the 400-line ceiling
+  is *gate-enforced* for the domain rather than merely asserted. And domain
+  purity becomes structural rather than a conformance check that no
+  `--all-features` gate would ever notice.
+  Date/Author: 2026-08-21, planning agent, on the review's structural findings.
+
+- **DEC-011: Put Kani and Verus in continuous integration.**
+  Neither runs today; `.github/workflows/` contains one proof-adjacent step,
+  `scripts/check-verus-fragment-id-bridge.sh`, which is four `grep -F` calls.
+  A proof outside a gate is a comment. Add a `proofs` job running `make kani`
+  and `make verus`, scheduled nightly and on pull requests that touch
+  `verus/**`, `crates/whitaker_string_literals/**`, or `scripts/run-*.sh`.
+  Rationale: the plan spends most of its verification budget on artefacts
+  that would otherwise be discharged once by hand and never re-run. The
+  toolchain-bump scenario is the concrete danger: a bump patches the adapter to
+  compile, the `.stderr` fixtures get re-blessed as "diagnostic drift", and
+  nobody notices the proof now describes code that no longer exists.
+  Date/Author: 2026-08-21, planning agent.
+
+- **DEC-012: Promote a label-resolution helper into `whitaker-common`.**
+  Add `safe_resolve_label(localizer, resolution, attribute, report_bug,
+  fallback) -> String` and `normalize_fluent_output(text: String) -> String`,
+  and make `strip_isolating_marks` delegate to the latter. Migrate
+  `bumpy_road_function` onto them in the same change.
+  Rationale: three divergent normalization contracts already exist in-tree —
+  `strip_isolating_marks` strips `{U+2068, U+2069}`; `bumpy_road_function` and
+  `no_std_fs_operations` strip different sets including `U+FFFD`;
+  `conditional_max_n_branches` *replaces* them with a quote character. Copying
+  the workaround would make a fourth. Stripping `U+FFFD` is itself a bug: it is
+  how Fluent signals an unresolved placeable, so deleting it converts "this
+  translation is broken" into "this translation reads plausibly and is wrong".
+  The typed `BundleLookup::attribute(MessageKey, AttrKey, &Arguments)` already
+  exists at `common/src/i18n/diagnostics.rs:73-93` and is bypassed by every
+  caller. The change is purely additive, so it sits inside `Tolerances`.
+  Date/Author: 2026-08-21, planning agent.
+
+- **DEC-013: Ship a configuration table, defaulting to manual applicability.
+  REQUIRES APPROVAL.**
+  RFC 0002 says "No configuration section is proposed. The proof predicate is
+  the configuration." For a warn-level style lint that is defensible; for a
+  lint that writes to source files it is the wrong instinct for release one.
+  Proposal: a `[string_continuation_style]` table in `dylint.toml` with
+  `applicability = "manual" | "machine"` defaulting to `"manual"`, plus
+  `excluded_crates` and `excluded_paths` mirroring `no_std_fs_operations`'s
+  shape exactly. Under `"manual"` the diagnostic still prints the full
+  replacement; only the unattended write is disarmed. Flipping one line in
+  `dylint.toml` arms the fixer estate-wide once the run-rustfix harness has
+  proven itself over real rewrites, with no rebuild.
+  Independently of the setting, skip any literal whose source file lies
+  outside the workspace root or beneath the target directory, with a new
+  `RequiredReason::GeneratedSourceFile` and a fixture pinning it. The
+  motivating case is a build script writing `$OUT_DIR/protocol.rs`, included
+  with `include!`: the user cannot annotate a file they do not write, and a
+  fix would rewrite a file the next build deletes.
+  Date/Author: 2026-08-21, planning agent. **Approver's call.**
+
+- **DEC-014: One lint name or two. REQUIRES APPROVAL.**
+  The plan of record ships one lint, `string_continuation_style`, covering
+  both branches — this is what RFC 0002 and the roadmap describe.
+  The review's alternative: two lint names,
+  `string_continuation_style` (plain literals) and
+  `format_string_continuation_style` (format strings), declared and driven by
+  the same single `EarlyLintPass` in the same crate. Users get `#[allow]`
+  granularity between a high-confidence branch and a lower-confidence one; the
+  format branch can ship at `Allow` and be promoted independently; `EP-M3`'s
+  recovery becomes a change users can make themselves. Cost: one extra Fluent
+  file per locale, one extra `SUITE_LINTS`/`SUITE_LINT_DECLS` pair, one extra
+  users-guide subsection. Two *crates* would be the wrong cut and is not
+  proposed.
+  Default if unanswered: one name.
+  Date/Author: 2026-08-21, planning agent. **Approver's call.**
+
+- **DEC-015: Order the adapter's checks cheapest-first, normatively.**
+  RFC 0002 §Ordinary string expressions puts `span_to_snippet` and a re-lex at
+  step 2, before anything has established the literal is a candidate. That runs
+  a source-file binary search and a `String` allocation for every cooked
+  literal in the crate — plausibly 30,000 to 80,000 per full-workspace build
+  here, for a candidate rate of essentially zero (`git ls-files '*.rs' |
+  xargs grep -c '\\$'` finds no continuation backslashes in this repository at
+  all). Worse, `span_to_snippet` on a foreign `SourceFile` decodes an external
+  crate's source out of crate metadata and retains it in the `SourceMap` for
+  the rest of the compilation.
+  Normative order: (1) `token::LitKind::Str`, touching no source map;
+  (2) the uncooked `Symbol` contains `\` followed by LF — an interned lookup
+  and an allocation-free scan; (3) wrapper depth is zero and the span is not
+  from an expansion; (4) only then `span_to_snippet` and the re-lex.
+  Date/Author: 2026-08-21, planning agent.
+
+- **DEC-016: Construct the localizer in `check_crate`, never in `check_expr`.**
+  `SharedConfig::load()` clones a `toml::Value` and runs a serde deserialize
+  per call, and building a Fluent bundle is not free. Every existing lint does
+  this in `check_crate`; `EarlyLintPass` offers the same hook. Stated
+  explicitly because the first draft quoted the idiom without naming the hook,
+  and a literal reader could reasonably have put it in `check_expr`.
   Date/Author: 2026-08-21, planning agent.
 
 ## Outcomes & retrospective
 
 Not started. To be completed at each milestone boundary and at plan closure.
+
 Before setting this plan to `COMPLETE`, reconcile every discovery against
-`docs/rfcs/0002-string-continuation-style.md`: `SURP-001`, `SURP-002`,
-`SURP-003`, `SURP-007`, and `SURP-010` all describe places where the RFC's
-prescribed mechanics differ from the pinned toolchain's actual behaviour, and
-the RFC must be amended rather than silently diverged from.
+`docs/rfcs/0002-string-continuation-style.md`. `SURP-012` and `SURP-016` are
+defects in the RFC, not merely divergences: the first would ship a
+source-corrupting suggestion, the second specifies the wrong language rule.
+`SURP-001`, `SURP-002`, `SURP-003`, `SURP-007`, `SURP-010`, and `SURP-013`
+describe places where the RFC's prescribed mechanics differ from the pinned
+toolchain's behaviour. `DEC-001`'s rationale correction and `DEC-009`'s scope
+change also require RFC edits. The RFC must be substantively revised, not
+annotated, before it moves from *Proposed* to *Accepted*.
 
 ## Context and orientation
 
 ### What this repository is
 
-Whitaker is a suite of [Dylint](https://github.com/trailofbits/dylint) lints for
-Rust. Dylint loads compiled lint libraries into `rustc` at build time, so each
-lint crate is a `cdylib` compiled against the pinned nightly compiler's private
-crates (`rustc_ast`, `rustc_lint`, and so on).
+Whitaker is a suite of [Dylint](https://github.com/trailofbits/dylint) lints
+for Rust. Dylint loads compiled lint libraries into `rustc` at build time, so
+each lint crate is a `cdylib` compiled against the pinned nightly compiler's
+private crates.
 
 Layout you need to know:
 
 - `crates/<lint_name>/` — one directory per lint. Ten exist today.
 - `crates/rustc_ast/`, `crates/rustc_lint/`, `crates/rustc_span/`,
   `crates/rustc_session/`, `crates/rustc_middle/`, `crates/clippy_utils/` —
-  thin proxy crates that re-export the nightly compiler crates so lint crates
-  do not each need `#![feature(rustc_private)]` plumbing. Depend on these by
-  workspace alias (`rustc_ast = { workspace = true }`), never on the raw
-  `extern crate`.
+  thin proxy crates re-exporting the nightly compiler crates. Depend on these
+  by workspace alias, never on the raw `extern crate`.
+- `crates/whitaker_clones_core/` — a plain `rlib` of pure logic used by lint
+  crates. It carries Kani harnesses, `proptest` properties, `insta`
+  snapshots, and Verus-bridged modules. **This is the template for
+  `crates/whitaker_string_literals/`**, the new pure-domain crate.
 - `common/` — the `whitaker-common` crate: pure helpers plus the Fluent
   localization engine.
-- `suite/` — `whitaker_suite`, the aggregated `cdylib` that bundles every lint.
-- `installer/` — the `whitaker` CLI that builds, links, and stages lint
-  libraries.
-- `src/` — the top-level `whitaker` crate, which holds the CLI plus shared test
-  harness code (`src/testing/ui/`) and the rustc-aware span helpers
+- `suite/` — `whitaker_suite`, the aggregated `cdylib` bundling every lint.
+- `installer/` — the `whitaker` command-line tool that builds, links, and
+  stages lint libraries.
+- `src/` — the top-level `whitaker` crate: the command-line tool plus the
+  shared test harness (`src/testing/ui/`) and rustc-aware span helpers
   (`src/hir/`).
 - `verus/` — Verus proof files, run out-of-band from Cargo.
 - `docs/` — the knowledge base. Start at `docs/contents.md` and
   `docs/repository-layout.md`.
 
-`rust-toolchain.toml` pins `nightly-2026-05-28` with the `rustc-dev` and
-`rust-src` components.
+`rust-toolchain.toml` pins `nightly-2026-05-28` with `rustc-dev` and
+`rust-src`.
 
 ### Terms used in this plan
 
@@ -455,43 +724,42 @@ Layout you need to know:
 - **Layout trim** — a continuation used to suppress a leading or trailing
   source newline and indentation rather than to divide two fragments, as in
   `"\` at the very start of a literal. The lint leaves these alone.
-- **Post-expansion early lint** — an `EarlyLintPass` that runs on the abstract
-  syntax tree (AST) after macro expansion but before lowering to the high-level
-  intermediate representation (HIR). It sees `ExprKind::FormatArgs`, which
-  records how `format!`-family arguments were bound, while still retaining the
-  literal's source spelling.
+- **Post-expansion early lint** — an `EarlyLintPass` running on the abstract
+  syntax tree after macro expansion but before lowering to the high-level
+  intermediate representation. It sees `ExprKind::FormatArgs`, which records
+  how `format!`-family arguments were bound.
 - **Implicit format capture** — writing `format!("{name}")` so that `name` is
   captured from the enclosing scope. The compiler permits this only when the
   format string is a direct source literal, which is exactly why a `concat!()`
   rewrite would break it.
+- **Wrapper depth** — this plan's counter of enclosing abstract-syntax-tree
+  nodes whose span came from a macro expansion. Zero means nothing stands
+  between the literal and the compiler. See `DEC-002` and `SURP-012`.
 - **Applicability** — rustc's confidence label on a suggestion.
   `MachineApplicable` means `cargo fix` may apply it unattended.
+- **Bless** — replacing a `.stderr` expectation with the output the code
+  currently produces. In this repository that is a manual copy, not a flag;
+  see `SURP-014`.
 
 ### What exists today that you will copy
 
-**Lint crate shape.** Use `crates/no_unwrap_or_else_panic/` as the template; it
-is the closest existing multi-module lint. Its `Cargo.toml` declares
-`[lib] crate-type = ["cdylib", "rlib"]`, `publish = false`, workspace-inherited
-metadata, and two features:
+**Pure-domain crate shape.** `crates/whitaker_clones_core/Cargo.toml`: no
+`[lib]` section, `publish = false`, workspace-inherited metadata,
+`rustc_lexer = { workspace = true }`, and dev-dependencies including `insta`,
+`proptest`, `rstest`, `rstest-bdd`, and `rstest-bdd-macros`. Kani harnesses
+live in `#[cfg(kani)] mod kani;` modules; the workspace already declares
+`unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }`
+(`Cargo.toml:180`), so a crate with `[lints] workspace = true` needs no local
+`check-cfg` entry.
 
-```toml
-[features]
-default = []
-dylint-driver = [
-    "dep:whitaker-common", "dep:dylint_linting", "dep:fluent-templates",
-    "dep:log", "dep:rustc_hir", "dep:rustc_lint", "dep:rustc_session",
-    "dep:rustc_span", "dep:serde", "dep:whitaker",
-]
-constituent = ["dylint-driver", "dylint_linting/constituent"]
-```
-
-Every compiler dependency is `optional = true` so that plain `cargo check`,
-`cargo doc`, and `cargo clippy` runs succeed without `rustc_private`. The
-crate's `src/lib.rs` opens with
-`#![cfg_attr(feature = "dylint-driver", feature(rustc_private))]` and gates
-every module on `dylint-driver`, with a `stub` module filling the crate when
-the feature is off. The `crates/*` glob in the workspace `members` list picks
-up a new directory automatically — no manifest edit is needed to register it.
+**Lint crate shape.** `crates/no_unwrap_or_else_panic/` is the template:
+`[lib] crate-type = ["cdylib", "rlib"]`, `publish = false`, and two features —
+`dylint-driver` gating every compiler dependency as `optional = true`, and
+`constituent = ["dylint-driver", "dylint_linting/constituent"]`. `src/lib.rs`
+opens with `#![cfg_attr(feature = "dylint-driver", feature(rustc_private))]`
+and gates every module, with a `stub` module filling the crate when the
+feature is off. The `crates/*` glob in the workspace `members` list picks up a
+new directory automatically.
 
 **Lint declaration.** `crates/conditional_max_n_branches/src/driver.rs:73-91`
 wraps the declaration macro in a private module so the macro-generated,
@@ -501,7 +769,8 @@ source-location-free items do not trip `missing_docs`:
 mod declaration {
     #![expect(
         missing_docs,
-        reason = "dylint_linting macro expansion emits items with no documentable source location"
+        reason = "dylint_linting macro expansion emits items with no \
+                  documentable source location"
     )]
     use super::ConditionalMaxNBranches;
     dylint_linting::impl_late_lint! {
@@ -518,36 +787,36 @@ pub use declaration::CONDITIONAL_MAX_N_BRANCHES;
 `dylint_linting` 6 provides `impl_early_lint!` with the same shape.
 
 **No early lint exists yet.** Every current lint is a `LateLintPass`. This will
-be the repository's first `EarlyLintPass`, so there is no in-repo precedent for
-early-pass registration to copy; write it from `SURP-005`.
+be the repository's first `EarlyLintPass`, so write the registration from
+`SURP-005`.
 
 **Diagnostics.** `crates/bumpy_road_function/src/driver/diagnostic.rs:33-83` is
-the model, because it is the only lint that emits per-item secondary labels:
+the model, being the only lint that emits per-item secondary labels:
 
 ```rust
-let messages = safe_resolve_message_set(localizer, resolution, noop_reporter, || {
-    fallback_messages(/* ... */)
-});
+let messages = safe_resolve_message_set(
+    localizer, resolution, noop_reporter, || fallback_messages(/* ... */),
+);
 cx.emit_span_lint(
     BUMPY_ROAD_FUNCTION,
     input.primary_span,
     rustc_lint::errors::DiagDecorator(|lint| {
         lint.primary_message(messages.primary().to_owned());
         lint.span_note(input.primary_span, messages.note().to_owned());
-        for (ordinal, interval) in highlighted.iter().enumerate() { /* span_label */ }
+        // one span_label per highlighted item
         lint.help(messages.help().to_owned());
     }),
 );
 ```
 
-Note that `clippy_utils` is vendored but **unused** by every lint's logic; do
-not reach for `span_lint_and_then`. Use `cx.emit_span_lint` with
-`rustc_lint::errors::DiagDecorator`.
+`clippy_utils` is vendored but unused by every lint's logic; do not reach for
+`span_lint_and_then`.
 
-**Localization.** `whitaker_common::i18n` wraps `fluent_templates::static_loader!`
-over `common/locales/{en-GB,cy,gd}/`. One `.ftl` file per lint, named after the
-lint slug, with the message keyed by the slug and attributes `.note`, `.help`,
-and (for labels) `.label`. A lint obtains its localizer once per run:
+**Localization.** `whitaker_common::i18n` wraps
+`fluent_templates::static_loader!` over `common/locales/{en-GB,cy,gd}/`. One
+`.ftl` file per lint, named after the lint slug, with the message keyed by the
+slug and attributes `.note`, `.help`, and `.label`. A lint obtains its
+localizer once per crate in `check_crate` (`DEC-016`):
 
 ```rust
 let shared_config = SharedConfig::load();
@@ -557,13 +826,10 @@ self.localizer = get_localizer_for_lint(LINT_NAME, shared_config.locale());
 and resolves the primary/note/help triple by passing a
 `MessageResolution { lint_name, key, args }` to
 `safe_resolve_message_set(&localizer, resolution, noop_reporter, fallback)`.
-Per-label strings use `localizer.attribute_with_args(LINT_NAME, "label", &args)`
-and must have Fluent's bidirectional isolation marks (`U+2068`, `U+2069`) and
-`U+FFFD` filtered out, exactly as `resolve_bump_label` does at
-`crates/bumpy_road_function/src/driver/diagnostic.rs:175-189`.
+Labels go through the new `safe_resolve_label` of `DEC-012`.
 
-**UI tests.** `crates/no_std_fs_operations/src/tests/ui.rs` is the locale-aware
-template:
+**UI tests.** `crates/no_std_fs_operations/src/tests/ui.rs` is the
+locale-aware template:
 
 ```rust
 use serial_test::serial;
@@ -572,235 +838,215 @@ use whitaker_common::test_support::with_locale;
 #[test] #[serial] fn ui() { run_with_locale("ui", None); }
 #[test] #[serial] fn ui_runs_in_welsh() { run_with_locale("ui-cy", Some("cy")); }
 #[test] #[serial] fn ui_runs_in_gaelic() { run_with_locale("ui-gd", Some("gd")); }
-#[test] #[serial] fn ui_runs_in_fallback_locale() { run_with_locale("ui-fallback", Some("zz")); }
 
 fn run_with_locale(directory: &str, locale: Option<&str>) {
     with_locale(locale, || {
-        whitaker::run_ui_tests!(directory).expect("UI tests should execute without diffs");
+        whitaker::run_ui_tests!(directory)
+            .expect("UI tests should execute without diffs");
     });
 }
 ```
 
-`#[serial]` is mandatory: `DYLINT_LOCALE` is process-global. Never mutate the
-environment directly in a test; use `whitaker_common::test_support::{with_locale,
-with_env_var, with_env_var_removed}` (`AGENTS.md` forbids direct mutation).
+`#[serial]` is mandatory. Never mutate the environment directly in a test; use
+`whitaker_common::test_support::{with_locale, with_env_var,
+with_env_var_removed}`. Note that nextest runs each test in its own process,
+so the real serialization comes from the `serial-dylint-ui` group in
+`.config/nextest.toml`, whose membership is an explicit filter — the layout
+above matches the `test(tests::ui::)` clause, so do not rename it.
 
-**Behavioural tests.** Feature files live at `<crate>/tests/features/*.feature`;
-step definitions live in `<crate>/tests/<name>_behaviour.rs`. Scenarios bind by
-crate-relative path and zero-based index:
-`#[scenario(path = "tests/features/string_continuation_style.feature", index = 0)]`.
-Fixtures carrying a "world" struct are wrapped in
-`#[whitaker_test_macros::allow_fixture_expansion_lints]`, which works around
-`rstest`'s macro expansion dropping `#[expect]` attributes.
+**Behavioural tests.** Feature files at `<crate>/tests/features/*.feature`;
+step definitions at `<crate>/tests/<name>_behaviour.rs`. Scenarios bind by
+crate-relative path and zero-based index. Fixtures carrying a "world" struct
+are wrapped in `#[whitaker_test_macros::allow_fixture_expansion_lints]`.
 
 **Suite registration.** `suite/src/lints.rs` holds two parallel, order-coupled
-arrays: `SUITE_LINTS` (plain `LintDescriptor { name, crate_name }` metadata,
-usable without the compiler) and `SUITE_LINT_DECLS` (`&[&rustc_lint::Lint]`).
-`suite/tests/registration.rs::then_decls_align` asserts they agree, so the new
-entry must go into both at the same index. `suite/src/driver.rs:65-68` is the
-registration function to extend.
+arrays: `SUITE_LINTS` and `SUITE_LINT_DECLS`.
+`suite/tests/registration.rs::then_decls_align` asserts they agree.
+`suite/src/driver.rs:65-68` is the function to extend.
 
-**Installer and Makefile.** The lint list is hard-coded in *two* places that
-must stay in step: `installer/src/resolution.rs:17` (`LINT_CRATES`, a Rust
-`&[&str]`) and `Makefile:58` (`LINT_CRATES`, a space-separated Make variable
-that additionally contains `whitaker_suite`).
+**Two hard-coded lint lists.** `installer/src/resolution.rs:17`
+(`LINT_CRATES`, a Rust slice) and `Makefile:58` (`LINT_CRATES`, a Make
+variable that additionally contains `whitaker_suite`).
 
 **Gates.** `make check-fmt`, `make typecheck`, `make lint`, `make test`,
-`make markdownlint`, `make nixie`. `make test` runs `cargo nextest run` over the
-workspace and then `cargo test --doc` with an exclusion list; doctests cannot
-link `rustc_driver`, so the new crate is automatically excluded once it is
-added to the Makefile's `LINT_CRATES`.
+`make markdownlint`, `make nixie`. Note two limits the first draft got wrong.
+`make lint-whitaker` runs the suite only over `WHITAKER_PACKAGES`
+(`Makefile:81`), which contains no lint crate, because `cargo dylint`'s plain
+check build cannot provide `rustc_private` plumbing — so `module_max_lines` is
+*not* enforced on `cdylib` lint crates today, and files over 400 lines already
+exist there. It *can* be enforced on the new plain-library crate, which is one
+of `DEC-010`'s reasons. And `DOCTEST_EXCLUDES` excludes every crate in
+`LINT_CRATES`, so doctests in the `cdylib` crate never run.
 
 ### The upstream specification
 
 `docs/rfcs/0002-string-continuation-style.md` is the design of record. Read it
-in full before starting. Its §Rule semantics, §Decision matrix, §Continuation
-scanner, §Rewrite construction, and §Test plan are normative for this work,
-except where §Surprises & discoveries above records a toolchain fact that
-contradicts them.
+in full before starting — but read §Surprises & discoveries here first. Two of
+its clauses are defective (`SURP-012`, `SURP-016`) and several others are
+superseded.
 
 ### Skills and documents to load
 
-Before starting implementation, load these skills (they encode conventions this
-plan relies on rather than restates):
+Skills: `rust-router`, then `rust-unit-testing` and `rust-types-and-apis`;
+`hexagonal-architecture` for `DEC-003`; `proptest`; `kani`; `verus`; `leta`
+for navigation (prefer `leta show`/`leta refs` over reading whole files);
+`execplans` for keeping this document current; `commit-message`;
+`en-GB-oxendict`.
 
-- `rust-router`, then `rust-unit-testing` and `rust-types-and-apis` for the
-  domain modules.
-- `hexagonal-architecture` for the port and adapter boundaries in `DEC-003`.
-- `proptest` for the property tests in `EP-M1`.
-- `kani` for the bounded harnesses in `EP-M1`.
-- `verus` for `LEM-REWRITE-1`.
-- `leta` for navigation; prefer `leta show`/`leta refs` over reading whole files.
-- `execplans` for keeping this document current.
-- `commit-message` when committing.
-- `en-GB-oxendict` for all prose.
-
-And these repository documents:
-
-- `AGENTS.md` — the binding project policy layer.
-- `docs/whitaker-dylint-suite-design.md` — suite conventions. Note that it is
-  entirely late-pass oriented and contains no early-pass guidance; `EP-M5` adds
-  that section.
-- `docs/developers-guide.md` — internal conventions, including the Verus trust
-  boundary rules.
-- `docs/users-guide.md` §Available Lints — where the user-facing description goes.
-- `docs/documentation-style-guide.md` — required for every doc edit.
-- `docs/rust-testing-with-rstest-fixtures.md` and
-  `docs/rstest-bdd-users-guide.md` — API mechanics. Both are adapted upstream
-  material and cite paths that do not exist here; trust `AGENTS.md` and existing
-  crate precedent over their file-path examples.
-- `docs/complexity-antipatterns-and-refactoring-strategies.md` — the scanner is
-  a natural home for the very complexity this repository lints against; keep
-  functions small and single-purpose.
-- `docs/rust-doctest-dry-guide.md` — doc examples must be genuine, but note that
-  this crate's doctests are excluded from `make test` because they cannot link
-  `rustc_driver`. Put runnable examples on the *pure* domain functions, which
-  are compiled without the `dylint-driver` feature; mark compiler-facing
-  examples `ignore` with a reason, as `suite/src/driver.rs` does.
+Documents: `AGENTS.md`; `docs/whitaker-dylint-suite-design.md` (entirely
+late-pass oriented, with no early-pass guidance — `EP-M5` adds it);
+`docs/developers-guide.md`, especially §Verus scope and trust boundary and
+§Toolchain and parser maintenance runbooks; `docs/users-guide.md` §Available
+Lints; `docs/documentation-style-guide.md`;
+`docs/rust-testing-with-rstest-fixtures.md` and
+`docs/rstest-bdd-users-guide.md` (both adapted upstream material citing paths
+that do not exist here — trust `AGENTS.md` and crate precedent over their
+examples); `docs/complexity-antipatterns-and-refactoring-strategies.md`;
+`docs/rust-doctest-dry-guide.md`;
+`docs/execplans/7-2-7-kani-verification-of-bounded-min-hasher-sketch-invariants.md`
+for what a comparable Kani obligation actually cost.
 
 ## Conformance basis
 
-Upstream artefacts, at the revisions current on branch
-`2-2-10-string-continuation-style-post-expansion-early-lint.md` (based on
+Upstream artefacts, at the revisions current on this branch (based on
 `harden-lint-config` at `9b758d1`):
 
 - **RFC-0002** — `docs/rfcs/0002-string-continuation-style.md`, status
-  *Proposed*. The design of record.
+  *Proposed*. The design of record, with the defects recorded above.
 - **ROADMAP-2.2.10** — `docs/roadmap.md` line 81. Depends on ROADMAP-2.1.1
-  (lint crate template, done) and ROADMAP-2.3.4 (locale selection via
-  `DYLINT_LOCALE` and `dylint.toml`, done).
-- **SUITE-DESIGN** — `docs/whitaker-dylint-suite-design.md`. Governs crate
-  layout, the `constituent` feature, and suite assembly. Contains no early-pass
-  guidance; `EP-M5` must add it.
-- **AGENTS** — `AGENTS.md`. Code style, testing policy, documentation
-  maintenance, and the 400-line module ceiling.
+  (lint crate template, done) and ROADMAP-2.3.4 (locale selection, done).
+- **SUITE-DESIGN** — `docs/whitaker-dylint-suite-design.md`.
+- **AGENTS** — `AGENTS.md`.
 - **STYLE** — `docs/documentation-style-guide.md`.
 
-There is no Terms of Reference document for this work; ROADMAP-2.2.10 plus
-RFC-0002 serve that role.
+There is no Terms of Reference document; ROADMAP-2.2.10 plus RFC-0002 serve
+that role.
 
 Trace links:
 
 ```plaintext
-ROADMAP-2.2.10 -> RFC-0002 §Continuation scanner -> EP-M1 -> INV-SCAN-1 -> crates/string_continuation_style/src/continuation/tests.rs
+ROADMAP-2.2.10 -> RFC-0002 §Continuation scanner -> EP-M1 -> INV-SCAN-1 -> crates/whitaker_string_literals/src/continuation/tests.rs
 ROADMAP-2.2.10 -> RFC-0002 §Rewrite construction -> EP-M1 -> LEM-REWRITE-1 -> verus/string_continuation_rewrite.rs
+ROADMAP-2.2.10 -> SURP-012 -> EP-M2 -> LEM-DEPTH-1 -> crates/string_continuation_style/ui/pass_literal_macro_capture.rs
 ROADMAP-2.2.10 -> RFC-0002 §Ordinary string expressions -> EP-M2 -> crates/string_continuation_style/ui/fail_plain_join.rs
+ROADMAP-2.2.10 -> Constraints §evaluated-value -> EP-M2 -> LEM-EMIT-1 -> crates/string_continuation_style/ui/fail_value_preserved.fixed
 ROADMAP-2.2.10 -> RFC-0002 §Why the motivating example passes -> EP-M3 -> crates/string_continuation_style/ui/pass_implicit_format_capture.rs
-ROADMAP-2.2.10 -> RFC-0002 §Detection architecture (allowlist) -> EP-M4 -> crates/string_continuation_style/ui/pass_local_macro_lookalikes.rs
-ROADMAP-2.2.10 -> RFC-0002 §Suite integration -> EP-M5 -> suite/tests/registration.rs::then_early_pass_count
+ROADMAP-2.2.10 -> RFC-0002 §Suite integration -> EP-M5 -> suite/tests/registration.rs::then_early_pass_registered
 ROADMAP-2.2.10 -> AGENTS §Documentation maintenance -> EP-M5 -> docs/users-guide.md §string_continuation_style
 ```
 
 ## Verification plan
 
-The implementation structure in `DEC-003` was chosen *because* it puts every
-obligation below into a pure module reachable without a compiler session. Each
-obligation names the artefact that discharges it and the control that proves
-the check is not vacuous.
+The structure in `DEC-003` and `DEC-010` was chosen so that every pure
+obligation is reachable without a compiler session — and, learning from the
+review, so that the *adapter's* obligations are named too, since that is where
+the byte offsets are.
 
-### Axioms (assumed, not verified)
+### Axioms (assumed, not verified here)
 
-- **AXIOM-1.** `rustc_ast::FormatArgs::is_source_literal == true` implies the
-  format string was written as a direct literal in the source file and its
-  recovered snippet matches the parsed input. Basis: `SURP-001`. This is a
-  third-party interface contract; we do not verify rustc's internals. We *do*
-  verify our repository-owned use of it: `EP-M3` includes UI fixtures for a
-  `concat!()`-generated format string and an `include_str!()`-generated one,
-  both of which must produce silence.
-- **AXIOM-2.** `FormatArgs::span` is the format-string literal token's span, and
-  `Span::from_inner(InnerSpan::new(a, b))` yields the sub-span at byte offsets
-  `a..b` from that token's start. Basis: `SURP-002`. Verified at the boundary by
-  the byte-exact `.stderr` fixtures, whose caret positions would move if this
-  were wrong.
-- **AXIOM-3.** `FormatArgs::uncooked_fmt_str.1` is the raw source body between the
-  quotes, unmodified by the `println!` newline append. Basis: `SURP-003`.
-  Boundary-verified by `fail_println_join.rs`, whose expected suggestion would
-  gain a stray `\n` fragment if this were false.
-- **AXIOM-4.** Rust consumes, after a continuation escape's newline, every
-  subsequent space, tab, and newline until the first other character. Basis:
-  the Rust Reference §String literals, and rustc's `skip_ascii_whitespace`.
-  This is the rule the scanner implements; `INV-SCAN-3` and its oracle test it.
-- **AXIOM-5.** `concat!()` yields a `&'static str` and, when it supplies a format
-  string, disables implicit named capture. Basis: RFC-0002 §Source basis and
-  rust-lang/rust's own UI test. Boundary-verified by
-  `pass_implicit_format_capture.rs`.
+Each is discharged behaviourally at `EP-M0a` and recorded in
+`EV-M0-transcript`, rather than resting on a source citation that a toolchain
+bump invalidates.
+
+- **AXIOM-1.** `is_source_literal == true` implies the format string was
+  written as a direct literal whose recovered snippet matches the parsed
+  input. Basis `SURP-001`. Boundary-verified by
+  `pass_generated_format_string.rs`.
+- **AXIOM-2.** `FormatArgs::span` is the format-string literal token's span,
+  and `Span::from_inner(InnerSpan::new(a, b))` yields the sub-span at byte
+  offsets `a..b` from that token's start. Basis `SURP-002`. Boundary-verified
+  by the byte-exact `.stderr` caret positions and by `LEM-SPAN-1`.
+- **AXIOM-3.** `uncooked_fmt_str.1` is the raw source body, unmodified by the
+  `println!` newline append. Basis `SURP-003`. Boundary-verified by
+  `fail_println_join`, whose `.fixed` file would gain a stray fragment.
+- **AXIOM-4.** After a continuation escape's newline, Rust discards every
+  subsequent byte in `{' ', '\t', '\n', '\r'}`, in any order, until the first
+  byte outside that set, excluding formfeed. Basis `SURP-016`. This is the rule
+  the scanner implements; `INV-SCAN-3` tests it.
+- **AXIOM-5.** `concat!()` yields a `&'static str` and, when it supplies a
+  format string, disables implicit named capture. Basis RFC-0002 §Source basis.
+  Boundary-verified by `pass_implicit_format_capture.rs`.
 - **AXIOM-6.** rustc normalizes CRLF to LF before lexing, so adapter-supplied
-  literal bodies contain LF only. Basis: `SURP-007`.
-- **AXIOM-7.** `LintStore::register_early_pass` causes the pass to run once per
-  crate, after expansion, before HIR lowering. Basis: `SURP-005` and
-  `compiler/rustc_interface/src/passes.rs:400`.
+  bodies contain LF only, and rustc un-normalizes byte offsets back to on-disk
+  positions before `rustfix` sees them. Basis `SURP-007`. The second half is
+  boundary-verified by the Windows continuous-integration job running the
+  run-rustfix fixtures.
+- **AXIOM-7.** `register_early_pass` causes the pass to run once per crate,
+  after expansion, before lowering. Basis `SURP-005`. Note `SURP-015`'s
+  caution: the plan does not *depend* on the once-per-crate property for
+  correctness, only for cost.
 
-### Obligations
+### Pure-domain obligations
 
 **INV-SCAN-1 — continuation detection is backslash-parity-correct.**
 
-- Statement: a byte offset `i` in the literal body begins a continuation escape
-  if and only if the byte at `i` is `\`, the maximal run of consecutive
-  backslashes ending at `i` has odd length, and the byte at `i + 1` is `\n` (or
-  begins a `\r\n` pair).
-- Method: `rstest` parameterized cases for the finite boundary partition
-  (runs of length 0 through 4, before LF, before CRLF, before a lone CR, before
-  end-of-body), plus a Kani harness for exhaustive coverage of short inputs.
+- Statement: a byte offset `i` begins a continuation escape if and only if the
+  byte at `i` is `\`, the maximal run of consecutive backslashes ending at `i`
+  has odd length, and the byte at `i + 1` is a source newline.
+- Method: `rstest` parameterized cases over the finite boundary partition
+  (runs of length 0 to 4, before LF, before CR, before tab, before
+  end-of-body), plus a Kani harness.
 - Rationale: the parity rule is where a naive implementation goes wrong, and
-  the input alphabet that matters is tiny, so bounded exhaustive exploration is
-  both cheap and complete over the interesting domain.
-- Domain: Kani harness over bodies of length ≤ 8 drawn from the four-symbol
-  alphabet `{ '\\', '\n', ' ', 'a' }`, with `#[kani::unwind(10)]`.
-- Artefact: `crates/string_continuation_style/src/continuation/tests.rs`
-  (parameterized) and `crates/string_continuation_style/src/continuation/kani.rs`
-  (`#[cfg(kani)]`).
-- Evidence: `cargo nextest run -p string_continuation_style continuation::` and
-  `scripts/run-kani.sh string-continuation`. Both must fail before the scanner
+  the interesting alphabet is tiny.
+- Domain and bound: Kani over bodies of length ≤ 5 drawn from
+  `{'\\', '\n', 'a'}` — 364 paths. Grow only if it discharges quickly. Use a
+  `#[cfg(kani)]` fixed-capacity sink `[Option<Continuation>; 3]` in place of
+  the `Vec`, mirroring `whitaker_clones_core`'s `KANI_MAX_RECORDED_PAIRS`
+  pattern, and derive the unwind bound from that capacity with a
+  `const _: () = assert!(...)`. **Stated limit:** the alphabet excludes `'\r'`,
+  `'\t'`, and space, so the Kani result is not exhaustive over `INV-SCAN-3`'s
+  whitespace set. Those bytes are covered by parameterized cases and proptest
+  only.
+- Artefact: `crates/whitaker_string_literals/src/continuation/tests.rs` and
+  `.../continuation/kani.rs`.
+- Evidence: `cargo nextest run -p whitaker_string_literals continuation::`
+  and `scripts/run-kani.sh string-literals`. Both must fail before the scanner
   exists.
-- Non-vacuity: witnesses `"a\\\nb"` (odd run, is a continuation) and
-  `"a\\\\\nb"` (even run, is a literal backslash followed by a real newline)
-  must both be exercised and must be classified differently. Negative control
-  `NV-SCAN-1`: replace the parity test with `is_backslash(prev)` and require the
-  Kani harness to produce a counter-example naming the even-run input.
+- Non-vacuity: `"a\\\nb"` (odd run, is a continuation) and `"a\\\\\nb"` (even
+  run, is a literal backslash then a real newline) must both be exercised and
+  classified differently. Negative control **NV-SCAN-1**: replace the parity
+  test with `is_backslash(prev)` and require Kani to produce a counter-example
+  naming the even-run input.
 
 **INV-SCAN-2 — recorded ranges are well-formed.**
 
-- Statement: for every `Continuation` the scanner emits,
+- Statement: for every emitted `Continuation`,
   `escape_range.start < escape_range.end <= skipped_whitespace_range.start <=
-  skipped_whitespace_range.end <= body.len()`; consecutive continuations are
-  strictly ordered; and no two continuations' combined
-  `escape_range ∪ skipped_whitespace_range` intervals overlap.
-- Method: `proptest`, asserted on every scan in every property test via a
-  shared `assert_scan_well_formed` helper, plus the same assertion inside the
-  Kani harness for `INV-SCAN-1`.
-- Rationale: this is a structural invariant over generated inputs of
-  unbounded length; a property test is the proportionate tool, and folding it
-  into every other property test costs nothing.
-- Domain: generated bodies mixing ASCII text, Unicode text, escaped quotes,
-  escaped backslashes, blank lines, and one to five continuations.
-- Artefact: `crates/string_continuation_style/src/continuation/props.rs`.
-- Evidence: `cargo nextest run -p string_continuation_style continuation::props`.
-- Non-vacuity: the generator must be classified with `proptest::prop_assume!`-free
-  construction and a `prop_assert!(scan.len() >= 1)` guard, so a generator that
-  silently stopped producing continuations fails loudly rather than passing
-  vacuously. Negative control `NV-SCAN-2`: make the scanner emit
-  `skipped_whitespace_range = escape_range` and require the disjointness or
-  ordering assertion to reject it.
+  skipped_whitespace_range.end <= body.len()`; continuations are strictly
+  ordered; and no two combined intervals overlap.
+- Method: `proptest`, asserted on every scan in every property test through a
+  shared `assert_scan_well_formed` helper. Deliberately **not** in the Kani
+  harness: an O(n²) pairwise assertion over a symbolic-length container buys
+  nothing over proptest and is exactly the shape that stalls the solver.
+- Domain: generated bodies mixing ASCII, Unicode, escaped quotes, escaped
+  backslashes, blank lines, and one to five continuations.
+- Artefact: `crates/whitaker_string_literals/src/continuation/props.rs`.
+- Evidence: `cargo nextest run -p whitaker_string_literals continuation::props`.
+- Non-vacuity: the generator is construction-based, not filter-based, and a
+  `prop_assert!(scan.len() >= 1)` guard fails loudly if it stops producing
+  continuations. Negative control **NV-SCAN-2**: make the scanner emit
+  `skipped_whitespace_range = escape_range` and require the ordering or
+  disjointness assertion to reject it.
 
 **INV-SCAN-3 — the skipped-whitespace range matches the language rule.**
 
 - Statement: `skipped_whitespace_range` covers exactly the bytes rustc
-  discards after the continuation's newline — every space, tab, LF, and
-  complete CRLF — terminating at the first other byte or at the end of the body.
-- Method: differential property test against an independent unescaper
-  (`DEC-007`), plus `rstest` cases for the boundaries (immediately-following
-  content, blank lines, whitespace-only trailing run, end of body).
+  discards after the continuation's newline, per `AXIOM-4`.
+- Method: `rstest` cases for the boundaries (immediately-following content,
+  blank lines, whitespace-only trailing run, mixed tab and carriage return, end
+  of body), plus a `proptest` differential against
+  `rustc_lexer::unescape::unescape_str` (`SURP-011`), plus — the strongest
+  layer — the run-rustfix fixtures of `LEM-REWRITE-2`, where the real compiler
+  adjudicates.
 - Rationale: this is the obligation most likely to be got subtly wrong, and it
-  is the one where an independent oracle is available. Examples alone would not
-  cover the interaction of blank lines with indentation.
+  is the one where independent oracles exist at two levels of strength.
 - Domain: as `INV-SCAN-2`, with the added generator requirement that at least
   one continuation is followed by non-empty indentation.
-- Artefact: `crates/string_continuation_style/src/continuation/props.rs`.
-- Evidence: as above.
-- Non-vacuity: the generator must emit non-empty indentation after every
-  newline, so that an implementation deleting only `escape_range` and retaining
-  the indentation fails. Negative control `NV-SCAN-3`: that exact mutation must
-  be rejected with a diff showing the retained spaces.
+- Artefact: `crates/whitaker_string_literals/src/continuation/props.rs`.
+- Non-vacuity: the generator emits non-empty indentation after every newline,
+  so an implementation deleting only `escape_range` fails. Negative control
+  **NV-SCAN-3**: that exact mutation must be rejected with a diff showing the
+  retained spaces.
 
 **INV-CLASS-1 — classification is total and mutually exclusive.**
 
@@ -809,116 +1055,197 @@ the check is not vacuous.
   is source content before the backslash on its physical line *and* source
   content after all consumed whitespace; when neither side has content,
   `LeadingLayoutTrim` wins.
-- Method: `rstest` parameterized cases covering the 2×2 content matrix plus the
-  precedence tie, and a Kani harness reusing the `INV-SCAN-1` symbolic input to
-  assert exclusivity exhaustively over short bodies.
-- Rationale: a finite partition with an explicit precedence rule. Both an
-  enumerated table and bounded exhaustive exploration are cheap; together they
-  cover the named cases and the unnamed ones.
-- Domain: the five rows of RFC-0002 §Continuation scanner's classification
-  table, plus Kani over bodies of length ≤ 8.
-- Artefact: `crates/string_continuation_style/src/classification/tests.rs` and
-  `crates/string_continuation_style/src/continuation/kani.rs`.
-- Evidence: `cargo nextest run -p string_continuation_style classification::`.
-- Non-vacuity: each of the three variants must be produced by at least one
-  case, and the Kani assertion must be `exactly_one_of(...)`, not
-  `at_least_one_of(...)`. Negative control `NV-CLASS-1`: swap the precedence so
-  `TrailingLayoutTrim` wins the tie, and require the precedence case to fail.
+- Method: `rstest` parameterized cases over the 2×2 content matrix plus the
+  precedence tie, and an `exactly_one_of` assertion inside the `INV-SCAN-1`
+  Kani harness (free, since the symbolic input is already there).
+- Domain: the five rows of RFC-0002 §Continuation scanner's table, plus the
+  Kani bound above.
+- Artefact: `crates/whitaker_string_literals/src/classification/tests.rs`.
+- Non-vacuity: each variant must be produced by at least one case, and the
+  Kani assertion must be `exactly_one_of`, not `at_least_one_of`. Negative
+  control **NV-CLASS-1**: swap the precedence so `TrailingLayoutTrim` wins the
+  tie, and require the precedence case to fail.
 
 **LEM-REWRITE-1 — splitting and re-concatenating equals removal.**
 
-- Statement: let `body` be the literal body and `R = [r_0, ..., r_{n-1}]` a
-  sorted, pairwise-disjoint sequence of sub-ranges of `body`. Let `fragments`
-  be the `n + 1` maximal sub-sequences of `body` lying between and outside the
-  ranges of `R`. Then `concat(fragments) == body with every r_i removed`.
-- Method: Verus deductive proof over `Seq<u8>`, by induction on `|R|`.
-- Rationale: this is the lemma the entire suggestion rests on, it must hold for
-  literals of every length and every number of joins, and it is a pure
-  statement about sequences — precisely the unbounded, algebraic shape Verus is
-  for. A property test would sample it; a proof settles it.
-- Domain: all `Seq<u8>` and all sorted disjoint range sequences. Unbounded.
-- Artefact: `verus/string_continuation_rewrite.rs`, following the layout of
-  `verus/clone_detector_candidate_pair.rs` — mirror the production range type
-  by `#[path]` include where the module's dependencies permit, and state the
-  trust boundary in the module doc comment otherwise.
-- Evidence: `make verus` (add a `string-continuation` group to
-  `scripts/run-verus.sh`). Before the proof body is written, the lemma must
-  fail with an open goal, not vacuously succeed.
-- Non-vacuity: inspect that the antecedent is inhabited by exhibiting a
-  concrete witness (`body = "abc"`, `R = [1..2]`, fragments `["a", "c"]`)
-  inside the proof file as an `assert` that Verus must discharge from the
-  lemma. The proof must not contain `assume`. The `decreases` clause must be
-  present and the base case must be `|R| == 0`, so the induction does work
-  rather than collapsing. Negative control `NV-REWRITE-2`: weaken the
-  disjointness precondition and confirm Verus rejects the proof rather than
-  accepting it.
+- Statement: let `body` be the literal body and `R` a sorted,
+  pairwise-disjoint sequence of sub-ranges. Let `fragments` be the `|R| + 1`
+  maximal sub-sequences of `body` lying outside `R`. Then
+  `concat(fragments) == body with every range in R removed`.
+- Method: Verus deductive proof over `Seq<u8>`, by induction on `|R|`,
+  **inducting on the last range, not the first**. With `r_{n-1}` removed
+  first, `body.subrange(0, r_{n-1}.start)` is untouched and no index-rebasing
+  lemma is needed; inducting from the left would require one, and that is
+  where these proofs stall in Z3.
+- Rationale: this is the algebraic core of the suggestion, it must hold for
+  every literal length and join count, and it is a pure statement about
+  sequences. Note the honest limitation: Verus cannot verify the shipped
+  `render(&str) -> String`, so this is a spec mirror, and the trust boundary is
+  stated in the proof's module doc comment. It is the *supporting* argument;
+  `LEM-REWRITE-2` and `LEM-EMIT-1` are what actually protect users.
+- Artefact: `verus/string_continuation_rewrite.rs`, following
+  `verus/clone_detector_candidate_pair.rs`.
+- Evidence: `make verus`, which requires three edits to
+  `scripts/run-verus.sh` — a new group arm in `proof_files_for_group`, an
+  addition to the `all` arm, and a new case in the
+  `all|decomposition|clone-detector)` dispatch. Before the proof body is
+  written the lemma must fail with an open goal, not vacuously succeed.
+- Non-vacuity: exhibit a concrete witness (`body = "abc"`, `R = [1..2]`,
+  fragments `["a", "c"]`) inside the proof file as an `assert` Verus must
+  discharge from the lemma. The proof must contain no `assume`. The
+  `decreases` clause must be present and the base case must be `|R| == 0`.
+  Negative control **NV-REWRITE-2**: weaken the disjointness precondition and
+  confirm Verus rejects the proof.
 
 **LEM-REWRITE-2 — the rewrite preserves the evaluated value.**
 
-- Statement: for a body whose selected joins are `J`, unescaping the original
-  body yields the same character sequence as unescaping each rewrite fragment
-  and concatenating the results.
-- Method: differential `proptest` against the reference unescaper of `DEC-007`,
-  plus three compile-and-run UI fixtures that assert the equality at runtime in
-  real compiled Rust.
-- Rationale: `LEM-REWRITE-1` is about source bytes; this is about *evaluated*
-  bytes, and the bridge between them is the escaping rule, which is external
-  (`AXIOM-4`). Verifying against an independent implementation of that rule, and
-  then grounding a few points in actual compiler output, covers both the
-  general case and the "did we understand the rule at all" case.
+- Statement: unescaping the original body yields the same character sequence
+  as unescaping each rewrite fragment and concatenating.
+- Method: two independent layers. (a) A `proptest` differential against
+  `rustc_lexer::unescape::unescape_str`. (b) The authoritative layer:
+  `// run-rustfix` fixtures whose `.fixed` files carry
+  `const _: () = assert!(bytes_eq(ORIGINAL, REWRITTEN));`. `SURP-014` shows
+  `compiletest_rs` compiles the fixed code, so **rustc's own escaping
+  implementation** adjudicates, with no shared lineage with our scanner.
+- Rationale: layer (a) samples broadly with a same-family oracle; layer (b)
+  is narrow but uses the real thing. Together they cover both "did we get the
+  general case right" and "did we understand the rule at all".
 - Domain: generated bodies containing Unicode above the basic multilingual
-  plane, escaped quotes, escaped backslashes, `\u{...}` escapes, doubled braces
-  (`{{`, `}}`), and one to five joins.
-- Artefact: `crates/string_continuation_style/src/rewrite/props.rs` and
-  `crates/string_continuation_style/ui/fail_value_preserved.rs` (a fixture whose
-  fixed output, once applied, is compiled and run).
-- Evidence: `cargo nextest run -p string_continuation_style rewrite::props`.
+  plane, escaped quotes, escaped backslashes, `\u{...}` escapes, doubled
+  braces, and one to five joins. Fixtures cover one case per scanner boundary.
+- Artefact: `crates/whitaker_string_literals/src/rewrite/props.rs` and
+  `crates/string_continuation_style/ui/fail_value_preserved.{rs,fixed,stderr}`.
 - Non-vacuity: classify generated cases by join count and by whether any
-  Unicode scalar above `U+FFFF` appears, and require every class to be hit
-  (`proptest`'s statistics, checked by an explicit counter assertion at the end
-  of the run rather than by eyeball). Negative control `NV-REWRITE-3`: make the
-  rewriter split at a `LeadingLayoutTrim` as well as at joins, and require the
-  property to fail with a fragment boundary inside the trimmed region.
+  scalar above `U+FFFF` appears, and assert every class is hit with an explicit
+  counter at the end of the run, not by eyeball. Negative control
+  **NV-REWRITE-3**: make the rewriter split at a `LeadingLayoutTrim` as well as
+  at joins, and require both layers to fail.
 
-**LEM-APPLY-1 — machine-applicable implies re-lexable.**
+**LEM-APPLY-1 — the applicability gate is consulted and complete.**
 
-- Statement: the lint labels a suggestion `MachineApplicable` only when the
-  original snippet lexes as exactly one cooked string token and the generated
-  replacement lexes as exactly one `concat!` macro-call expression.
-- Method: `rstest` parameterized cases over the applicability gate, driven
-  through the pure gate function, plus the UI matrix as an end-to-end check.
-- Rationale: this is a finite conjunction of checks; enumerating the ways each
-  conjunct can fail is proportionate. The real risk is that the gate is never
-  consulted, which the negative control catches.
-- Domain: the seven conditions in RFC-0002 §Applicability.
-- Artefact: `crates/string_continuation_style/src/rewrite/tests.rs`.
-- Evidence: `cargo nextest run -p string_continuation_style rewrite::`.
-- Non-vacuity: each of the seven conditions must have a case that fails it
-  alone, with all others satisfied, and each such case must downgrade the
-  applicability. Negative control `NV-APPLY-1`: hard-code the gate to return
-  `MachineApplicable` and require all seven cases to fail.
+- Statement: `ConcatRewrite::build` returns `Some` only when the original
+  snippet lexes as exactly one cooked string token, the generated replacement
+  lexes as exactly one `concat!` macro-call expression, every selected split is
+  an interior join, and the context accepts a general expression. Re-lexing
+  uses `rustc_lexer` (`SURP-011`).
+- Method: `rstest` cases, one per failure condition, each failing exactly one
+  conjunct with all others satisfied.
+- Artefact: `crates/whitaker_string_literals/src/rewrite/tests.rs`.
+- Non-vacuity: each condition must have a case that downgrades the result to
+  `None`. Negative control **NV-APPLY-1**: hard-code `build` to return `Some`
+  and require every case to fail. Note that the type shape of `DEC-003` makes
+  this stronger than a field check: `PreferConcat(ConcatRewrite)` means, by
+  construction, that a proven rewrite exists.
 
-**Obligations deliberately not verified formally.** The macro-identity
-allowlist (`EP-M4`) is a policy table, not an invariant: its correctness is a
-statement about third-party crates' macro definitions, which change between
-their versions. It is verified by UI fixtures pinning both the accepted forms
-and the lookalikes, and by the "uncertain contract produces neither a
-diagnostic nor a suggestion" default, which is the safe direction. This is
-recorded here rather than omitted, because a reader could reasonably expect a
-proof and should know why there is not one.
+**LEM-FIX-1 — the rewrite is a fixed point.**
+
+- Statement: applying the suggestion produces source on which the lint does
+  not fire again.
+- Method: free, from `SURP-014` — `compiletest_rs` fails the test if the
+  recompiled fixed code "is still producing diagnostics". Every `fail_*`
+  fixture therefore proves idempotence at no extra cost.
+- Rationale: `cargo fix` re-runs the lint up to four rounds and reports an
+  error blaming the user's code if it does not converge. Worth pinning the
+  awkward shapes explicitly: a literal with both a leading layout trim and an
+  interior join, and a literal with two adjacent continuations.
+- Non-vacuity: **NV-FIX-1** — make the rewriter emit a fragment that itself
+  contains an interior join, and require the recompile step to report residual
+  diagnostics.
+
+### Adapter obligations
+
+These are the ones the first draft omitted, and they guard the twelve lines
+that turn a byte offset into a write.
+
+**LEM-SPAN-1 — body offsets map to source spans correctly.**
+
+- Statement: `body_span(token_span, BodyOffset(o))` equals
+  `token_span.from_inner(InnerSpan::new(o + prefix_len, ...))` where
+  `prefix_len` is the literal's quote-prefix length, and the conversion is the
+  only place that arithmetic occurs.
+- Method: `BodyOffset` and `TokenOffset` newtypes make the shift a
+  compiler-checked conversion rather than a remembered `+ 1`; in-process
+  `rstest` cases in `crates/string_continuation_style/src/driver/tests.rs`
+  drive the conversion directly; and the byte-exact `.stderr` caret positions
+  pin it end to end.
+- Rationale: this is the single place an off-by-one corrupts source. The
+  `+ 1` convention is only sound because raw, byte, and C literals are excluded
+  by construction (`prefix_len` is 2 for `b"…"` and `c"…"`), so the two type
+  fixes reinforce each other.
+- Non-vacuity: negative control **NV-REWRITE-1** — seed a deliberate
+  off-by-one in the conversion and require both the unit cases and at least one
+  `.stderr` caret to move.
+- Note on coverage: `make coverage` instruments the adapter into the test
+  binary but the adapter only executes inside a separate `rustc` subprocess, so
+  without in-process tests these lines report as zero per cent and the
+  changed-line gate blocks the pull request. Three crates already solve this
+  with `src/driver*/tests.rs`; follow them.
+
+**LEM-DEPTH-1 — wrapper depth is maintained across every containing node.**
+
+- Statement: for every abstract-syntax-tree node kind that can contain an
+  expression and that this pass visits, entering an expansion-derived node
+  increments the counter and leaving it decrements; the counter is zero exactly
+  when no enclosing node came from an expansion.
+- Method: in-process `rstest` cases over a synthetic visit sequence, plus one
+  UI fixture per containing kind: a literal inside a `macro_rules!`-expanded
+  `let`, inside an expanded item, inside an expanded statement, inside a
+  derive-generated impl, and inside a nested two-level expansion. All must be
+  silent.
+- Rationale: `SURP-012` makes this the load-bearing soundness gate, and it is
+  the one part of the design the pure-domain verification cannot reach.
+- Non-vacuity: negative control **NV-DEPTH-1** — disable the counter and
+  require `pass_literal_macro_capture.rs` to emit a diagnostic. This is the
+  control that proves the whole class of `pass_*` fixtures is not vacuous.
+
+**LEM-EMIT-1 — no suggestion is emitted without a run-time value check.**
+
+- Statement: before attaching an applicability above `MaybeIncorrect`, the
+  lint unescapes the recovered original snippet and the generated replacement's
+  fragments with `rustc_lexer::unescape` and compares the resulting byte
+  sequences. On mismatch it emits nothing.
+- Method: in-process `rstest` cases feeding the emission path a deliberately
+  corrupted rewrite and asserting silence.
+- Rationale: this is the highest-value single item in the plan. It converts
+  every span-arithmetic bug — including ones no test anticipated — from silent
+  source corruption into a silent no-op. Cost is a few microseconds on a path
+  that runs approximately never, because `DEC-015`'s cheap pre-filter has
+  already eliminated almost every literal.
+- Non-vacuity: negative control **NV-EMIT-1** — seed an off-by-one span and
+  require the gate to suppress the diagnostic, with the `.stderr` showing
+  nothing rather than showing a wrong suggestion.
+
+### Silence fixtures need controls too
+
+Roughly a dozen `pass_*` fixtures assert that the lint emits nothing. Against
+an unimplemented `check_expr` every one of them passes, so as specified they
+prove nothing. Each therefore gets a paired control: temporarily invert the
+one gate it exercises — drop the `Captured` check for
+`pass_implicit_format_capture`, accept `StrRaw` for `pass_raw_strings`, disable
+the depth counter for `pass_literal_macro_capture`, and so on — and record that
+the fixture then fails with a diagnostic. Run each control once, record the
+transcript in §Artefacts and notes, and revert it.
+
+### Deliberately not verified formally
+
+Nothing in this plan's scope is a policy table over third-party macro
+grammars, because `DEC-002` removed the allowlist and `DEC-009` removes the
+facades. If `DEC-009` is declined, reinstate the first draft's note explaining
+why the allowlist gets fixtures rather than a proof.
 
 ## Plan of work
 
 ### Stage A — understand and propose (no code changes)
 
-Read RFC-0002 in full. Read `AGENTS.md`. Confirm `DEC-002` and `DEC-007` have
-been decided. Do not write code until this plan is approved.
+Read RFC-0002 in full, then §Surprises & discoveries here. Confirm `DEC-009`,
+`DEC-013`, and `DEC-014` have been answered. Do not write code until this plan
+is approved.
 
 ### Stage B — red tests and the behaviour specification
 
 Write the feature file and the failing tests before any production code. The
-feature specification that drives `EP-M1` and `EP-M2` is, at
-`crates/string_continuation_style/tests/features/string_continuation_style.feature`:
+specification driving `EP-M1` and `EP-M2`, at
+`crates/whitaker_string_literals/tests/features/string_continuation.feature`:
 
 ```gherkin
 Feature: Context-sensitive string continuation style
@@ -955,219 +1282,218 @@ Feature: Context-sensitive string continuation style
     When the continuation is classified
     Then the disposition is PreferConcat
     And the rewrite has four fragments
+
+  Scenario: A rewrite that would change the value is withheld
+    Given a rewrite whose fragments do not unescape to the original value
+    When the emission gate runs
+    Then no suggestion is produced
 ```
 
-Each stage below ends with `make check-fmt && make typecheck && make lint &&
-make test`. Do not proceed while any gate fails.
+Each stage ends with `make check-fmt && make typecheck && make lint &&
+make test`, run sequentially. Do not proceed while any gate fails.
 
 ### Stage C — implementation with verification developed alongside
 
-Milestones `EP-M0` through `EP-M4`, in order. Each writes its Kani harness or
-Verus lemma in the same commit as the code it constrains, not afterwards.
+`EP-M0a` through `EP-M3`, in order. Each writes its Kani harness or Verus
+lemma in the same commit as the code it constrains.
 
-### Stage D — refactor, documentation, and wider validation
+### Stage D — integration, tooling, documentation, and wider validation
 
-Milestone `EP-M5`: suite registration, installer and Makefile lists, user
-guide, developers' guide, suite design addendum, RFC amendments for
-`SURP-001`/`SURP-002`/`SURP-003`/`SURP-007`/`SURP-010`, and the roadmap tick.
+`EP-M5`.
 
 ## Milestones and plateaus
 
-### EP-M0 — Architecture spike (prototyping)
+### EP-M0a — Expansion-shape probe (prototyping, boxed at two hours)
 
-- **Outcome.** A throwaway branch-local experiment that answers `DEC-002`, then
-  is deleted. Repository state at the end of the milestone is unchanged except
-  for this plan's `Decision log` and `Surprises & discoveries`.
-- **Requirements advanced.** RFC-0002 §Detection architecture.
-- **Method.** Create a scratch lint crate registering an `EarlyLintPass` that,
-  for every `ExprKind::FormatArgs` and `ExprKind::Lit`, prints: the expression
-  span, `span.ctxt().outer_expn_data()`'s `kind`, `macro_def_id`, and
-  `def_site` filename; `is_source_literal`; `uncooked_fmt_str.0`; and the
-  argument kinds. Run it over a fixture crate that uses `format!`, `println!`,
-  `write!`, `assert!`, `log::info!`, `log::warn!(target: ...)`,
-  `tracing::info!` with fields, `tracing::info!` with controls, a local
-  `macro_rules!` named `info`, and a local macro binding `$msg:literal`.
-- **Acceptance evidence.** A transcript in this plan's §Artefacts and notes
-  showing, for each fixture line, whether a `FormatArgs` node appeared, whether
-  `is_source_literal` was true, whether duplicate nodes appeared for one source
-  literal, and what identity information `ExpnData` carried. Evidence
-  identifier `EV-M0-transcript`.
-- **Go/no-go.** If `log` and `tracing` invocations reach the AST as
-  `ExprKind::FormatArgs` with `is_source_literal == true` **and** `ExpnData`
-  alone cannot distinguish `log::info!` from a local `info!`, adopt `DEC-002`
-  option 3 and revise `EP-M3`/`EP-M4` accordingly. If they do not appear as
-  `FormatArgs` at all, adopt option 1 and move `log`/`tracing` support out of
-  this plan into a new roadmap item, recording the deviation in `Decision log`
-  and setting this plan to `BLOCKED` pending acceptance.
-- **Conformance check.** Does the evidence falsify RFC-0002's assumption that a
-  pure early pass suffices? If so, the RFC must be amended before `EP-M3`.
-- **Recovery.** `git checkout -- .` and delete the scratch crate; nothing is
-  committed from this milestone except plan updates.
+- **Outcome.** A transcript answering the questions `DEC-002` and the axioms
+  depend on. No repository change except this plan's living sections.
+- **Method.** Three compiler flags, no code. On a scratch file outside the
+  workspace containing `format!`, `println!`, `write!`, `assert!`, a
+  `macro_rules!` capturing `$l:literal`, a local `macro_rules! info`, and — if
+  `DEC-009` is declined — `log::info!` and `tracing::info!` with fields:
+  - `cargo rustc -- -Zunpretty=expanded` — does each form reach the abstract
+    syntax tree as a `format_args!` node?
+  - `cargo rustc -- -Zunpretty=expanded,hygiene` — what syntax context does the
+    message literal carry, and does a `$l:literal`-captured literal differ
+    observably from a directly written one? This is the direct probe for
+    `SURP-012`.
+  - `-Zmacro-backtrace` on a deliberately erroring literal — renders the
+    expansion chain for free.
+- **Acceptance evidence.** `EV-M0-transcript` in §Artefacts and notes, with one
+  line per probe, plus a statement for each of `AXIOM-1` through `AXIOM-3` and
+  `AXIOM-7` recording whether the observed behaviour matches.
+- **Go/no-go.** If `SURP-012` reproduces — a `$l:literal`-captured literal
+  presents with a root syntax context — `DEC-002`'s wrapper-depth gate is
+  mandatory and `EP-M2` proceeds as written. If it does not reproduce, record
+  that in §Surprises, simplify the gate accordingly, and note that RFC-0002
+  §Ordinary string expressions step 1 needs no amendment after all.
+- **Conformance check.** Does any observation falsify an axiom? If so, amend
+  the RFC before `EP-M1`.
+- **Recovery.** Delete the scratch file. It lives outside `crates/`
+  specifically so the `crates/*` workspace glob does not sweep it into
+  `make lint` and `make test` while the probe runs. Do not run
+  `git checkout -- .`; that would discard the plan updates this milestone
+  exists to produce.
 - **Remaining gaps.** All implementation.
-- **Compatibility decision.** None required; nothing ships.
+- **Compatibility decision.** None; nothing ships.
 
-### EP-M1 — Pure domain core
+### EP-M1 — Pure domain crate
 
-- **Outcome.** `crates/string_continuation_style/` exists and builds under both
-  feature configurations. The three pure modules — `continuation` (scanner),
-  `classification` (policy), `rewrite` (fragment construction and the
-  applicability gate) — are complete, documented, and fully covered. The lint is
-  declared and an `EarlyLintPass` is wired, but `check_expr` does nothing yet.
-  `cargo dylint --lib string_continuation_style` runs and reports nothing.
-- **Requirements discharged.** RFC-0002 §Continuation scanner, §Rewrite
-  construction. `INV-SCAN-1`, `INV-SCAN-2`, `INV-SCAN-3`, `INV-CLASS-1`,
-  `LEM-REWRITE-1`, `LEM-REWRITE-2`, `LEM-APPLY-1`.
-- **Acceptance evidence.** `EV-M1`: `cargo nextest run -p string_continuation_style`
-  passes; `scripts/run-kani.sh string-continuation` discharges both harnesses;
-  `make verus` discharges `verus/string_continuation_rewrite.rs`; every
-  negative control `NV-*` has been run and observed to fail for the stated
-  reason, with the transcript recorded in §Artefacts and notes.
-- **Conformance check.** Domain modules import no `rustc_*` crate — verify with
-  `leta refs` and by confirming the modules compile with `--no-default-features`.
-  Every module is under 400 lines. No public interface outside this crate
-  changed except the three workspace dependency additions of `DEC-006`.
-- **Recovery.** The crate is self-contained and unregistered; deleting the
-  directory and reverting the workspace manifest returns the repository to its
-  prior state.
-- **Remaining gaps.** No AST is inspected; no diagnostic is emitted.
-- **Compatibility decision.** None. This is a new pre-1.0 crate with no
-  consumers.
+- **Outcome.** `crates/whitaker_string_literals/` exists as a plain library
+  with no rustc dependency. The three pure modules — `continuation`,
+  `classification`, `rewrite` — plus the `facts` value types are complete,
+  documented with runnable doctests, and fully covered. Nothing consumes it
+  yet.
+- **Requirements discharged.** RFC-0002 §Continuation scanner (as corrected by
+  `SURP-016`), §Rewrite construction. `INV-SCAN-1`, `INV-SCAN-2`, `INV-SCAN-3`,
+  `INV-CLASS-1`, `LEM-REWRITE-1`, `LEM-REWRITE-2` layer (a), `LEM-APPLY-1`.
+- **Acceptance evidence.** `EV-M1`:
+  `cargo nextest run -p whitaker_string_literals` passes;
+  `cargo test -p whitaker_string_literals --doc` passes;
+  `scripts/run-kani.sh string-literals` discharges the harness with the bound
+  recorded; `make verus` discharges `verus/string_continuation_rewrite.rs`;
+  every negative control in the pure set has been run and observed to fail for
+  the stated reason.
+- **Conformance check.** `cargo tree -p whitaker_string_literals` shows no
+  `rustc_*` proxy crate. Every module is under 400 lines, now gate-enforced via
+  `WHITAKER_PACKAGES`. No `#[expect]` of a panic-class lint anywhere.
+- **Recovery.** The crate is unconsumed; deleting the directory and reverting
+  the workspace manifest and `WHITAKER_PACKAGES` returns the tree to its prior
+  state.
+- **Remaining gaps.** No abstract syntax tree is inspected; no diagnostic is
+  emitted.
+- **Compatibility decision.** None. New pre-1.0 crate, no consumers.
 
 ### EP-M2 — Plain cooked string literals
 
-- **Outcome.** `check_expr` handles `ExprKind::Lit` with a cooked
-  `token::LitKind::Str`. A plain source-line join produces one warning with a
-  note, a help, one secondary label per join, and a `MachineApplicable`
-  whole-literal `concat!()` suggestion. Byte strings, C strings, raw strings,
-  layout trims, and literals from macro expansions produce silence. Diagnostics
-  are localized in `en-GB`, `cy`, and `gd`.
+- **Outcome.** `crates/string_continuation_style/` exists as a `cdylib`
+  adapter. `check_expr` handles `ExprKind::Lit` with a cooked
+  `token::LitKind::Str` behind `DEC-015`'s cheap-first ordering and
+  `DEC-002`'s wrapper-depth gate. A plain source-line join produces one
+  warning with a note, a help, one secondary label per join, and a
+  whole-literal `concat!()` suggestion whose applicability follows `DEC-013`.
+  Byte strings, C strings, raw strings, layout trims, macro-captured literals,
+  and generated source files produce silence. Diagnostics are localized in
+  `en-GB`, `cy`, and `gd`.
 - **Requirements discharged.** RFC-0002 §Ordinary string expressions,
-  §Diagnostic, and the plain-literal rows of §Decision matrix.
-- **Acceptance evidence.** `EV-M2`: the UI fixtures `fail_plain_join`,
+  §Diagnostic, and the plain-literal rows of §Decision matrix. `LEM-SPAN-1`,
+  `LEM-DEPTH-1`, `LEM-EMIT-1`, `LEM-FIX-1`, `LEM-REWRITE-2` layer (b).
+- **Go/no-go before any suggestion ships.** Prove that `// run-rustfix` works
+  end to end through `dylint_testing` on the first fixture. If it does not,
+  that is a hard blocker on any applicability above `MaybeIncorrect`, not a
+  footnote: escalate rather than shipping an unverified fixer.
+- **Acceptance evidence.** `EV-M2`: fixtures `fail_plain_join`,
   `fail_multiple_joins`, `fail_join_across_blank_lines`,
-  `fail_value_preserved`, `pass_leading_layout_trim`,
-  `pass_trailing_layout_trim`, `pass_byte_and_c_strings`, `pass_raw_strings`,
-  `pass_real_newline`, `pass_literal_in_pattern`, and
-  `pass_unknown_literal_macro` all pass with byte-exact `.stderr`; `ui-cy`,
-  `ui-gd`, and `ui-fallback` locale smoke fixtures pass. The behavioural
-  scenarios for `PreferConcat`, `LeadingOrTrailingLayoutTrim`,
-  `NonStringLiteralType`, `Ignore`, and the multi-join rewrite all pass.
-- **Conformance check.** Confirm the suggestion span covers the whole literal
-  including quotes and that applying it by hand to `fail_plain_join.rs`
-  produces source that compiles and evaluates identically. Confirm no lint
-  fires on any pattern, attribute, or meta-item literal.
-- **Recovery.** Revert the `check_expr` body to the `EP-M1` no-op; the crate
-  returns to a coherent silent state.
+  `fail_value_preserved`, `fail_trim_and_join`, `fail_adjacent_joins`,
+  `pass_leading_layout_trim`, `pass_trailing_layout_trim`,
+  `pass_byte_and_c_strings`, `pass_raw_strings`, `pass_real_newline`,
+  `pass_literal_in_pattern`, `pass_literal_macro_capture`,
+  `pass_expanded_item`, `pass_generated_source_file` all pass, each `fail_*`
+  with a `.fixed` file under `// run-rustfix`; `ui-cy`, `ui-gd`, and
+  `ui-fallback` locale smokes pass; every silence fixture's paired control has
+  been run and observed to fail. `EV-M2-cost`: `time cargo dylint --lib
+  string_continuation_style` over one medium crate, before and after.
+- **Conformance check.** Applying `fail_plain_join`'s suggestion produces
+  source that compiles and evaluates identically — now verified by the harness
+  rather than by hand. No lint fires on any pattern, attribute, or meta-item
+  literal.
+- **Recovery.** Revert `check_expr` to a no-op; the crate returns to a
+  coherent silent state.
 - **Remaining gaps.** Format strings are not inspected.
 - **Compatibility decision.** None.
 
 ### EP-M3 — Source-authored format strings from compiler built-ins
 
 - **Outcome.** `check_expr` also handles `ExprKind::FormatArgs`. Format strings
-  from `format_args!`, `format!`, `print`/`println`/`eprint`/`eprintln`,
-  `write`/`writeln`, `panic`/`todo`/`unimplemented`/`unreachable`, and the
-  custom-message branches of `assert`/`debug_assert`/`assert_eq`/`assert_ne`/
-  `debug_assert_eq`/`debug_assert_ne` are diagnosed when — and only when — the
-  format string is a source literal, contains no `FormatArgumentKind::Captured`
-  argument, and the macro identity is proven per the `EP-M0` decision.
+  from the built-in set in `DEC-002` are diagnosed when the format string is a
+  source literal, contains no `FormatArgumentKind::Captured` argument, wrapper
+  depth is zero, the outermost expansion frame's name is in the set, and the
+  crate shadows none of those names.
 - **Requirements discharged.** RFC-0002 §Format strings, §Why the motivating
   example passes, and the format-string rows of §Decision matrix.
-- **Acceptance evidence.** `EV-M3`: the UI fixtures `fail_positional_arguments`,
+- **Acceptance evidence.** `EV-M3`: `fail_positional_arguments`,
   `fail_explicit_format_arguments`, `fail_println_join`, `fail_write_join`,
   `fail_assert_message_join`, `pass_implicit_format_capture` (the exact
-  pull-request-296 example, which must remain clean), `pass_implicit_width_capture`,
-  `pass_implicit_precision_capture`, and `pass_generated_format_string` all pass.
-  The RFC's "must fail with a machine-applicable rewrite" example produces
-  exactly the RFC's expected replacement, pinned by an `insta` snapshot of the
-  generated `concat!()` text.
-- **Conformance check.** Re-read RFC-0002 §Why the motivating example passes
-  and confirm the implemented predicate is `any(|a| matches!(a.kind,
-  Captured(_)))` over `arguments.all_args()`, catching captured width and
-  precision. Confirm no diagnostic is emitted for any macro whose identity was
-  not proven.
+  pull-request-296 example, which must remain clean),
+  `pass_implicit_width_capture`, `pass_implicit_precision_capture`,
+  `pass_generated_format_string`, `pass_shadowed_println` (a crate defining its
+  own `println!`, which must disable the lint entirely) all pass. The RFC's
+  "must fail with a machine-applicable rewrite" example produces exactly the
+  RFC's expected replacement, pinned by an `insta` snapshot of the *pure*
+  generated `concat!` text — a second, independently blessable artefact, so
+  that drift requires two files to be blessed in agreement.
+- **Conformance check.** The capture predicate is
+  `any(|a| matches!(a.kind, Captured(_)))` over `arguments.all_args()`,
+  catching captured width and precision. `log::info!` and `tracing::info!`
+  fixtures, if present, are silent.
 - **Recovery.** Remove the `FormatArgs` arm; `EP-M2` behaviour is intact.
-- **Remaining gaps.** `log` and `tracing` are not yet in the allowlist.
+- **Remaining gaps.** Integration.
 - **Compatibility decision.** None.
 
-### EP-M4 — `log` and `tracing` facade allowlist
-
-*Conditional on the `EP-M0` go/no-go.*
-
-- **Outcome.** The allowlist admits `log::{trace, debug, info, warn, error}!`
-  in the `(format, arguments...)` and `(target: expr, format, arguments...)`
-  forms, and `tracing::{trace, debug, info, warn, error}!` with a message tail
-  after validated `target:`/`parent:`/`name:` controls and structured fields.
-  Every other variant, every same-named local macro, and every same-named macro
-  from an unapproved crate produce silence. Invocations carrying `log`'s
-  `logger:` control are rejected (`DEC-008`).
-- **Requirements discharged.** RFC-0002 §Detection architecture allowlist and
-  §Acceptance fixtures.
-- **Acceptance evidence.** `EV-M4`: `fail_log_message`, `fail_log_target`,
-  `fail_tracing_fields`, `fail_tracing_controls`, `pass_log_implicit_capture`,
-  `pass_log_target_implicit_capture`, `pass_log_kv_fields`,
-  `pass_log_logger_control`, `pass_tracing_implicit_capture`,
-  `pass_tracing_controls_implicit_capture`, `pass_tracing_no_message`,
-  `pass_local_macro_lookalikes`, and `pass_external_macro_lookalikes` all pass.
-  A `pass_tracing_with_log_feature` fixture proves exactly one diagnostic is
-  emitted when `tracing/log` is enabled.
-- **Conformance check.** Confirm the identity proof matches the architecture
-  chosen at `EP-M0`. Confirm the divergence from RFC-0002's `log` grammar
-  (`DEC-008`) has been written back into the RFC.
-- **Recovery.** Remove the two facade entries from the allowlist table; the
-  built-in coverage from `EP-M3` is unaffected.
-- **Remaining gaps.** Suite integration.
-- **Compatibility decision.** None.
-
-### EP-M5 — Suite, installer, and documentation integration
+### EP-M5 — Suite, installer, tooling, and documentation integration
 
 - **Outcome.** `whitaker_suite` registers the early pass alongside its combined
-  late pass. `cargo dylint list` shows `string_continuation_style` in both the
-  standalone and suite libraries. Documentation is complete and the roadmap item
-  is ticked.
+  late pass. `cargo dylint list` shows the lint in both libraries. Proofs run
+  in continuous integration. Documentation is complete and the roadmap item is
+  ticked.
 - **Requirements discharged.** RFC-0002 §Suite integration; AGENTS
-  §Documentation maintenance; ROADMAP-2.2.10.
+  §Documentation maintenance; ROADMAP-2.2.10; `DEC-011`, `DEC-012`.
 - **Acceptance evidence.** `EV-M5`: `suite/tests/registration.rs` passes,
-  including a new `then_early_pass_count` step asserting
-  `store.early_passes.len() == 1` and a matching scenario line in
-  `suite/tests/features/suite_registration.feature`;
-  `make publish-check` succeeds; `make markdownlint` and `make nixie` pass.
+  including a new `then_early_pass_registered` step that asserts *which* pass
+  is registered, not merely how many — a count would also pass if the wrong
+  pass were registered, and unlike a late pass omitted from
+  `late_lint_methods!`, an omitted `register_early_pass` line is not a compile
+  error. `make publish-check` succeeds. `make markdownlint` and `make nixie`
+  pass. `cargo nextest show-config test-groups --profile ci` shows the new
+  crate's UI test in `serial-dylint-ui`. The new `proofs` job passes.
 - **Conformance check.** Both `LINT_CRATES` lists agree. `SUITE_LINTS` and
-  `SUITE_LINT_DECLS` are index-aligned. Every discovery in §Surprises &
-  discoveries has been reconciled with RFC-0002. No unapproved dependency,
-  trust boundary, or persisted-format change was introduced.
+  `SUITE_LINT_DECLS` are index-aligned. Every discovery is reconciled with
+  RFC-0002. `bumpy_road_function`'s fixtures are unchanged after the `DEC-012`
+  migration.
 - **Recovery.** Revert the suite and installer edits; the standalone lint crate
-  remains usable on its own.
+  remains usable.
 - **Remaining gaps.** None. Plan closes.
-- **Compatibility decision.** None. Whitaker is pre-1.0 (`version = "0.2.7"`)
-  and the suite's lint list is not an external commitment.
+- **Compatibility decision.** None. Whitaker is at `0.2.7` and the suite's lint
+  list is not an external commitment.
 
 ## Concrete steps
 
-All commands run from the repository root,
-`/home/leynos/.lody/repos/github---leynos---whitaker/worktrees/79835686-da6f-44b3-8bc2-5c7544bdeec4`,
-on branch `2-2-10-string-continuation-style-post-expansion-early-lint.md`.
+All commands run from the repository root on branch
+`2-2-10-string-continuation-style-post-expansion-early-lint.md`.
 
-Log every gate run to a file so truncated output can be reviewed:
+Log every gate run so truncated output can be reviewed:
 
 ```bash
 make test 2>&1 | tee "/tmp/test-whitaker-$(git branch --show-current).out"
 ```
 
-### Step 1 — workspace dependency additions (`DEC-006`)
+### Step 0 — baseline measurement
 
-Edit `Cargo.toml` `[workspace.dependencies]`, adding:
+Before any change:
 
-```toml
-googletest = "0.14"
-pretty_assertions = "1"
-serial_test = "3"
+```bash
+time make test 2>&1 | tee "/tmp/baseline-whitaker-$(git branch --show-current).out"
 ```
 
-Pin `googletest` and `serial_test` to whatever `cargo add --dry-run` reports as
-current and compatible with `rstest 0.26.1`; record the resolved versions here
-when the step is done. Then update the three crates that pin `serial_test`
-locally (`function_attrs_follow_docs`, `module_must_have_inner_docs`,
-`no_std_fs_operations`) to `serial_test = { workspace = true }`.
+Record the wall-clock as `EV-BASELINE` in §Artefacts and notes. The
+`Tolerances` wall-clock trigger is relative to this number.
+
+### Step 1 — workspace changes
+
+Edit `Cargo.toml`:
+
+- `[workspace.dependencies]`: add `googletest`, `pretty_assertions`, and
+  `serial_test = "4.0.1"` (matching the four existing per-crate pins exactly —
+  do not write `"3"`, which would silently downgrade them). Record the resolved
+  `googletest` version here once `cargo add --dry-run` reports it.
+- Add `[profile.release] overflow-checks = true`.
+- Migrate all **four** crates pinning `serial_test` locally —
+  `conditional_max_n_branches`, `function_attrs_follow_docs`,
+  `module_must_have_inner_docs`, `no_std_fs_operations` — to
+  `serial_test = { workspace = true }`.
+
+Edit `Makefile`: add `whitaker_string_literals` to `WHITAKER_PACKAGES` so the
+suite lints the new pure crate and the 400-line ceiling is gate-enforced there.
 
 Expected:
 
@@ -1176,73 +1502,113 @@ $ cargo metadata --format-version 1 >/dev/null && echo ok
 ok
 ```
 
-Commit: `Add googletest, pretty_assertions, and serial_test workspace pins`.
+Commit: `Add test-assertion dependencies and enable release overflow checks`.
 
-### Step 2 — scaffold the crate
+### Step 2 — scaffold both crates
 
-Copy the shape of `crates/no_unwrap_or_else_panic/`. Create:
+`crates/whitaker_string_literals/` (plain library, copy
+`crates/whitaker_clones_core/Cargo.toml`'s shape):
+
+```plaintext
+crates/whitaker_string_literals/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   ├── facts.rs
+│   ├── continuation/{mod.rs,kani.rs,props.rs,tests.rs}
+│   ├── classification/{mod.rs,tests.rs}
+│   └── rewrite/{mod.rs,props.rs,tests.rs}
+└── tests/
+    ├── features/string_continuation.feature
+    └── string_continuation_behaviour.rs
+```
+
+`crates/string_continuation_style/` (cdylib adapter, copy
+`crates/no_unwrap_or_else_panic/Cargo.toml`'s shape):
 
 ```plaintext
 crates/string_continuation_style/
 ├── Cargo.toml
 ├── src/
 │   ├── lib.rs
-│   ├── classification/{mod.rs,tests.rs}
-│   ├── continuation/{mod.rs,kani.rs,props.rs,tests.rs}
 │   ├── diagnostics.rs
-│   ├── driver.rs
-│   ├── facts.rs
-│   ├── rewrite/{mod.rs,props.rs,tests.rs}
+│   ├── driver/{mod.rs,depth.rs,facts.rs,span.rs,tests.rs}
 │   ├── lib_ui_tests.rs
-│   └── tests/{mod.rs,behaviour.rs,ui.rs}
-├── tests/features/string_continuation_style.feature
-├── ui/            ui-cy/            ui-gd/            ui-fallback/
+│   └── tests/{mod.rs,ui.rs}
+├── ui/    ui-cy/    ui-gd/    ui-fallback/
 ```
 
-The `crates/*` glob in the workspace `members` list picks the directory up
-automatically. Verify:
+`src/driver/tests.rs` is not optional: without in-process driver tests the
+adapter reports zero per cent under `make coverage`, which runs on every pull
+request against changed lines. Three crates already solve this the same way.
+
+Verify:
 
 ```plaintext
-$ cargo check -p string_continuation_style
+$ cargo check -p whitaker_string_literals
     Finished `dev` profile
 $ cargo check -p string_continuation_style --features dylint-driver
     Finished `dev` profile
 ```
 
-Commit: `Scaffold the string_continuation_style lint crate`.
+Commit: `Scaffold the string-literal domain and lint crates`.
 
 ### Step 3 — EP-M1, red first
 
-Write `crates/string_continuation_style/src/continuation/tests.rs` with the
+Write `crates/whitaker_string_literals/src/continuation/tests.rs` with the
 `INV-SCAN-1` boundary cases before writing the scanner. Confirm the red:
 
 ```plaintext
-$ cargo nextest run -p string_continuation_style continuation::
+$ cargo nextest run -p whitaker_string_literals continuation::
 error[E0433]: failed to resolve: use of undeclared crate or module `continuation`
 ```
 
 Then implement, and confirm green. Repeat for `classification` and `rewrite`.
+
 Add the Kani harness and the Verus proof in the same commits as the code they
-constrain. Run each negative control once, record the observed failure in
-§Artefacts and notes, then revert it.
+constrain, together with their runner edits:
 
-### Step 4 — EP-M2 through EP-M4
+- `scripts/run-kani.sh`: a new `run_string_literal_harnesses()` with an
+  explicit harness-name list and
+  `--manifest-path "${REPO_ROOT}/crates/whitaker_string_literals/Cargo.toml"`,
+  a new `string-literals)` case arm, **and** a call in the no-argument path at
+  lines 83-87 so `make kani` picks it up. Note the existing catch-all `*)`
+  arm falls through to `run_decomposition_harnesses`, which would `cd common`
+  and silently match nothing — an unknown group does not error.
+- `Makefile`: a `kani-string-literals` target beside `kani-clone-detector`,
+  and a `verus-string-literals` target beside `verus-clone-detector`.
+- `scripts/run-verus.sh`: three edits — the new group arm in
+  `proof_files_for_group`, the addition to the `all` arm, and the new case in
+  the `all|decomposition|clone-detector)` dispatch.
 
-For each UI fixture: write the `.rs` file first, run the UI test, inspect the
-produced diff, and only then create the `.stderr` from the observed output.
-`dylint_testing` layers on `trybuild`, so the blessing mechanism is
-`TRYBUILD=overwrite`; confirm this on the first fixture before relying on it,
-and if it does not apply, transcribe the diff by hand rather than guessing.
+Run each pure negative control once, record the observed failure in §Artefacts
+and notes, then revert it.
+
+### Step 4 — EP-M2 and EP-M3 fixtures
+
+For each `fail_*` fixture: write the `.rs` file, add `// run-rustfix` as the
+first line, write the `.fixed` file by hand with a
+`const _: () = assert!(...)` value assertion, run the UI test, and create the
+`.stderr` from the observed output.
+
+**Blessing is manual.** `dylint_testing` gives `compiletest_rs` a default
+config with `bless: false` and exposes no override; `TRYBUILD=overwrite` does
+nothing. The report prints a line of the form `Actual stderr saved to PATH`;
+copy that file over your `.stderr`. Read it first. A blessed-but-wrong
+expectation is worse than a failing test, and the toolchain-bump scenario is
+exactly where that discipline fails under time pressure — which is why
+`EP-M3`'s `insta` snapshot exists as a second, independently blessable
+artefact.
 
 ```bash
-TRYBUILD=overwrite cargo nextest run -p string_continuation_style ui 2>&1 \
+cargo nextest run -p string_continuation_style ui 2>&1 \
   | tee "/tmp/ui-whitaker-$(git branch --show-current).out"
 ```
 
-Never bless a `.stderr` without reading it. A blessed-but-wrong expectation is
-worse than a failing test.
+For each `pass_*` fixture, run its paired gate-inversion control once, record
+the failure, and revert.
 
-### Step 5 — EP-M5 integration
+### Step 5 — integration
 
 Edit, in this order:
 
@@ -1250,30 +1616,68 @@ Edit, in this order:
    `dylint-driver` feature and the path dependency with
    `features = ["dylint-driver", "constituent"]`.
 2. `suite/src/lints.rs` — append to `SUITE_LINTS` and `SUITE_LINT_DECLS` at the
-   same index, and extend the doctest's expected name list.
-3. `suite/src/driver.rs` — insert the `store.register_early_pass(...)` call
-   into `register_suite_lints`, between `register_lints` and
-   `register_late_pass`. Update the doctest's `get_lints().len()` from 9 to 10.
+   same index; extend the doctest's expected name list. Give `LintDescriptor`
+   a `pass: PassKind { Early, Late }` field so the early-pass assertion in
+   step 4 below derives from the same source rather than from a literal.
+3. `suite/src/driver.rs` — insert `store.register_early_pass(...)` into
+   `register_suite_lints`, between `register_lints` and `register_late_pass`.
+   Update the doctest's `get_lints().len()` from 9 to 10.
 4. `suite/tests/features/suite_registration.feature` and
-   `suite/tests/registration.rs` — add the early-pass count scenario and step.
+   `suite/tests/registration.rs` — add a scenario and a
+   `then_early_pass_registered` step asserting which pass is registered.
 5. `installer/src/resolution.rs` — add `"string_continuation_style"` to
    `LINT_CRATES`.
 6. `Makefile` — add `string_continuation_style` to the `LINT_CRATES` variable.
-7. `common/locales/{en-GB,cy,gd}/string_continuation_style.ftl` — the message,
-   `.note`, `.help`, and `.label` entries.
-8. `README.md` — the lint table row, and the "ships nine standard lints" count.
-9. `docs/users-guide.md` — a `### string_continuation_style` subsection under
-   §Available Lints covering what fires, what does not, and why.
-10. `docs/developers-guide.md` — a short section on writing early passes in this
-    repository: the `EarlyContext` limitations from `SURP-006`, the
-    `is_source_literal` guarantee from `SURP-001`, and the locale-serialization
-    requirement.
-11. `docs/whitaker-dylint-suite-design.md` — an addendum documenting early-pass
-    registration in the suite.
-12. `docs/rfcs/0002-string-continuation-style.md` — amendments for `SURP-001`,
-    `SURP-002`, `SURP-003`, `SURP-007`, and `SURP-010`; move status from
-    *Proposed* to *Accepted*.
-13. `docs/roadmap.md` — tick item 2.2.10.
+7. `.config/nextest.toml` — confirm the new crate's UI test matches the
+   `serial-dylint-ui` filter (the `src/tests/ui.rs` layout yields
+   `tests::ui::ui`, which the `test(tests::ui::)` clause catches) and add a
+   crate-specific `slow-timeout` override. Record
+   `cargo nextest show-config test-groups --profile ci` as evidence.
+8. `.github/workflows/ci.yml` — add the `proofs` job of `DEC-011`.
+9. `common/src/i18n/helpers.rs` and `common/src/i18n/diagnostics.rs` — add
+   `safe_resolve_label` and `normalize_fluent_output` per `DEC-012`; migrate
+   `bumpy_road_function`.
+10. `common/tests/i18n_quality/suite.rs` — generalize
+    `localized_help_attributes_are_complete`, which today checks only `.help`,
+    to assert that every attribute present on an en-GB message is present and
+    non-empty in every secondary locale. Without this, a missing `.label`
+    translation renders English, gets blessed into a `ui-cy` golden, and the
+    fixture then enforces the bug. This retroactively protects
+    `bumpy_road_function` too.
+11. `common/locales/{en-GB,cy,gd}/string_continuation_style.ftl` — the message,
+    `.note`, `.help`, and `.label`. Decide the `.label` argument shape now:
+    adding a `{ $ordinal }` placeable later is a breaking change to three
+    Fluent files, the placeable-parity test, and every golden at once. Put a
+    one-line comment at the head of each file naming the dependent fixture
+    directories.
+12. `README.md` — the lint table row and the "ships nine standard lints" count.
+13. `docs/users-guide.md` — a `### string_continuation_style` subsection
+    covering what fires, what does not, the `DEC-013` configuration table, and
+    `RUST_LOG=string_continuation_style=debug` for asking the lint why.
+14. `docs/developers-guide.md` — a section on writing early passes here
+    (`EarlyContext` has no `TyCtxt`; the `is_source_literal` guarantee; the
+    wrapper-depth pattern and why `is_root()` is insufficient; locale
+    serialization), **and** an addition to the toolchain-bump runbook naming
+    this crate: which `rustc_ast` items are load-bearing
+    (`FormatArgs::{span, is_source_literal, uncooked_fmt_str}`,
+    `FormatArgumentKind::Captured`), that the `EP-M0a` probe must be re-run and
+    `EV-M0-transcript` re-recorded on every bump, and that a change in
+    `is_source_literal` semantics silently converts firing cases into silence —
+    the failure direction no test catches.
+15. `docs/whitaker-dylint-suite-design.md` — an addendum on early-pass
+    registration.
+16. `docs/adr-005-early-lint-pass-position-proof.md` — a new Architectural
+    Decision Record for `DEC-002`, written in the Y-Statement form of the
+    existing ADRs. This is the repository's first `EarlyLintPass`, the decision
+    weighs four architectures, it is hard to reverse because every later early
+    pass inherits it, and `AGENTS.md` requires an ADR for substantive
+    decisions. Reference it from `docs/whitaker-dylint-suite-design.md`.
+17. `docs/contents.md` — index the new ADR; it lists all four existing ones.
+18. `docs/repository-layout.md` — note the new pure-domain crate.
+19. `docs/rfcs/0002-string-continuation-style.md` — the substantive revision
+    described in §Outcomes & retrospective; move status to *Accepted*.
+20. `docs/roadmap.md` — tick item 2.2.10, and add 2.2.11 if `DEC-009` is
+    approved.
 
 Then:
 
@@ -1286,8 +1690,8 @@ string_continuation_style
 
 ## Validation and acceptance
 
-Run all four gates after every milestone, sequentially, never in parallel — the
-build cache makes sequential runs faster overall:
+Run all four gates after every milestone, sequentially — the build cache makes
+sequential runs faster overall:
 
 ```bash
 make check-fmt 2>&1 | tee "/tmp/check-fmt-whitaker-$(git branch --show-current).out"
@@ -1296,203 +1700,262 @@ make lint      2>&1 | tee "/tmp/lint-whitaker-$(git branch --show-current).out"
 make test      2>&1 | tee "/tmp/test-whitaker-$(git branch --show-current).out"
 ```
 
-Delegate full gate runs to the `scrutineer` subagent, which runs them
-sequentially, captures each to a log, and returns a bounded report. When it
-reports a failure, read the cited log rather than re-running the gate.
+Delegate full gate runs to the `scrutineer` subagent. When it reports a
+failure, read the cited log rather than re-running the gate.
 
-Red-Green-Refactor evidence to record for each domain module:
+Red-Green-Refactor evidence per domain module:
 
-- **Red.** `cargo nextest run -p string_continuation_style <module>::` fails
+- **Red.** `cargo nextest run -p whitaker_string_literals <module>::` fails
   with an unresolved-item or assertion error naming the missing behaviour.
 - **Green.** The same command passes after the minimal implementation.
 - **Refactor.** The same command, then the four gates, all pass after cleanup.
 
 Behaviour-driven evidence:
 
-- **Red.** `cargo nextest run -p string_continuation_style behaviour` fails
+- **Red.** `cargo nextest run -p whitaker_string_literals behaviour` fails
   because the step definitions are unimplemented.
-- **Green.** The same command passes; each scenario in
-  `tests/features/string_continuation_style.feature` maps to one `#[scenario]`.
+- **Green.** The same command passes; each scenario maps to one `#[scenario]`.
 
 Verification evidence:
 
-- `scripts/run-kani.sh string-continuation` reports both harnesses
-  `VERIFICATION:- SUCCESSFUL`, with the explored unwind bound recorded.
+- `scripts/run-kani.sh string-literals` reports `VERIFICATION:- SUCCESSFUL`,
+  with the explored bound recorded and the excluded alphabet stated.
 - `make verus` reports `verification results:: N verified, 0 errors` for
   `verus/string_continuation_rewrite.rs`.
-- Every `NV-*` negative control has been run and its failure transcript
-  recorded in §Artefacts and notes.
+- Every `NV-*` control has been run and its failure transcript recorded.
 
 Quality criteria — what "done" means:
 
-- **Tests.** `make test` passes with the whole workspace green, including the
-  new crate's unit, property, behavioural, snapshot, and UI suites in four
-  locales.
-- **Verification.** `INV-SCAN-1`, `INV-SCAN-2`, `INV-SCAN-3`, `INV-CLASS-1`,
-  `LEM-REWRITE-1`, `LEM-REWRITE-2`, and `LEM-APPLY-1` are all discharged by the
-  named artefacts, with non-vacuity controls observed.
-- **Lint and typecheck.** `make check-fmt`, `make typecheck`, and `make lint`
-  all exit zero. Whitaker lints itself clean, including `module_max_lines`.
+- **Tests.** `make test` passes with the whole workspace green.
+- **Verification.** All pure and adapter obligations discharged by their named
+  artefacts, with non-vacuity controls observed.
+- **Fixer.** Every `fail_*` fixture applies, recompiles, and produces no
+  residual diagnostics under `// run-rustfix`.
+- **Lint and typecheck.** `make check-fmt`, `make typecheck`, `make lint` exit
+  zero. Whitaker lints the new pure crate clean, `module_max_lines` included.
 - **Documentation.** `make markdownlint` and `make nixie` pass.
-- **Performance.** No benchmark threshold. The scanner is linear in literal
-  length and runs once per string literal; if `make test` wall-clock grows by
-  more than 10 per cent, investigate before closing the plan.
-- **Security.** None applicable; this lint reads source and emits diagnostics.
+- **Performance.** `EV-M2-cost` recorded; `make test` within the `Tolerances`
+  growth budget relative to `EV-BASELINE`.
+- **Security.** None applicable.
 
-Quality method:
-
-- `scrutineer` runs the gates and reports.
-- Request a CodeRabbit review via `scrutineer` before marking the plan complete,
-  and action every finding.
+Quality method: `scrutineer` runs the gates; request a CodeRabbit review
+through it before marking the plan complete, and action every finding.
 
 ## Idempotence and recovery
 
-Every step is re-runnable. `cargo` builds are incremental and safe to repeat.
-UI-fixture blessing overwrites `.stderr` files in place, so review the diff
-before committing; if a blessing goes wrong, `git checkout -- crates/string_continuation_style/ui/`
+Every step is re-runnable. UI-fixture blessing overwrites `.stderr` files in
+place, so review the diff before committing; `git checkout -- crates/…/ui/`
 restores the committed expectations.
 
-Commit after each milestone, and after each of the numbered edits in Step 5, so
-that `git bisect` and time-travel review both work. Nothing in this plan writes
-outside the repository except log files under `/tmp`, which are disposable.
+Commit after each milestone and after each numbered edit in Step 5, so that
+`git bisect` and time-travel review both work. Nothing writes outside the
+repository except disposable log files under `/tmp`.
 
-If a milestone must be abandoned mid-flight, each milestone's Recovery entry
-names the single revert that returns the tree to the previous plateau.
+Each milestone's Recovery entry names the single revert that returns the tree
+to the previous plateau.
 
 ## Artefacts and notes
 
 To be filled in as work proceeds. Required entries:
 
-- `EV-M0-transcript` — the `EP-M0` spike output.
-- The observed failure of each `NV-*` negative control.
+- `EV-BASELINE` — `make test` wall-clock before Step 1.
+- `EV-M0-transcript` — the `EP-M0a` probe output, with a per-axiom statement.
+- The observed failure of each `NV-*` control, including one per silence
+  fixture.
+- `EV-M2-cost` — `cargo dylint` timing over one medium crate, before and after.
 - The `insta` snapshot of the RFC's motivating-example rewrite.
-- The `make publish-check` tail showing `string_continuation_style` in
-  `cargo dylint list`.
+- `cargo nextest show-config test-groups --profile ci` output.
+- The `make publish-check` tail showing the lint in `cargo dylint list`.
 
 ## Interfaces and dependencies
 
-### Domain (pure; no `rustc_*` imports)
+### Domain — `crates/whitaker_string_literals` (no rustc imports)
 
-In `crates/string_continuation_style/src/facts.rs`, the input port — everything
-the policy needs to know about a literal, with no compiler types:
+The types make illegal states unrepresentable rather than relying on tests to
+notice them. Note in particular that the offset origin is stated once, in the
+`LiteralBody` doc comment, and never re-derived.
+
+In `src/facts.rs`:
 
 ```rust
-/// What the adapter observed about one string literal.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct LiteralFacts<'a> {
-    /// Raw source bytes between the quotes, exactly as written.
-    pub body: &'a str,
-    /// Which flavour of literal token this is.
-    pub token: LiteralToken,
-    /// Where the literal sits, and what the surrounding grammar permits.
-    pub context: LiteralContext,
+/// The raw source bytes of a cooked literal, quotes excluded.
+///
+/// Every offset produced by this module is relative to the start of this
+/// slice, never to the enclosing literal token. The adapter converts.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LiteralBody<'a>(&'a str);
+
+/// A byte offset into a [`LiteralBody`].
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct BodyOffset(usize);
+
+/// What the adapter observed about one literal.
+///
+/// Raw, byte, and C literals are excluded by construction: the scanner is
+/// only reachable through the `Cooked` variant.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LiteralFacts<'a> {
+    Cooked { body: LiteralBody<'a>, context: LiteralContext },
+    /// `b"..."` or `c"..."`. Carries no body; nothing to scan.
+    NonStringLiteral,
+    /// `r"..."`, `br"..."`, `cr"..."`. Continuations are not interpreted.
+    Raw,
 }
 
+/// The grammatical position of a cooked literal. Adapter capability is not
+/// modelled here: when the adapter cannot do its job it declines by
+/// returning `None` rather than encoding its own failure as a context.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum LiteralToken {
-    CookedStr,
-    RawStr,
-    ByteStr,
-    RawByteStr,
-    CStr,
-    RawCStr,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum LiteralContext {
-    /// A general expression position in root syntax context.
+pub enum LiteralContext {
     Expression,
-    /// A source-authored format string in a proven macro contract.
-    SourceFormatString { has_implicit_capture: bool },
-    /// A format string produced by `concat!`, `include_str!`, or similar.
+    SourceFormatString { capture: CaptureStatus },
     GeneratedFormatString,
-    /// The macro contract, format-string position, or span could not be proven.
-    UnprovenContract,
-    /// The editable source span could not be recovered exactly.
-    UnrecoverableSpan,
 }
+
+/// Whether any format argument was implicitly captured. Not a `bool`: this
+/// is the one bit separating "emit a machine-applicable fix" from "emit
+/// nothing", and it is computed by the adapter from
+/// `FormatArgumentKind::Captured`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CaptureStatus { NoneObserved, Present }
 ```
 
-In `crates/string_continuation_style/src/continuation/mod.rs`:
+In `src/continuation/mod.rs`:
 
 ```rust
-pub(crate) struct Continuation {
-    pub escape_range: core::ops::Range<usize>,
-    pub skipped_whitespace_range: core::ops::Range<usize>,
+pub struct Continuation {
+    pub escape_range: core::ops::Range<BodyOffset>,
+    pub skipped_whitespace_range: core::ops::Range<BodyOffset>,
     pub kind: ContinuationKind,
 }
 
-pub(crate) enum ContinuationKind { Join, LeadingLayoutTrim, TrailingLayoutTrim }
+pub enum ContinuationKind { Join, LeadingLayoutTrim, TrailingLayoutTrim }
 
-/// Scans a cooked literal body for continuation escapes.
-///
-/// The caller must pass the body without its delimiting quotes.
-pub(crate) fn scan(body: &str) -> Vec<Continuation>;
+impl<'a> LiteralBody<'a> {
+    /// Scans for continuation escapes. Total: never panics, never slices.
+    pub fn scan(self) -> Vec<Continuation>;
+}
 ```
 
-In `crates/string_continuation_style/src/classification/mod.rs`:
+In `src/classification/mod.rs`:
 
 ```rust
-pub(crate) enum ContinuationDisposition {
-    PreferConcat(ConcatRewrite),
+pub enum ContinuationDisposition<'a> {
+    /// A proven rewrite. Construction of `ConcatRewrite` is the proof.
+    PreferConcat(ConcatRewrite<'a>),
     RequireContinuation(RequiredReason),
     Ignore,
 }
 
-pub(crate) enum RequiredReason {
+/// Only reasons the decision matrix can actually produce. RFC-0002's
+/// `GeneratedFormatString` and `UnrecoverableSourceSpan` variants are absent:
+/// the matrix routes both to `Ignore`, so as `RequireContinuation` variants
+/// they were unreachable, and two encodings of one outcome cannot be
+/// distinguished end to end because both produce silence.
+pub enum RequiredReason {
     ImplicitFormatCapture,
     NonStringLiteralType,
     LeadingOrTrailingLayoutTrim,
-    UnknownMacroContract,
-    GeneratedFormatString,
-    UnrecoverableSourceSpan,
+    GeneratedSourceFile,
 }
 
 /// The single policy entry point. Pure: same facts in, same disposition out.
-pub(crate) fn classify(facts: &LiteralFacts<'_>) -> ContinuationDisposition;
+pub fn classify<'a>(facts: &LiteralFacts<'a>) -> ContinuationDisposition<'a>;
 ```
 
-In `crates/string_continuation_style/src/rewrite/mod.rs`:
+In `src/rewrite/mod.rs`:
 
 ```rust
-pub(crate) struct ConcatRewrite {
-    /// Source spellings of each fragment, in order, quotes excluded.
-    pub fragments: Vec<core::ops::Range<usize>>,
-    /// Byte offsets of each selected join's backslash, for secondary labels.
-    pub join_offsets: Vec<usize>,
-    pub applicability: RewriteApplicability,
+/// A rewrite that has passed the applicability gate.
+///
+/// Fields are private and there is exactly one constructor, so
+/// `fragments.len() == join_offsets.len() + 1` holds by construction rather
+/// than by assertion, and the lifetime ties the fragments to the body they
+/// came from so they cannot be rendered against a different literal.
+pub struct ConcatRewrite<'a> {
+    fragments: Vec<&'a str>,
+    join_offsets: Vec<BodyOffset>,
 }
 
-pub(crate) enum RewriteApplicability { MachineApplicable, MaybeIncorrect }
+impl<'a> ConcatRewrite<'a> {
+    /// The only constructor. `None` when the applicability gate fails.
+    pub fn build(body: LiteralBody<'a>, joins: &[Continuation]) -> Option<Self>;
 
-/// Builds the replacement text for a whole literal.
-pub(crate) fn render(body: &str, rewrite: &ConcatRewrite) -> String;
+    pub fn fragments(&self) -> &[&'a str];
+    /// Byte offsets of each selected join's backslash, for secondary labels.
+    pub fn join_offsets(&self) -> &[BodyOffset];
+
+    /// Renders the replacement text at the given source indentation.
+    pub fn render(&self, indent: usize, newline: Newline) -> String;
+}
+
+/// The line ending to emit in a multi-line replacement. Detected by the
+/// adapter from the source file's dominant ending; emitting LF into a CRLF
+/// checkout produces mixed endings inside the hunk.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Newline { Lf, CrLf }
 ```
 
-### Adapters (rustc-facing; `dylint-driver` feature only)
+There is deliberately no `RewriteApplicability` enum. The domain never
+produces anything but a proven rewrite, so a two-variant enum with one
+reachable variant would carry no information; `DEC-013`'s configuration decides
+the rustc `Applicability` at the single `span_suggestion` call site.
 
-`crates/string_continuation_style/src/driver.rs` holds the `EarlyLintPass`
-implementation, the `LiteralFacts` construction from `ExprKind::Lit` and
-`ExprKind::FormatArgs`, the macro-identity allowlist, and the lint declaration
-inside a private `declaration` module per the `conditional_max_n_branches`
-pattern. It must stay under 400 lines; split the allowlist into
-`src/driver/allowlist.rs` if it grows.
+`render` takes an indentation because a replacement that ignores the original
+literal's column breaks `cargo fmt --check` after every fix run — which, for a
+rollout plan whose step three is "apply machine fixes across repositories",
+means every fixed repository needs a follow-up formatting commit. Prefer a
+single-line `concat!("alpha ", "beta")` when it fits within the formatter's
+width, and fall back to the indented multi-line form otherwise.
 
-`crates/string_continuation_style/src/diagnostics.rs` converts a
-`ContinuationDisposition` plus the recovered spans into a localized
-`cx.emit_span_lint` call, following
-`crates/bumpy_road_function/src/driver/diagnostic.rs`.
+### Adapter — `crates/string_continuation_style` (`dylint-driver` only)
+
+- `src/driver/mod.rs` — the `EarlyLintPass`, config and localizer lifecycle
+  (`check_crate`, per `DEC-016`), and dispatch. The lint declaration lives in a
+  private `declaration` module per the `conditional_max_n_branches` pattern.
+- `src/driver/depth.rs` — the wrapper-depth counter of `DEC-002`, the built-in
+  name set, and the crate-scoped shadow kill switch.
+- `src/driver/facts.rs` — construction of `LiteralFacts` from `ExprKind::Lit`
+  and `ExprKind::FormatArgs`, under `DEC-015`'s cheap-first ordering.
+- `src/driver/span.rs` — the sole owner of the offset conversion:
+
+  ```rust
+  /// Byte offset relative to a literal token, quotes included.
+  struct TokenOffset(u32);
+
+  /// The only place body-relative offsets become token-relative. `prefix_len`
+  /// is 1 for `"…"`; the `b"…"`/`c"…"` cases never reach here because
+  /// `LiteralFacts::NonStringLiteral` excludes them.
+  fn to_token(offset: BodyOffset, prefix_len: u32) -> Option<TokenOffset>;
+
+  /// Maps a body offset range onto a source span. Returns `None` on any
+  /// arithmetic failure, which the caller maps to silence.
+  fn body_span(token: Span, range: Range<BodyOffset>) -> Option<Span>;
+  ```
+
+- `src/diagnostics.rs` — converts a disposition plus recovered spans into a
+  localized `cx.emit_span_lint` call, and runs `LEM-EMIT-1`'s value check
+  before attaching any applicability. Emits
+  `debug!(target: LINT_NAME, ...)` at two points: the classification boundary,
+  recording the disposition and any `RequiredReason`, and the applicability
+  gate, recording which condition withheld the suggestion. Those two lines turn
+  every "why didn't it fire" report into self-service through
+  `RUST_LOG=string_continuation_style=debug`.
 
 ### Dependencies
 
-The crate's `Cargo.toml` declares, all `optional = true` under `dylint-driver`:
-`dylint_linting`, `rustc_ast`, `rustc_lint`, `rustc_session`, `rustc_span`,
-`fluent-templates`, `log`, `serde`, `whitaker-common`, `whitaker` (with
-`features = ["dylint-driver"]`). If `DEC-002` resolves to option 3, add
-`rustc_hir` and `rustc_middle`. Do not add `clippy_utils`; no lint in this
-repository uses it.
+`crates/whitaker_string_literals`: `rustc_lexer` (workspace). Nothing else.
+Dev-dependencies: `rstest`, `rstest-bdd`, `rstest-bdd-macros`, `proptest`,
+`insta`, `googletest`, `pretty_assertions`, `whitaker_test_macros`.
 
+`crates/string_continuation_style`, all `optional = true` under
+`dylint-driver`: `dylint_linting`, `rustc_ast`, `rustc_lint`, `rustc_session`,
+`rustc_span`, `fluent-templates`, `log`, `serde`, `whitaker-common`,
+`whitaker` (with `features = ["dylint-driver"]`), and
+`whitaker_string_literals`. Do not add `clippy_utils`; no lint here uses it.
 Dev-dependencies: `whitaker_test_macros`, `whitaker-common`, `whitaker`,
-`rstest`, `rstest-bdd`, `rstest-bdd-macros`, `dylint_testing`, `proptest`,
-`insta`, `googletest`, `pretty_assertions`, `serial_test`, `camino`,
-`tempfile`, and — subject to `DEC-007` — `rustc-literal-escaper`.
+`rstest`, `dylint_testing`, `googletest`, `pretty_assertions`, `serial_test`,
+`camino`, `tempfile`.
+
+Both crates set `[lints] workspace = true` and additionally deny
+`arithmetic_side_effects`.

--- a/docs/execplans/2-2-10-string-continuation-style-post-expansion-early-lint.md
+++ b/docs/execplans/2-2-10-string-continuation-style-post-expansion-early-lint.md
@@ -1,0 +1,1496 @@
+# Implement `string_continuation_style` as a post-expansion early lint
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & discoveries`,
+`Decision log`, `Outcomes & retrospective`, `Conformance basis`, and
+`Verification plan` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Whitaker's house style says a long string literal should be spelled with
+`concat!()` rather than an escaped newline continuation. Reviewers keep
+applying that rule by hand, and they keep getting it wrong: some
+continuations cannot be replaced without changing what the program does.
+
+After this change, a Rust author who writes
+
+```rust
+let text = "alpha \
+            beta";
+```
+
+and runs `cargo whitaker` (or `cargo dylint --lib string_continuation_style`)
+sees a warning offering a machine-applicable fix that rewrites the expression
+to `concat!("alpha ", "beta")`, byte-for-byte equivalent at runtime. The same
+author who writes
+
+```rust
+let header = format!(
+    "HTTP/1.1 {status_line}\r\nContent-Length: {}\r\n\
+     Content-Type: application/octet-stream\r\n\r\n",
+    body.len(),
+);
+```
+
+sees **nothing**, because `format!(concat!(...))` cannot implicitly capture
+`status_line` and the rewrite would not compile. The lint is deliberately
+asymmetric: it fires only when the replacement is proven safe.
+
+Observable success:
+
+1. `cargo test -p string_continuation_style` passes, including a UI matrix
+   that pins both the firing and non-firing cases.
+2. The suite library reports the new lint:
+   `cargo dylint list` includes `string_continuation_style`.
+3. `docs/users-guide.md` documents the rule and its exemptions.
+4. Running the lint over Whitaker itself produces no findings on the
+   pull-request-296 fixture reproduced in `crates/string_continuation_style/ui/`.
+
+## Constraints
+
+Hard invariants. Violating one requires escalation, not a workaround.
+
+- **Evaluated-value preservation.** A suggested rewrite must produce a string
+  whose evaluated bytes are identical to the original literal's. There is no
+  acceptable margin here.
+- **Near-zero false positives.** When the lint cannot prove safety it must be
+  silent. It must never emit an unfixable style complaint. Prefer
+  `Ignore`/`RequireContinuation` over a speculative diagnostic.
+- **No macro-argument surgery.** The lint must not add explicit format
+  arguments (`status_line = status_line`) to unlock a rewrite. See RFC 0002
+  §Non-goals.
+- **Module size.** No source file added by this work may exceed 400 lines
+  (`AGENTS.md` §Code style, enforced by Whitaker's own `module_max_lines`).
+- **British English.** Comments and documentation use en-GB-oxendict spelling
+  (`AGENTS.md`), except where quoting an external API.
+- **Domain purity.** The pure classification, scanning, and rewrite-construction
+  logic must not import `rustc_*` types. It must be unit-testable without a
+  compiler session. See §Interfaces and dependencies.
+- **No changes to existing lints' behaviour.** This plan adds a lint; it must
+  not alter the diagnostics of the nine existing standard lints.
+- **Suite structure.** Do not force an early pass into
+  `rustc_lint::late_lint_methods!`/`declare_combined_late_lint_pass!`. Register
+  it separately (RFC 0002 §Suite integration).
+- **Toolchain.** `rust-toolchain.toml` pins `nightly-2026-05-28`. Do not bump it.
+
+## Tolerances (exception triggers)
+
+- **Scope.** If implementation requires touching more than 45 files, or more
+  than 3500 net lines outside `crates/string_continuation_style/`, stop and
+  escalate.
+- **Dependencies.** Three dependency additions are pre-authorized (see
+  `DEC-006`): `googletest`, `pretty_assertions`, and promoting `serial_test`
+  into `[workspace.dependencies]`. A fourth (`rustc-literal-escaper`, see
+  `DEC-007`) is proposed but **requires approval before use**. Any dependency
+  beyond these four: stop and escalate.
+- **Public interface.** If `whitaker-common`'s public API must change in a way
+  that is not purely additive, stop and escalate.
+- **Architecture.** If milestone `EP-M0` concludes that a pure early pass
+  cannot soundly prove macro identity for the `log`/`tracing` families, stop at
+  the `EP-M0` go/no-go and present the options in `DEC-002` before continuing.
+- **Iterations.** If a UI fixture's `.stderr` cannot be made stable after 4
+  attempts, stop and escalate; unstable diagnostic output usually means the
+  span recovery is wrong, not that the fixture needs another nudge.
+- **Verification.** If a planned Verus lemma or Kani harness cannot be
+  discharged after 6 hours of work on that single obligation, stop and
+  escalate with the current proof state rather than weakening the obligation.
+- **Ambiguity.** If a decision materially changes which source shapes the lint
+  fires on, stop and present options with trade-offs.
+
+## Risks
+
+- **Risk: macro identity cannot be proven from an `EarlyContext`.**
+  Severity: high. Likelihood: high.
+  `rustc_lint::EarlyContext` exposes only `sess()`; it has no `TyCtxt`, so
+  `DefId → crate name / definition path` resolution is not directly available.
+  RFC 0002 §Detection architecture requires "resolved definition identifier,
+  defining crate, and canonical definition path" to match an allowlist entry.
+  Mitigation: `EP-M0` spike determines empirically what `ExpnData` yields;
+  `DEC-002` records the three candidate architectures and the decision.
+
+- **Risk: duplicate diagnostics from facade macros.**
+  Severity: medium. Likelihood: medium.
+  `tracing` with the `log` feature can emit the message through two paths, and
+  each may lower to its own `ExprKind::FormatArgs` node carrying the same
+  source literal span. Mitigation: deduplicate emitted diagnostics by the
+  recovered literal span within one pass instance; assert this with a UI
+  fixture that enables `tracing/log`.
+
+- **Risk: `concat!()` rewrite changes the type in a coercion site.**
+  Severity: medium. Likelihood: low.
+  `"a"` and `concat!("a", "b")` are both `&'static str`, so the type is
+  preserved, but a literal in a `const` pattern position or a `#[doc = "..."]`
+  meta item is not an expression. Mitigation: the lint visits `check_expr`
+  only, never patterns, attributes, or meta items (RFC 0002 §AST entry points).
+  A UI fixture pins that a literal in a pattern is untouched.
+
+- **Risk: suggestion applies incorrectly under `cargo fix`.**
+  Severity: medium. Likelihood: low.
+  A machine-applicable suggestion whose span is off by one quote character
+  silently corrupts source. Mitigation: the applicability gate in
+  `EP-M2`/`EP-M3` requires the recovered snippet to re-lex as exactly one
+  cooked string token *and* the generated replacement to re-lex as exactly one
+  `concat!` expression, before `MachineApplicable` is used. Non-vacuity control
+  `NV-REWRITE-1` seeds a deliberate off-by-one and requires the check to reject
+  it.
+
+- **Risk: no existing lint in this repository emits a suggestion.**
+  Severity: low. Likelihood: high (it is already true).
+  Every current lint uses `cx.emit_span_lint(..., DiagDecorator(|lint| ...))`
+  with `primary_message`/`span_note`/`span_label`/`help` only. `span_suggestion`
+  exists on `rustc_errors::Diag` (verified, see `SURP-004`), but this lint will
+  be the first user. Mitigation: `EP-M2` lands the suggestion path first, on
+  the simplest possible case (a plain literal), so the mechanics are proven
+  before the format-string complexity arrives.
+
+- **Risk: `insta` snapshots of diagnostics duplicate the UI `.stderr` files.**
+  Severity: low. Likelihood: medium.
+  Mitigation: snapshots are used only for the *pure* rewrite output
+  (fragment lists and the generated `concat!()` text across locales and
+  multi-join shapes), not for rendered rustc diagnostics, which `.stderr`
+  fixtures already pin.
+
+- **Risk: Verus proof drifts from the production scanner.**
+  Severity: medium. Likelihood: medium.
+  Verus compiles its own files and mirrors production types
+  (`docs/developers-guide.md` §Verus scope and trust boundary; existing proofs
+  in `verus/` use `#[path = "../crates/..."]` includes where possible).
+  Mitigation: include the production `continuation` domain module by `#[path]`
+  where its dependencies allow, exactly as
+  `verus/clone_detector_candidate_pair.rs` includes `fragment_id.rs`; where a
+  spec mirror is unavoidable, state the trust boundary in the proof's module
+  doc comment.
+
+## Progress
+
+- [x] (2026-08-21) Branch `2-2-10-string-continuation-style-post-expansion-early-lint.md`
+      created from `harden-lint-config` and pushed with upstream tracking.
+- [x] (2026-08-21) Reconnaissance of crate template, suite integration, i18n,
+      and testing conventions completed; recorded in §Context and orientation.
+- [x] (2026-08-21) Compiler API assumptions in RFC 0002 verified against
+      `nightly-2026-05-28`; recorded in §Surprises & discoveries.
+- [x] (2026-08-21) ExecPlan drafted.
+- [ ] Plan approved by the user (required before any implementation).
+- [ ] EP-M0 spike: pass architecture go/no-go.
+- [ ] EP-M1 pure domain core.
+- [ ] EP-M2 plain cooked string literals.
+- [ ] EP-M3 source-authored format strings (compiler built-ins).
+- [ ] EP-M4 `log` and `tracing` facade allowlist.
+- [ ] EP-M5 suite, installer, and documentation integration.
+- [ ] Roadmap item 2.2.10 marked done.
+
+## Surprises & discoveries
+
+These were found while validating RFC 0002 against the pinned toolchain,
+before implementation started. They materially change parts of the RFC's
+prescribed approach.
+
+- **SURP-001: rustc already proves "the format string was written in source".**
+  Observation: `rustc_ast::FormatArgs::is_source_literal` is computed by
+  `rustc_parse_format::Parser::new`, which compares the recovered source
+  snippet against the parsed input and returns `false` when a proc macro has
+  respanned the literal (the fix for rust-lang/rust#114865).
+  Evidence: `compiler/rustc_parse_format/src/lib.rs:302-345` and
+  `compiler/rustc_builtin_macros/src/format.rs:290` in the
+  `nightly-2026-05-28` `rustc-src` component.
+  Impact: RFC 0002 §Format strings steps 3 and 4 ("recover an exact source
+  literal span", "reject spans attributable only to an external or proc-macro
+  expansion") are largely discharged by checking `is_source_literal`. The lint
+  still re-lexes the snippet as a belt-and-braces check, but this is now
+  defence in depth rather than the primary proof.
+
+- **SURP-002: `FormatArgs::span` is the format-string literal token span.**
+  Observation: `make_format_args` constructs `FormatArgs { span: fmt_span, .. }`
+  where `fmt_span` comes from `expr_to_spanned_string`, which returns
+  `span: expr.span` of the fully-expanded format-string expression — that is,
+  the literal token including its quotes when `is_source_literal` holds.
+  `Span::from_inner(InnerSpan)` maps a byte offset within that token to a
+  source span (`compiler/rustc_span/src/lib.rs:1256`).
+  Evidence: `compiler/rustc_builtin_macros/src/format.rs:170-181, 675-681`;
+  `compiler/rustc_builtin_macros/src/util.rs:61-101`.
+  Impact: per-continuation secondary labels and the whole-literal replacement
+  span come directly from `FormatArgs::span`, offset by one for the opening
+  quote. No bespoke span arithmetic over the enclosing macro call is needed.
+
+- **SURP-003: `uncooked_fmt_str` carries the raw source body and is *not*
+  newline-appended.**
+  Observation: `FormatArgs::uncooked_fmt_str: (token::LitKind, Symbol)`, where
+  the `Symbol` is `token_lit.symbol` — the raw, unescaped source text between
+  the quotes. `println!`-family macros append `\n` to the *cooked* symbol
+  (`fmt.symbol`) but leave `uncooked_symbol` untouched.
+  Evidence: `compiler/rustc_ast/src/format.rs:44-59`;
+  `compiler/rustc_builtin_macros/src/util.rs:61-101`;
+  `compiler/rustc_builtin_macros/src/format.rs:190-192`.
+  Impact: the scanner's input is `uncooked_fmt_str.1.as_str()` for format
+  strings and `token::Lit::symbol` for plain literals. The
+  `token::LitKind` discriminant (`Str` / `StrRaw(_)` / `ByteStr` / `CStr` /
+  `CStrRaw(_)`) is exactly the cooked-versus-raw and type discriminator RFC
+  0002 §Decision matrix needs.
+
+- **SURP-004: `EarlyContext` implements `LintContext`; `Diag::span_suggestion`
+  exists.**
+  Observation: `impl LintContext for EarlyContext<'_>`
+  (`compiler/rustc_lint/src/context.rs:619`) provides `sess()` and
+  `emit_span_lint`. `Diag::span_suggestion(sp, msg, suggestion, applicability)`
+  is available (`compiler/rustc_errors/src/diagnostic.rs:918`).
+  Impact: the diagnostic path mirrors `bumpy_road_function`'s
+  `cx.emit_span_lint(LINT, span, DiagDecorator(|lint| { ... }))`, adding
+  `lint.span_suggestion(...)`. Source text comes from
+  `cx.sess().source_map().span_to_snippet(span)`.
+
+- **SURP-005: `LintStore::register_early_pass` exists and takes a
+  `TyCtxt`-free factory.**
+  Observation:
+  `pub fn register_early_pass(&mut self, pass: impl Fn() -> EarlyLintPassObject + ...)`
+  (`compiler/rustc_lint/src/context.rs:168`), alongside the public
+  `early_passes` / `late_passes` fields.
+  Impact: RFC 0002 §Suite integration's snippet compiles as written. The suite's
+  existing behavioural assertion `then_late_pass_count` reads
+  `store.late_passes.len()` and is unaffected; a new assertion on
+  `store.early_passes.len()` is possible and should be added.
+
+- **SURP-006: `EarlyContext` has no `TyCtxt`, so macro identity is not directly
+  resolvable.**
+  Observation: `ExpnData` gives `kind: ExpnKind::Macro(MacroKind, Symbol)`,
+  `macro_def_id: Option<DefId>`, `def_site: Span`, `allow_internal_unstable`,
+  and `parent_module` (`compiler/rustc_span/src/hygiene.rs:969-1015`), but
+  turning a `DefId` into a crate name or definition path needs `TyCtxt`, which
+  `EarlyContext` does not hold.
+  Countervailing observation: early lints run inside a query —
+  `fn early_lint_checks(tcx: TyCtxt<'_>, (): ())`
+  (`compiler/rustc_interface/src/passes.rs:400`) — so a `TyCtxt` *does* exist
+  on the thread, reachable via `rustc_middle::ty::tls`.
+  Impact: this is the single largest open design question. See `DEC-002` and
+  milestone `EP-M0`.
+
+- **SURP-007: rustc normalizes CRLF out of source before lexing.**
+  Observation: `normalize_src` calls `normalize_newlines`
+  (`compiler/rustc_span/src/lib.rs:2510-2528`), so a `SourceFile`'s contents —
+  and therefore every literal `Symbol` and every `span_to_snippet` result —
+  contain LF only.
+  Impact: RFC 0002 §Continuation scanner's CRLF and lone-CR branches are
+  unreachable from the rustc adapter. Keep them in the *pure* scanner (they are
+  cheap, they make the domain module self-contained, and the domain tests
+  exercise them directly), but do not claim adapter-level coverage for them,
+  and do not write a UI fixture that pretends to.
+
+- **SURP-008: `googletest` and `pretty_assertions` are not yet dependencies.**
+  Observation: neither appears in any `Cargo.toml` in the workspace nor in
+  `[workspace.dependencies]`. Every existing test uses bare `assert_eq!`.
+  `serial_test` is used pervasively for locale UI tests but is pinned
+  per-crate, not in `[workspace.dependencies]`.
+  Impact: see `DEC-006`.
+
+- **SURP-009: `rustc-literal-escaper` is already in `Cargo.lock`.**
+  Observation: `rustc-literal-escaper 0.0.4` is present transitively (pulled in
+  by `ra_ap_syntax`). This is the crate rustc itself now uses for unescaping;
+  it is no longer vendored inside `rustc_lexer`.
+  Impact: it is the natural differential oracle for "the rewrite preserves the
+  evaluated value". See `DEC-007`.
+
+- **SURP-010: `log 0.4.33`'s facade macros capture `$($arg:tt)+`.**
+  Observation: `log::info!` matches `(logger: $logger:expr, target: $target:expr, $($arg:tt)+)`,
+  `(target: $target:expr, $($arg:tt)+)`, `(logger: $logger:expr, $($arg:tt)+)`,
+  and `($($arg:tt)+)`, forwarding to `log!` and then `__log!`; key-value fields
+  are separated from the message by `;`
+  (`~/.cargo/registry/src/*/log-0.4.33/src/macros.rs:75-115, 252-270`).
+  Impact: RFC 0002's `log` allowlist omits the newer `logger:` control. The
+  allowlist must either add it or explicitly reject invocations carrying it.
+  Because the captures are `tt`, a `concat!(...)` expression in the message
+  position is grammatically accepted — but the lint must still *prove* it is
+  looking at `log`'s macro, not a same-named local macro (`SURP-006`).
+
+## Decision log
+
+- **DEC-001: Implement as a post-expansion early lint, per RFC 0002.**
+  Rationale: pre-expansion cannot see `FormatArgumentKind::Captured`; late HIR
+  has lost the source spelling that distinguishes an escaped newline from an
+  equivalent evaluated string. RFC 0002 §Alternatives considered records both
+  rejections and this plan adopts them unchanged.
+  Date/Author: 2026-08-21, planning agent.
+
+- **DEC-002: Pass architecture for macro identity — OPEN, resolved at `EP-M0`.**
+  Context: `SURP-006`. Three candidates:
+  1. *Pure early pass, narrowed allowlist.* Prove identity only from
+     `ExpnData` (`macro_def_id.is_local()`, `def_site` file, `ExpnKind`
+     symbol, `allow_internal_unstable`). Cheapest; cannot satisfy RFC 0002's
+     "defining crate and canonical definition path" clause; would force
+     `log`/`tracing` out of the initial allowlist.
+  2. *Early pass reaching `TyCtxt` through `rustc_middle::ty::tls::with_opt`.*
+     Satisfies the RFC clause exactly, at the cost of a hidden global and a
+     `rustc_middle` dependency. Must degrade to "no diagnostic" when the
+     `TyCtxt` is absent.
+  3. *Early collector plus late emitter*, mirroring Clippy's
+     `FormatArgsStorage`: an `EarlyLintPass` records `FormatArgs` nodes keyed by
+     span into shared storage; a `LateLintPass` (which has `TyCtxt`) resolves
+     identity, handles plain literals from HIR, and emits every diagnostic.
+     Most faithful to the RFC and to established prior art; costs a hand-written
+     two-pass registration in the lint crate and in the suite.
+  Recommendation to the reviewer: option 3 if `EP-M0` shows that
+  `log`/`tracing` invocations reach the AST as `ExprKind::FormatArgs` with
+  `is_source_literal == true`; otherwise option 1 with `log`/`tracing` deferred.
+  Do not adopt option 2 without an explicit decision: reaching into thread-local
+  compiler state is exactly the kind of hidden coupling this repository's
+  hexagonal boundaries exist to prevent.
+  Date/Author: 2026-08-21, planning agent. **Requires user decision or `EP-M0`
+  evidence before `EP-M3` starts.**
+
+- **DEC-003: Hexagonal split — domain modules take no rustc types.**
+  The scanner (`continuation`), the policy (`classification`), and the
+  rewriter (`rewrite`) are pure over `&str` and `Range<usize>`. The rustc
+  adapter (`driver`) converts AST nodes into a `LiteralFacts` value and
+  converts a `ContinuationDisposition` back into spans. The diagnostic adapter
+  (`diagnostics`) converts a disposition into localized Fluent output.
+  Rationale: `hexagonal-architecture` skill §Domain purity, and the practical
+  benefit that the invariants worth proving (`INV-SCAN-*`, `LEM-REWRITE-1`) all
+  live in the pure half, where `proptest`, Kani, and Verus can reach them
+  without a compiler session.
+  Date/Author: 2026-08-21, planning agent.
+
+- **DEC-004: Keep CRLF handling in the pure scanner; do not claim adapter
+  coverage.**
+  Rationale: `SURP-007`. The pure scanner is a reusable byte-level component
+  with a documented contract; the contract should be complete. But a UI fixture
+  claiming to exercise CRLF would be theatre, since rustc normalizes it away.
+  The verification plan records this as an explicit reachability bound.
+  Date/Author: 2026-08-21, planning agent.
+
+- **DEC-005: One diagnostic per literal, with one whole-literal replacement.**
+  Rationale: RFC 0002 §Decision matrix, final row. Cascaded per-continuation
+  suggestions would conflict under `cargo fix`.
+  Date/Author: 2026-08-21, planning agent.
+
+- **DEC-006: Add `googletest` and `pretty_assertions` to
+  `[workspace.dependencies]`; promote `serial_test` there too.**
+  Rationale: the task brief explicitly authorizes `googletest` and
+  `pretty_assertions` and requires their use for clear test semantics; neither
+  is present today (`SURP-008`). `serial_test` is already used by three lint
+  crates with per-crate pins, and this crate needs it for locale UI tests, so
+  promoting it removes a version-skew hazard. This is additive and touches only
+  the workspace manifest and the new crate's manifest.
+  Date/Author: 2026-08-21, planning agent.
+
+- **DEC-007: Use `rustc-literal-escaper` as the value-preservation oracle —
+  PROPOSED, requires approval.**
+  Rationale: the central constraint is "the rewrite preserves the evaluated
+  bytes". A property test asserting that against a reference unescaper written
+  in the same pull request is weak — a shared misunderstanding of the escaping
+  rules passes both. `rustc-literal-escaper` is the crate rustc itself uses and
+  is already resolved in `Cargo.lock` (`SURP-009`), so this is a new direct
+  edge, not a new subtree.
+  Alternative if declined: write a spec-derived reference unescaper in the test
+  module from the Rust Reference §String literals, and add three
+  compile-and-run UI fixtures that `assert_eq!` the original literal against its
+  rewritten form at runtime, which grounds the property in real compiler
+  behaviour at a handful of points.
+  Date/Author: 2026-08-21, planning agent. **Requires user decision before
+  `EP-M1` starts.**
+
+- **DEC-008: Add `logger:` to the `log` allowlist grammar, or reject it.**
+  Rationale: `SURP-010`. RFC 0002 was written against an older `log` surface.
+  Recommendation: reject invocations carrying `logger:` in the initial
+  allowlist (they are rare, and rejecting is the conservative direction), and
+  add a `pass_log_logger_control.rs` fixture asserting silence. Record the
+  divergence from RFC 0002 §Detection architecture in the RFC itself at
+  `EP-M4`.
+  Date/Author: 2026-08-21, planning agent.
+
+## Outcomes & retrospective
+
+Not started. To be completed at each milestone boundary and at plan closure.
+Before setting this plan to `COMPLETE`, reconcile every discovery against
+`docs/rfcs/0002-string-continuation-style.md`: `SURP-001`, `SURP-002`,
+`SURP-003`, `SURP-007`, and `SURP-010` all describe places where the RFC's
+prescribed mechanics differ from the pinned toolchain's actual behaviour, and
+the RFC must be amended rather than silently diverged from.
+
+## Context and orientation
+
+### What this repository is
+
+Whitaker is a suite of [Dylint](https://github.com/trailofbits/dylint) lints for
+Rust. Dylint loads compiled lint libraries into `rustc` at build time, so each
+lint crate is a `cdylib` compiled against the pinned nightly compiler's private
+crates (`rustc_ast`, `rustc_lint`, and so on).
+
+Layout you need to know:
+
+- `crates/<lint_name>/` — one directory per lint. Ten exist today.
+- `crates/rustc_ast/`, `crates/rustc_lint/`, `crates/rustc_span/`,
+  `crates/rustc_session/`, `crates/rustc_middle/`, `crates/clippy_utils/` —
+  thin proxy crates that re-export the nightly compiler crates so lint crates
+  do not each need `#![feature(rustc_private)]` plumbing. Depend on these by
+  workspace alias (`rustc_ast = { workspace = true }`), never on the raw
+  `extern crate`.
+- `common/` — the `whitaker-common` crate: pure helpers plus the Fluent
+  localization engine.
+- `suite/` — `whitaker_suite`, the aggregated `cdylib` that bundles every lint.
+- `installer/` — the `whitaker` CLI that builds, links, and stages lint
+  libraries.
+- `src/` — the top-level `whitaker` crate, which holds the CLI plus shared test
+  harness code (`src/testing/ui/`) and the rustc-aware span helpers
+  (`src/hir/`).
+- `verus/` — Verus proof files, run out-of-band from Cargo.
+- `docs/` — the knowledge base. Start at `docs/contents.md` and
+  `docs/repository-layout.md`.
+
+`rust-toolchain.toml` pins `nightly-2026-05-28` with the `rustc-dev` and
+`rust-src` components.
+
+### Terms used in this plan
+
+- **Cooked string literal** — an ordinary `"..."` literal, in which backslash
+  escape sequences are interpreted. Contrast a *raw* literal `r"..."`, where
+  they are not.
+- **Continuation escape** — a backslash immediately followed by a source
+  newline inside a cooked literal, plus the whitespace the compiler then
+  consumes. Its evaluated value is empty.
+- **Source-line join** — a continuation escape with source content both before
+  it on its physical line and after the whitespace it consumes. Its only
+  purpose is to wrap one logical string across two source lines. This is what
+  the lint targets.
+- **Layout trim** — a continuation used to suppress a leading or trailing
+  source newline and indentation rather than to divide two fragments, as in
+  `"\` at the very start of a literal. The lint leaves these alone.
+- **Post-expansion early lint** — an `EarlyLintPass` that runs on the abstract
+  syntax tree (AST) after macro expansion but before lowering to the high-level
+  intermediate representation (HIR). It sees `ExprKind::FormatArgs`, which
+  records how `format!`-family arguments were bound, while still retaining the
+  literal's source spelling.
+- **Implicit format capture** — writing `format!("{name}")` so that `name` is
+  captured from the enclosing scope. The compiler permits this only when the
+  format string is a direct source literal, which is exactly why a `concat!()`
+  rewrite would break it.
+- **Applicability** — rustc's confidence label on a suggestion.
+  `MachineApplicable` means `cargo fix` may apply it unattended.
+
+### What exists today that you will copy
+
+**Lint crate shape.** Use `crates/no_unwrap_or_else_panic/` as the template; it
+is the closest existing multi-module lint. Its `Cargo.toml` declares
+`[lib] crate-type = ["cdylib", "rlib"]`, `publish = false`, workspace-inherited
+metadata, and two features:
+
+```toml
+[features]
+default = []
+dylint-driver = [
+    "dep:whitaker-common", "dep:dylint_linting", "dep:fluent-templates",
+    "dep:log", "dep:rustc_hir", "dep:rustc_lint", "dep:rustc_session",
+    "dep:rustc_span", "dep:serde", "dep:whitaker",
+]
+constituent = ["dylint-driver", "dylint_linting/constituent"]
+```
+
+Every compiler dependency is `optional = true` so that plain `cargo check`,
+`cargo doc`, and `cargo clippy` runs succeed without `rustc_private`. The
+crate's `src/lib.rs` opens with
+`#![cfg_attr(feature = "dylint-driver", feature(rustc_private))]` and gates
+every module on `dylint-driver`, with a `stub` module filling the crate when
+the feature is off. The `crates/*` glob in the workspace `members` list picks
+up a new directory automatically — no manifest edit is needed to register it.
+
+**Lint declaration.** `crates/conditional_max_n_branches/src/driver.rs:73-91`
+wraps the declaration macro in a private module so the macro-generated,
+source-location-free items do not trip `missing_docs`:
+
+```rust
+mod declaration {
+    #![expect(
+        missing_docs,
+        reason = "dylint_linting macro expansion emits items with no documentable source location"
+    )]
+    use super::ConditionalMaxNBranches;
+    dylint_linting::impl_late_lint! {
+        /// ...
+        pub CONDITIONAL_MAX_N_BRANCHES,
+        Warn,
+        "...",
+        ConditionalMaxNBranches::default()
+    }
+}
+pub use declaration::CONDITIONAL_MAX_N_BRANCHES;
+```
+
+`dylint_linting` 6 provides `impl_early_lint!` with the same shape.
+
+**No early lint exists yet.** Every current lint is a `LateLintPass`. This will
+be the repository's first `EarlyLintPass`, so there is no in-repo precedent for
+early-pass registration to copy; write it from `SURP-005`.
+
+**Diagnostics.** `crates/bumpy_road_function/src/driver/diagnostic.rs:33-83` is
+the model, because it is the only lint that emits per-item secondary labels:
+
+```rust
+let messages = safe_resolve_message_set(localizer, resolution, noop_reporter, || {
+    fallback_messages(/* ... */)
+});
+cx.emit_span_lint(
+    BUMPY_ROAD_FUNCTION,
+    input.primary_span,
+    rustc_lint::errors::DiagDecorator(|lint| {
+        lint.primary_message(messages.primary().to_owned());
+        lint.span_note(input.primary_span, messages.note().to_owned());
+        for (ordinal, interval) in highlighted.iter().enumerate() { /* span_label */ }
+        lint.help(messages.help().to_owned());
+    }),
+);
+```
+
+Note that `clippy_utils` is vendored but **unused** by every lint's logic; do
+not reach for `span_lint_and_then`. Use `cx.emit_span_lint` with
+`rustc_lint::errors::DiagDecorator`.
+
+**Localization.** `whitaker_common::i18n` wraps `fluent_templates::static_loader!`
+over `common/locales/{en-GB,cy,gd}/`. One `.ftl` file per lint, named after the
+lint slug, with the message keyed by the slug and attributes `.note`, `.help`,
+and (for labels) `.label`. A lint obtains its localizer once per run:
+
+```rust
+let shared_config = SharedConfig::load();
+self.localizer = get_localizer_for_lint(LINT_NAME, shared_config.locale());
+```
+
+and resolves the primary/note/help triple with
+`safe_resolve_message_set(&localizer, MessageResolution { lint_name, key, args }, noop_reporter, fallback)`.
+Per-label strings use `localizer.attribute_with_args(LINT_NAME, "label", &args)`
+and must have Fluent's bidirectional isolation marks (`U+2068`, `U+2069`) and
+`U+FFFD` filtered out, exactly as `resolve_bump_label` does at
+`crates/bumpy_road_function/src/driver/diagnostic.rs:175-189`.
+
+**UI tests.** `crates/no_std_fs_operations/src/tests/ui.rs` is the locale-aware
+template:
+
+```rust
+use serial_test::serial;
+use whitaker_common::test_support::with_locale;
+
+#[test] #[serial] fn ui() { run_with_locale("ui", None); }
+#[test] #[serial] fn ui_runs_in_welsh() { run_with_locale("ui-cy", Some("cy")); }
+#[test] #[serial] fn ui_runs_in_gaelic() { run_with_locale("ui-gd", Some("gd")); }
+#[test] #[serial] fn ui_runs_in_fallback_locale() { run_with_locale("ui-fallback", Some("zz")); }
+
+fn run_with_locale(directory: &str, locale: Option<&str>) {
+    with_locale(locale, || {
+        whitaker::run_ui_tests!(directory).expect("UI tests should execute without diffs");
+    });
+}
+```
+
+`#[serial]` is mandatory: `DYLINT_LOCALE` is process-global. Never mutate the
+environment directly in a test; use `whitaker_common::test_support::{with_locale,
+with_env_var, with_env_var_removed}` (`AGENTS.md` forbids direct mutation).
+
+**Behavioural tests.** Feature files live at `<crate>/tests/features/*.feature`;
+step definitions live in `<crate>/tests/<name>_behaviour.rs`. Scenarios bind by
+crate-relative path and zero-based index:
+`#[scenario(path = "tests/features/string_continuation_style.feature", index = 0)]`.
+Fixtures carrying a "world" struct are wrapped in
+`#[whitaker_test_macros::allow_fixture_expansion_lints]`, which works around
+`rstest`'s macro expansion dropping `#[expect]` attributes.
+
+**Suite registration.** `suite/src/lints.rs` holds two parallel, order-coupled
+arrays: `SUITE_LINTS` (plain `LintDescriptor { name, crate_name }` metadata,
+usable without the compiler) and `SUITE_LINT_DECLS` (`&[&rustc_lint::Lint]`).
+`suite/tests/registration.rs::then_decls_align` asserts they agree, so the new
+entry must go into both at the same index. `suite/src/driver.rs:65-68` is the
+registration function to extend.
+
+**Installer and Makefile.** The lint list is hard-coded in *two* places that
+must stay in step: `installer/src/resolution.rs:17` (`LINT_CRATES`, a Rust
+`&[&str]`) and `Makefile:58` (`LINT_CRATES`, a space-separated Make variable
+that additionally contains `whitaker_suite`).
+
+**Gates.** `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+`make markdownlint`, `make nixie`. `make test` runs `cargo nextest run` over the
+workspace and then `cargo test --doc` with an exclusion list; doctests cannot
+link `rustc_driver`, so the new crate is automatically excluded once it is
+added to the Makefile's `LINT_CRATES`.
+
+### The upstream specification
+
+`docs/rfcs/0002-string-continuation-style.md` is the design of record. Read it
+in full before starting. Its §Rule semantics, §Decision matrix, §Continuation
+scanner, §Rewrite construction, and §Test plan are normative for this work,
+except where §Surprises & discoveries above records a toolchain fact that
+contradicts them.
+
+### Skills and documents to load
+
+Before starting implementation, load these skills (they encode conventions this
+plan relies on rather than restates):
+
+- `rust-router`, then `rust-unit-testing` and `rust-types-and-apis` for the
+  domain modules.
+- `hexagonal-architecture` for the port and adapter boundaries in `DEC-003`.
+- `proptest` for the property tests in `EP-M1`.
+- `kani` for the bounded harnesses in `EP-M1`.
+- `verus` for `LEM-REWRITE-1`.
+- `leta` for navigation; prefer `leta show`/`leta refs` over reading whole files.
+- `execplans` for keeping this document current.
+- `commit-message` when committing.
+- `en-GB-oxendict` for all prose.
+
+And these repository documents:
+
+- `AGENTS.md` — the binding project policy layer.
+- `docs/whitaker-dylint-suite-design.md` — suite conventions. Note that it is
+  entirely late-pass oriented and contains no early-pass guidance; `EP-M5` adds
+  that section.
+- `docs/developers-guide.md` — internal conventions, including the Verus trust
+  boundary rules.
+- `docs/users-guide.md` §Available Lints — where the user-facing description goes.
+- `docs/documentation-style-guide.md` — required for every doc edit.
+- `docs/rust-testing-with-rstest-fixtures.md` and
+  `docs/rstest-bdd-users-guide.md` — API mechanics. Both are adapted upstream
+  material and cite paths that do not exist here; trust `AGENTS.md` and existing
+  crate precedent over their file-path examples.
+- `docs/complexity-antipatterns-and-refactoring-strategies.md` — the scanner is
+  a natural home for the very complexity this repository lints against; keep
+  functions small and single-purpose.
+- `docs/rust-doctest-dry-guide.md` — doc examples must be genuine, but note that
+  this crate's doctests are excluded from `make test` because they cannot link
+  `rustc_driver`. Put runnable examples on the *pure* domain functions, which
+  are compiled without the `dylint-driver` feature; mark compiler-facing
+  examples `ignore` with a reason, as `suite/src/driver.rs` does.
+
+## Conformance basis
+
+Upstream artefacts, at the revisions current on branch
+`2-2-10-string-continuation-style-post-expansion-early-lint.md` (based on
+`harden-lint-config` at `9b758d1`):
+
+- **RFC-0002** — `docs/rfcs/0002-string-continuation-style.md`, status
+  *Proposed*. The design of record.
+- **ROADMAP-2.2.10** — `docs/roadmap.md` line 81. Depends on ROADMAP-2.1.1
+  (lint crate template, done) and ROADMAP-2.3.4 (locale selection via
+  `DYLINT_LOCALE` and `dylint.toml`, done).
+- **SUITE-DESIGN** — `docs/whitaker-dylint-suite-design.md`. Governs crate
+  layout, the `constituent` feature, and suite assembly. Contains no early-pass
+  guidance; `EP-M5` must add it.
+- **AGENTS** — `AGENTS.md`. Code style, testing policy, documentation
+  maintenance, and the 400-line module ceiling.
+- **STYLE** — `docs/documentation-style-guide.md`.
+
+There is no Terms of Reference document for this work; ROADMAP-2.2.10 plus
+RFC-0002 serve that role.
+
+Trace links:
+
+```plaintext
+ROADMAP-2.2.10 -> RFC-0002 §Continuation scanner -> EP-M1 -> INV-SCAN-1 -> crates/string_continuation_style/src/continuation/tests.rs
+ROADMAP-2.2.10 -> RFC-0002 §Rewrite construction -> EP-M1 -> LEM-REWRITE-1 -> verus/string_continuation_rewrite.rs
+ROADMAP-2.2.10 -> RFC-0002 §Ordinary string expressions -> EP-M2 -> crates/string_continuation_style/ui/fail_plain_join.rs
+ROADMAP-2.2.10 -> RFC-0002 §Why the motivating example passes -> EP-M3 -> crates/string_continuation_style/ui/pass_implicit_format_capture.rs
+ROADMAP-2.2.10 -> RFC-0002 §Detection architecture (allowlist) -> EP-M4 -> crates/string_continuation_style/ui/pass_local_macro_lookalikes.rs
+ROADMAP-2.2.10 -> RFC-0002 §Suite integration -> EP-M5 -> suite/tests/registration.rs::then_early_pass_count
+ROADMAP-2.2.10 -> AGENTS §Documentation maintenance -> EP-M5 -> docs/users-guide.md §string_continuation_style
+```
+
+## Verification plan
+
+The implementation structure in `DEC-003` was chosen *because* it puts every
+obligation below into a pure module reachable without a compiler session. Each
+obligation names the artefact that discharges it and the control that proves
+the check is not vacuous.
+
+### Axioms (assumed, not verified)
+
+- **AX-1.** `rustc_ast::FormatArgs::is_source_literal == true` implies the
+  format string was written as a direct literal in the source file and its
+  recovered snippet matches the parsed input. Basis: `SURP-001`. This is a
+  third-party interface contract; we do not verify rustc's internals. We *do*
+  verify our repository-owned use of it: `EP-M3` includes UI fixtures for a
+  `concat!()`-generated format string and an `include_str!()`-generated one,
+  both of which must produce silence.
+- **AX-2.** `FormatArgs::span` is the format-string literal token's span, and
+  `Span::from_inner(InnerSpan::new(a, b))` yields the sub-span at byte offsets
+  `a..b` from that token's start. Basis: `SURP-002`. Verified at the boundary by
+  the byte-exact `.stderr` fixtures, whose caret positions would move if this
+  were wrong.
+- **AX-3.** `FormatArgs::uncooked_fmt_str.1` is the raw source body between the
+  quotes, unmodified by the `println!` newline append. Basis: `SURP-003`.
+  Boundary-verified by `fail_println_join.rs`, whose expected suggestion would
+  gain a stray `\n` fragment if this were false.
+- **AX-4.** Rust consumes, after a continuation escape's newline, every
+  subsequent space, tab, and newline until the first other character. Basis:
+  the Rust Reference §String literals, and rustc's `skip_ascii_whitespace`.
+  This is the rule the scanner implements; `INV-SCAN-3` and its oracle test it.
+- **AX-5.** `concat!()` yields a `&'static str` and, when it supplies a format
+  string, disables implicit named capture. Basis: RFC-0002 §Source basis and
+  rust-lang/rust's own UI test. Boundary-verified by
+  `pass_implicit_format_capture.rs`.
+- **AX-6.** rustc normalizes CRLF to LF before lexing, so adapter-supplied
+  literal bodies contain LF only. Basis: `SURP-007`.
+- **AX-7.** `LintStore::register_early_pass` causes the pass to run once per
+  crate, after expansion, before HIR lowering. Basis: `SURP-005` and
+  `compiler/rustc_interface/src/passes.rs:400`.
+
+### Obligations
+
+**INV-SCAN-1 — continuation detection is backslash-parity-correct.**
+
+- Statement: a byte offset `i` in the literal body begins a continuation escape
+  if and only if the byte at `i` is `\`, the maximal run of consecutive
+  backslashes ending at `i` has odd length, and the byte at `i + 1` is `\n` (or
+  begins a `\r\n` pair).
+- Method: `rstest` parameterized cases for the finite boundary partition
+  (runs of length 0 through 4, before LF, before CRLF, before a lone CR, before
+  end-of-body), plus a Kani harness for exhaustive coverage of short inputs.
+- Rationale: the parity rule is where a naive implementation goes wrong, and
+  the input alphabet that matters is tiny, so bounded exhaustive exploration is
+  both cheap and complete over the interesting domain.
+- Domain: Kani harness over bodies of length ≤ 8 drawn from the four-symbol
+  alphabet `{ '\\', '\n', ' ', 'a' }`, with `#[kani::unwind(10)]`.
+- Artefact: `crates/string_continuation_style/src/continuation/tests.rs`
+  (parameterized) and `crates/string_continuation_style/src/continuation/kani.rs`
+  (`#[cfg(kani)]`).
+- Evidence: `cargo nextest run -p string_continuation_style continuation::` and
+  `scripts/run-kani.sh string-continuation`. Both must fail before the scanner
+  exists.
+- Non-vacuity: witnesses `"a\\\nb"` (odd run, is a continuation) and
+  `"a\\\\\nb"` (even run, is a literal backslash followed by a real newline)
+  must both be exercised and must be classified differently. Negative control
+  `NV-SCAN-1`: replace the parity test with `is_backslash(prev)` and require the
+  Kani harness to produce a counter-example naming the even-run input.
+
+**INV-SCAN-2 — recorded ranges are well-formed.**
+
+- Statement: for every `Continuation` the scanner emits,
+  `escape_range.start < escape_range.end <= skipped_whitespace_range.start <=
+  skipped_whitespace_range.end <= body.len()`; consecutive continuations are
+  strictly ordered; and no two continuations' combined
+  `escape_range ∪ skipped_whitespace_range` intervals overlap.
+- Method: `proptest`, asserted on every scan in every property test via a
+  shared `assert_scan_well_formed` helper, plus the same assertion inside the
+  Kani harness for `INV-SCAN-1`.
+- Rationale: this is a structural invariant over generated inputs of
+  unbounded length; a property test is the proportionate tool, and folding it
+  into every other property test costs nothing.
+- Domain: generated bodies mixing ASCII text, Unicode text, escaped quotes,
+  escaped backslashes, blank lines, and one to five continuations.
+- Artefact: `crates/string_continuation_style/src/continuation/props.rs`.
+- Evidence: `cargo nextest run -p string_continuation_style continuation::props`.
+- Non-vacuity: the generator must be classified with `proptest::prop_assume!`-free
+  construction and a `prop_assert!(scan.len() >= 1)` guard, so a generator that
+  silently stopped producing continuations fails loudly rather than passing
+  vacuously. Negative control `NV-SCAN-2`: make the scanner emit
+  `skipped_whitespace_range = escape_range` and require the disjointness or
+  ordering assertion to reject it.
+
+**INV-SCAN-3 — the skipped-whitespace range matches the language rule.**
+
+- Statement: `skipped_whitespace_range` covers exactly the bytes rustc
+  discards after the continuation's newline — every space, tab, LF, and
+  complete CRLF — terminating at the first other byte or at the end of the body.
+- Method: differential property test against an independent unescaper
+  (`DEC-007`), plus `rstest` cases for the boundaries (immediately-following
+  content, blank lines, whitespace-only trailing run, end of body).
+- Rationale: this is the obligation most likely to be got subtly wrong, and it
+  is the one where an independent oracle is available. Examples alone would not
+  cover the interaction of blank lines with indentation.
+- Domain: as `INV-SCAN-2`, with the added generator requirement that at least
+  one continuation is followed by non-empty indentation.
+- Artefact: `crates/string_continuation_style/src/continuation/props.rs`.
+- Evidence: as above.
+- Non-vacuity: the generator must emit non-empty indentation after every
+  newline, so that an implementation deleting only `escape_range` and retaining
+  the indentation fails. Negative control `NV-SCAN-3`: that exact mutation must
+  be rejected with a diff showing the retained spaces.
+
+**INV-CLASS-1 — classification is total and mutually exclusive.**
+
+- Statement: every continuation receives exactly one of `Join`,
+  `LeadingLayoutTrim`, `TrailingLayoutTrim`; `Join` holds if and only if there
+  is source content before the backslash on its physical line *and* source
+  content after all consumed whitespace; when neither side has content,
+  `LeadingLayoutTrim` wins.
+- Method: `rstest` parameterized cases covering the 2×2 content matrix plus the
+  precedence tie, and a Kani harness reusing the `INV-SCAN-1` symbolic input to
+  assert exclusivity exhaustively over short bodies.
+- Rationale: a finite partition with an explicit precedence rule. Both an
+  enumerated table and bounded exhaustive exploration are cheap; together they
+  cover the named cases and the unnamed ones.
+- Domain: the five rows of RFC-0002 §Continuation scanner's classification
+  table, plus Kani over bodies of length ≤ 8.
+- Artefact: `crates/string_continuation_style/src/classification/tests.rs` and
+  `crates/string_continuation_style/src/continuation/kani.rs`.
+- Evidence: `cargo nextest run -p string_continuation_style classification::`.
+- Non-vacuity: each of the three variants must be produced by at least one
+  case, and the Kani assertion must be `exactly_one_of(...)`, not
+  `at_least_one_of(...)`. Negative control `NV-CLASS-1`: swap the precedence so
+  `TrailingLayoutTrim` wins the tie, and require the precedence case to fail.
+
+**LEM-REWRITE-1 — splitting and re-concatenating equals removal.**
+
+- Statement: let `body` be the literal body and `R = [r_0, ..., r_{n-1}]` a
+  sorted, pairwise-disjoint sequence of sub-ranges of `body`. Let `fragments`
+  be the `n + 1` maximal sub-sequences of `body` lying between and outside the
+  ranges of `R`. Then `concat(fragments) == body with every r_i removed`.
+- Method: Verus deductive proof over `Seq<u8>`, by induction on `|R|`.
+- Rationale: this is the lemma the entire suggestion rests on, it must hold for
+  literals of every length and every number of joins, and it is a pure
+  statement about sequences — precisely the unbounded, algebraic shape Verus is
+  for. A property test would sample it; a proof settles it.
+- Domain: all `Seq<u8>` and all sorted disjoint range sequences. Unbounded.
+- Artefact: `verus/string_continuation_rewrite.rs`, following the layout of
+  `verus/clone_detector_candidate_pair.rs` — mirror the production range type
+  by `#[path]` include where the module's dependencies permit, and state the
+  trust boundary in the module doc comment otherwise.
+- Evidence: `make verus` (add a `string-continuation` group to
+  `scripts/run-verus.sh`). Before the proof body is written, the lemma must
+  fail with an open goal, not vacuously succeed.
+- Non-vacuity: inspect that the antecedent is inhabited by exhibiting a
+  concrete witness (`body = "abc"`, `R = [1..2]`, fragments `["a", "c"]`)
+  inside the proof file as an `assert` that Verus must discharge from the
+  lemma. The proof must not contain `assume`. The `decreases` clause must be
+  present and the base case must be `|R| == 0`, so the induction does work
+  rather than collapsing. Negative control `NV-REWRITE-2`: weaken the
+  disjointness precondition and confirm Verus rejects the proof rather than
+  accepting it.
+
+**LEM-REWRITE-2 — the rewrite preserves the evaluated value.**
+
+- Statement: for a body whose selected joins are `J`, unescaping the original
+  body yields the same character sequence as unescaping each rewrite fragment
+  and concatenating the results.
+- Method: differential `proptest` against the reference unescaper of `DEC-007`,
+  plus three compile-and-run UI fixtures that assert the equality at runtime in
+  real compiled Rust.
+- Rationale: `LEM-REWRITE-1` is about source bytes; this is about *evaluated*
+  bytes, and the bridge between them is the escaping rule, which is external
+  (`AX-4`). Verifying against an independent implementation of that rule, and
+  then grounding a few points in actual compiler output, covers both the
+  general case and the "did we understand the rule at all" case.
+- Domain: generated bodies containing Unicode above the basic multilingual
+  plane, escaped quotes, escaped backslashes, `\u{...}` escapes, doubled braces
+  (`{{`, `}}`), and one to five joins.
+- Artefact: `crates/string_continuation_style/src/rewrite/props.rs` and
+  `crates/string_continuation_style/ui/fail_value_preserved.rs` (a fixture whose
+  fixed output, once applied, is compiled and run).
+- Evidence: `cargo nextest run -p string_continuation_style rewrite::props`.
+- Non-vacuity: classify generated cases by join count and by whether any
+  Unicode scalar above `U+FFFF` appears, and require every class to be hit
+  (`proptest`'s statistics, checked by an explicit counter assertion at the end
+  of the run rather than by eyeball). Negative control `NV-REWRITE-3`: make the
+  rewriter split at a `LeadingLayoutTrim` as well as at joins, and require the
+  property to fail with a fragment boundary inside the trimmed region.
+
+**LEM-APPLY-1 — machine-applicable implies re-lexable.**
+
+- Statement: the lint labels a suggestion `MachineApplicable` only when the
+  original snippet lexes as exactly one cooked string token and the generated
+  replacement lexes as exactly one `concat!` macro-call expression.
+- Method: `rstest` parameterized cases over the applicability gate, driven
+  through the pure gate function, plus the UI matrix as an end-to-end check.
+- Rationale: this is a finite conjunction of checks; enumerating the ways each
+  conjunct can fail is proportionate. The real risk is that the gate is never
+  consulted, which the negative control catches.
+- Domain: the seven conditions in RFC-0002 §Applicability.
+- Artefact: `crates/string_continuation_style/src/rewrite/tests.rs`.
+- Evidence: `cargo nextest run -p string_continuation_style rewrite::`.
+- Non-vacuity: each of the seven conditions must have a case that fails it
+  alone, with all others satisfied, and each such case must downgrade the
+  applicability. Negative control `NV-APPLY-1`: hard-code the gate to return
+  `MachineApplicable` and require all seven cases to fail.
+
+**Obligations deliberately not verified formally.** The macro-identity
+allowlist (`EP-M4`) is a policy table, not an invariant: its correctness is a
+statement about third-party crates' macro definitions, which change between
+their versions. It is verified by UI fixtures pinning both the accepted forms
+and the lookalikes, and by the "uncertain contract produces neither a
+diagnostic nor a suggestion" default, which is the safe direction. This is
+recorded here rather than omitted, because a reader could reasonably expect a
+proof and should know why there is not one.
+
+## Plan of work
+
+### Stage A — understand and propose (no code changes)
+
+Read RFC-0002 in full. Read `AGENTS.md`. Confirm `DEC-002` and `DEC-007` have
+been decided. Do not write code until this plan is approved.
+
+### Stage B — red tests and the behaviour specification
+
+Write the feature file and the failing tests before any production code. The
+feature specification that drives `EP-M1` and `EP-M2` is, at
+`crates/string_continuation_style/tests/features/string_continuation_style.feature`:
+
+```gherkin
+Feature: Context-sensitive string continuation style
+
+  Scenario: An ordinary source-line join prefers concat
+    Given a cooked string expression with an interior continuation
+    And the literal is in a general expression context
+    When the continuation is classified
+    Then the disposition is PreferConcat
+
+  Scenario: An implicit format capture requires the direct literal
+    Given a source-authored format string with an interior continuation
+    And rustc classified one argument as Captured
+    When the continuation is classified
+    Then the disposition is RequireContinuation with reason ImplicitFormatCapture
+
+  Scenario: A leading continuation expresses source layout
+    Given a cooked string whose first token after the opening quote is a continuation
+    When the continuation is classified
+    Then the disposition is RequireContinuation with reason LeadingOrTrailingLayoutTrim
+
+  Scenario: A byte string keeps its continuation
+    Given a cooked byte string expression with an interior continuation
+    When the continuation is classified
+    Then the disposition is RequireContinuation with reason NonStringLiteralType
+
+  Scenario: A raw string is not the lint's business
+    Given a raw string expression containing a backslash before a newline
+    When the continuation is classified
+    Then the disposition is Ignore
+
+  Scenario: Several joins produce one rewrite
+    Given a cooked string expression with three interior continuations
+    When the continuation is classified
+    Then the disposition is PreferConcat
+    And the rewrite has four fragments
+```
+
+Each stage below ends with `make check-fmt && make typecheck && make lint &&
+make test`. Do not proceed while any gate fails.
+
+### Stage C — implementation with verification developed alongside
+
+Milestones `EP-M0` through `EP-M4`, in order. Each writes its Kani harness or
+Verus lemma in the same commit as the code it constrains, not afterwards.
+
+### Stage D — refactor, documentation, and wider validation
+
+Milestone `EP-M5`: suite registration, installer and Makefile lists, user
+guide, developers' guide, suite design addendum, RFC amendments for
+`SURP-001`/`SURP-002`/`SURP-003`/`SURP-007`/`SURP-010`, and the roadmap tick.
+
+## Milestones and plateaus
+
+### EP-M0 — Architecture spike (prototyping)
+
+- **Outcome.** A throwaway branch-local experiment that answers `DEC-002`, then
+  is deleted. Repository state at the end of the milestone is unchanged except
+  for this plan's `Decision log` and `Surprises & discoveries`.
+- **Requirements advanced.** RFC-0002 §Detection architecture.
+- **Method.** Create a scratch lint crate registering an `EarlyLintPass` that,
+  for every `ExprKind::FormatArgs` and `ExprKind::Lit`, prints: the expression
+  span, `span.ctxt().outer_expn_data()`'s `kind`, `macro_def_id`, and
+  `def_site` filename; `is_source_literal`; `uncooked_fmt_str.0`; and the
+  argument kinds. Run it over a fixture crate that uses `format!`, `println!`,
+  `write!`, `assert!`, `log::info!`, `log::warn!(target: ...)`,
+  `tracing::info!` with fields, `tracing::info!` with controls, a local
+  `macro_rules!` named `info`, and a local macro binding `$msg:literal`.
+- **Acceptance evidence.** A transcript in this plan's §Artefacts and notes
+  showing, for each fixture line, whether a `FormatArgs` node appeared, whether
+  `is_source_literal` was true, whether duplicate nodes appeared for one source
+  literal, and what identity information `ExpnData` carried. Evidence
+  identifier `EV-M0-transcript`.
+- **Go/no-go.** If `log` and `tracing` invocations reach the AST as
+  `ExprKind::FormatArgs` with `is_source_literal == true` **and** `ExpnData`
+  alone cannot distinguish `log::info!` from a local `info!`, adopt `DEC-002`
+  option 3 and revise `EP-M3`/`EP-M4` accordingly. If they do not appear as
+  `FormatArgs` at all, adopt option 1 and move `log`/`tracing` support out of
+  this plan into a new roadmap item, recording the deviation in `Decision log`
+  and setting this plan to `BLOCKED` pending acceptance.
+- **Conformance check.** Does the evidence falsify RFC-0002's assumption that a
+  pure early pass suffices? If so, the RFC must be amended before `EP-M3`.
+- **Recovery.** `git checkout -- .` and delete the scratch crate; nothing is
+  committed from this milestone except plan updates.
+- **Remaining gaps.** All implementation.
+- **Compatibility decision.** None required; nothing ships.
+
+### EP-M1 — Pure domain core
+
+- **Outcome.** `crates/string_continuation_style/` exists and builds under both
+  feature configurations. The three pure modules — `continuation` (scanner),
+  `classification` (policy), `rewrite` (fragment construction and the
+  applicability gate) — are complete, documented, and fully covered. The lint is
+  declared and an `EarlyLintPass` is wired, but `check_expr` does nothing yet.
+  `cargo dylint --lib string_continuation_style` runs and reports nothing.
+- **Requirements discharged.** RFC-0002 §Continuation scanner, §Rewrite
+  construction. `INV-SCAN-1`, `INV-SCAN-2`, `INV-SCAN-3`, `INV-CLASS-1`,
+  `LEM-REWRITE-1`, `LEM-REWRITE-2`, `LEM-APPLY-1`.
+- **Acceptance evidence.** `EV-M1`: `cargo nextest run -p string_continuation_style`
+  passes; `scripts/run-kani.sh string-continuation` discharges both harnesses;
+  `make verus` discharges `verus/string_continuation_rewrite.rs`; every
+  negative control `NV-*` has been run and observed to fail for the stated
+  reason, with the transcript recorded in §Artefacts and notes.
+- **Conformance check.** Domain modules import no `rustc_*` crate — verify with
+  `leta refs` and by confirming the modules compile with `--no-default-features`.
+  Every module is under 400 lines. No public interface outside this crate
+  changed except the three workspace dependency additions of `DEC-006`.
+- **Recovery.** The crate is self-contained and unregistered; deleting the
+  directory and reverting the workspace manifest returns the repository to its
+  prior state.
+- **Remaining gaps.** No AST is inspected; no diagnostic is emitted.
+- **Compatibility decision.** None. This is a new pre-1.0 crate with no
+  consumers.
+
+### EP-M2 — Plain cooked string literals
+
+- **Outcome.** `check_expr` handles `ExprKind::Lit` with a cooked
+  `token::LitKind::Str`. A plain source-line join produces one warning with a
+  note, a help, one secondary label per join, and a `MachineApplicable`
+  whole-literal `concat!()` suggestion. Byte strings, C strings, raw strings,
+  layout trims, and literals from macro expansions produce silence. Diagnostics
+  are localized in `en-GB`, `cy`, and `gd`.
+- **Requirements discharged.** RFC-0002 §Ordinary string expressions,
+  §Diagnostic, and the plain-literal rows of §Decision matrix.
+- **Acceptance evidence.** `EV-M2`: the UI fixtures `fail_plain_join`,
+  `fail_multiple_joins`, `fail_join_across_blank_lines`,
+  `fail_value_preserved`, `pass_leading_layout_trim`,
+  `pass_trailing_layout_trim`, `pass_byte_and_c_strings`, `pass_raw_strings`,
+  `pass_real_newline`, `pass_literal_in_pattern`, and
+  `pass_unknown_literal_macro` all pass with byte-exact `.stderr`; `ui-cy`,
+  `ui-gd`, and `ui-fallback` locale smoke fixtures pass. The behavioural
+  scenarios for `PreferConcat`, `LeadingOrTrailingLayoutTrim`,
+  `NonStringLiteralType`, `Ignore`, and the multi-join rewrite all pass.
+- **Conformance check.** Confirm the suggestion span covers the whole literal
+  including quotes and that applying it by hand to `fail_plain_join.rs`
+  produces source that compiles and evaluates identically. Confirm no lint
+  fires on any pattern, attribute, or meta-item literal.
+- **Recovery.** Revert the `check_expr` body to the `EP-M1` no-op; the crate
+  returns to a coherent silent state.
+- **Remaining gaps.** Format strings are not inspected.
+- **Compatibility decision.** None.
+
+### EP-M3 — Source-authored format strings from compiler built-ins
+
+- **Outcome.** `check_expr` also handles `ExprKind::FormatArgs`. Format strings
+  from `format_args!`, `format!`, `print`/`println`/`eprint`/`eprintln`,
+  `write`/`writeln`, `panic`/`todo`/`unimplemented`/`unreachable`, and the
+  custom-message branches of `assert`/`debug_assert`/`assert_eq`/`assert_ne`/
+  `debug_assert_eq`/`debug_assert_ne` are diagnosed when — and only when — the
+  format string is a source literal, contains no `FormatArgumentKind::Captured`
+  argument, and the macro identity is proven per the `EP-M0` decision.
+- **Requirements discharged.** RFC-0002 §Format strings, §Why the motivating
+  example passes, and the format-string rows of §Decision matrix.
+- **Acceptance evidence.** `EV-M3`: the UI fixtures `fail_positional_arguments`,
+  `fail_explicit_format_arguments`, `fail_println_join`, `fail_write_join`,
+  `fail_assert_message_join`, `pass_implicit_format_capture` (the exact
+  pull-request-296 example, which must remain clean), `pass_implicit_width_capture`,
+  `pass_implicit_precision_capture`, and `pass_generated_format_string` all pass.
+  The RFC's "must fail with a machine-applicable rewrite" example produces
+  exactly the RFC's expected replacement, pinned by an `insta` snapshot of the
+  generated `concat!()` text.
+- **Conformance check.** Re-read RFC-0002 §Why the motivating example passes
+  and confirm the implemented predicate is `any(|a| matches!(a.kind,
+  Captured(_)))` over `arguments.all_args()`, catching captured width and
+  precision. Confirm no diagnostic is emitted for any macro whose identity was
+  not proven.
+- **Recovery.** Remove the `FormatArgs` arm; `EP-M2` behaviour is intact.
+- **Remaining gaps.** `log` and `tracing` are not yet in the allowlist.
+- **Compatibility decision.** None.
+
+### EP-M4 — `log` and `tracing` facade allowlist
+
+*Conditional on the `EP-M0` go/no-go.*
+
+- **Outcome.** The allowlist admits `log::{trace, debug, info, warn, error}!`
+  in the `(format, arguments...)` and `(target: expr, format, arguments...)`
+  forms, and `tracing::{trace, debug, info, warn, error}!` with a message tail
+  after validated `target:`/`parent:`/`name:` controls and structured fields.
+  Every other variant, every same-named local macro, and every same-named macro
+  from an unapproved crate produce silence. Invocations carrying `log`'s
+  `logger:` control are rejected (`DEC-008`).
+- **Requirements discharged.** RFC-0002 §Detection architecture allowlist and
+  §Acceptance fixtures.
+- **Acceptance evidence.** `EV-M4`: `fail_log_message`, `fail_log_target`,
+  `fail_tracing_fields`, `fail_tracing_controls`, `pass_log_implicit_capture`,
+  `pass_log_target_implicit_capture`, `pass_log_kv_fields`,
+  `pass_log_logger_control`, `pass_tracing_implicit_capture`,
+  `pass_tracing_controls_implicit_capture`, `pass_tracing_no_message`,
+  `pass_local_macro_lookalikes`, and `pass_external_macro_lookalikes` all pass.
+  A `pass_tracing_with_log_feature` fixture proves exactly one diagnostic is
+  emitted when `tracing/log` is enabled.
+- **Conformance check.** Confirm the identity proof matches the architecture
+  chosen at `EP-M0`. Confirm the divergence from RFC-0002's `log` grammar
+  (`DEC-008`) has been written back into the RFC.
+- **Recovery.** Remove the two facade entries from the allowlist table; the
+  built-in coverage from `EP-M3` is unaffected.
+- **Remaining gaps.** Suite integration.
+- **Compatibility decision.** None.
+
+### EP-M5 — Suite, installer, and documentation integration
+
+- **Outcome.** `whitaker_suite` registers the early pass alongside its combined
+  late pass. `cargo dylint list` shows `string_continuation_style` in both the
+  standalone and suite libraries. Documentation is complete and the roadmap item
+  is ticked.
+- **Requirements discharged.** RFC-0002 §Suite integration; AGENTS
+  §Documentation maintenance; ROADMAP-2.2.10.
+- **Acceptance evidence.** `EV-M5`: `suite/tests/registration.rs` passes,
+  including a new `then_early_pass_count` step asserting
+  `store.early_passes.len() == 1` and a matching scenario line in
+  `suite/tests/features/suite_registration.feature`;
+  `make publish-check` succeeds; `make markdownlint` and `make nixie` pass.
+- **Conformance check.** Both `LINT_CRATES` lists agree. `SUITE_LINTS` and
+  `SUITE_LINT_DECLS` are index-aligned. Every discovery in §Surprises &
+  discoveries has been reconciled with RFC-0002. No unapproved dependency,
+  trust boundary, or persisted-format change was introduced.
+- **Recovery.** Revert the suite and installer edits; the standalone lint crate
+  remains usable on its own.
+- **Remaining gaps.** None. Plan closes.
+- **Compatibility decision.** None. Whitaker is pre-1.0 (`version = "0.2.7"`)
+  and the suite's lint list is not an external commitment.
+
+## Concrete steps
+
+All commands run from the repository root,
+`/home/leynos/.lody/repos/github---leynos---whitaker/worktrees/79835686-da6f-44b3-8bc2-5c7544bdeec4`,
+on branch `2-2-10-string-continuation-style-post-expansion-early-lint.md`.
+
+Log every gate run to a file so truncated output can be reviewed:
+
+```bash
+make test 2>&1 | tee "/tmp/test-whitaker-$(git branch --show-current).out"
+```
+
+### Step 1 — workspace dependency additions (`DEC-006`)
+
+Edit `Cargo.toml` `[workspace.dependencies]`, adding:
+
+```toml
+googletest = "0.14"
+pretty_assertions = "1"
+serial_test = "3"
+```
+
+Pin `googletest` and `serial_test` to whatever `cargo add --dry-run` reports as
+current and compatible with `rstest 0.26.1`; record the resolved versions here
+when the step is done. Then update the three crates that pin `serial_test`
+locally (`function_attrs_follow_docs`, `module_must_have_inner_docs`,
+`no_std_fs_operations`) to `serial_test = { workspace = true }`.
+
+Expected:
+
+```plaintext
+$ cargo metadata --format-version 1 >/dev/null && echo ok
+ok
+```
+
+Commit: `Add googletest, pretty_assertions, and serial_test workspace pins`.
+
+### Step 2 — scaffold the crate
+
+Copy the shape of `crates/no_unwrap_or_else_panic/`. Create:
+
+```plaintext
+crates/string_continuation_style/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   ├── classification/{mod.rs,tests.rs}
+│   ├── continuation/{mod.rs,kani.rs,props.rs,tests.rs}
+│   ├── diagnostics.rs
+│   ├── driver.rs
+│   ├── facts.rs
+│   ├── rewrite/{mod.rs,props.rs,tests.rs}
+│   ├── lib_ui_tests.rs
+│   └── tests/{mod.rs,behaviour.rs,ui.rs}
+├── tests/features/string_continuation_style.feature
+├── ui/            ui-cy/            ui-gd/            ui-fallback/
+```
+
+The `crates/*` glob in the workspace `members` list picks the directory up
+automatically. Verify:
+
+```plaintext
+$ cargo check -p string_continuation_style
+    Finished `dev` profile
+$ cargo check -p string_continuation_style --features dylint-driver
+    Finished `dev` profile
+```
+
+Commit: `Scaffold the string_continuation_style lint crate`.
+
+### Step 3 — EP-M1, red first
+
+Write `crates/string_continuation_style/src/continuation/tests.rs` with the
+`INV-SCAN-1` boundary cases before writing the scanner. Confirm the red:
+
+```plaintext
+$ cargo nextest run -p string_continuation_style continuation::
+error[E0433]: failed to resolve: use of undeclared crate or module `continuation`
+```
+
+Then implement, and confirm green. Repeat for `classification` and `rewrite`.
+Add the Kani harness and the Verus proof in the same commits as the code they
+constrain. Run each negative control once, record the observed failure in
+§Artefacts and notes, then revert it.
+
+### Step 4 — EP-M2 through EP-M4
+
+For each UI fixture: write the `.rs` file first, run the UI test, inspect the
+produced diff, and only then create the `.stderr` from the observed output.
+`dylint_testing` layers on `trybuild`, so the blessing mechanism is
+`TRYBUILD=overwrite`; confirm this on the first fixture before relying on it,
+and if it does not apply, transcribe the diff by hand rather than guessing.
+
+```bash
+TRYBUILD=overwrite cargo nextest run -p string_continuation_style ui 2>&1 \
+  | tee "/tmp/ui-whitaker-$(git branch --show-current).out"
+```
+
+Never bless a `.stderr` without reading it. A blessed-but-wrong expectation is
+worse than a failing test.
+
+### Step 5 — EP-M5 integration
+
+Edit, in this order:
+
+1. `suite/Cargo.toml` — add `dep:string_continuation_style` to the
+   `dylint-driver` feature and the path dependency with
+   `features = ["dylint-driver", "constituent"]`.
+2. `suite/src/lints.rs` — append to `SUITE_LINTS` and `SUITE_LINT_DECLS` at the
+   same index, and extend the doctest's expected name list.
+3. `suite/src/driver.rs` — insert the `store.register_early_pass(...)` call
+   into `register_suite_lints`, between `register_lints` and
+   `register_late_pass`. Update the doctest's `get_lints().len()` from 9 to 10.
+4. `suite/tests/features/suite_registration.feature` and
+   `suite/tests/registration.rs` — add the early-pass count scenario and step.
+5. `installer/src/resolution.rs` — add `"string_continuation_style"` to
+   `LINT_CRATES`.
+6. `Makefile` — add `string_continuation_style` to the `LINT_CRATES` variable.
+7. `common/locales/{en-GB,cy,gd}/string_continuation_style.ftl` — the message,
+   `.note`, `.help`, and `.label` entries.
+8. `README.md` — the lint table row, and the "ships nine standard lints" count.
+9. `docs/users-guide.md` — a `### string_continuation_style` subsection under
+   §Available Lints covering what fires, what does not, and why.
+10. `docs/developers-guide.md` — a short section on writing early passes in this
+    repository: the `EarlyContext` limitations from `SURP-006`, the
+    `is_source_literal` guarantee from `SURP-001`, and the locale-serialization
+    requirement.
+11. `docs/whitaker-dylint-suite-design.md` — an addendum documenting early-pass
+    registration in the suite.
+12. `docs/rfcs/0002-string-continuation-style.md` — amendments for `SURP-001`,
+    `SURP-002`, `SURP-003`, `SURP-007`, and `SURP-010`; move status from
+    *Proposed* to *Accepted*.
+13. `docs/roadmap.md` — tick item 2.2.10.
+
+Then:
+
+```plaintext
+$ make publish-check 2>&1 | tee "/tmp/publish-check-whitaker-$(git branch --show-current).out"
+...
+$ cargo dylint list | grep string_continuation_style
+string_continuation_style
+```
+
+## Validation and acceptance
+
+Run all four gates after every milestone, sequentially, never in parallel — the
+build cache makes sequential runs faster overall:
+
+```bash
+make check-fmt 2>&1 | tee "/tmp/check-fmt-whitaker-$(git branch --show-current).out"
+make typecheck 2>&1 | tee "/tmp/typecheck-whitaker-$(git branch --show-current).out"
+make lint      2>&1 | tee "/tmp/lint-whitaker-$(git branch --show-current).out"
+make test      2>&1 | tee "/tmp/test-whitaker-$(git branch --show-current).out"
+```
+
+Delegate full gate runs to the `scrutineer` subagent, which runs them
+sequentially, captures each to a log, and returns a bounded report. When it
+reports a failure, read the cited log rather than re-running the gate.
+
+Red-Green-Refactor evidence to record for each domain module:
+
+- **Red.** `cargo nextest run -p string_continuation_style <module>::` fails
+  with an unresolved-item or assertion error naming the missing behaviour.
+- **Green.** The same command passes after the minimal implementation.
+- **Refactor.** The same command, then the four gates, all pass after cleanup.
+
+Behaviour-driven evidence:
+
+- **Red.** `cargo nextest run -p string_continuation_style behaviour` fails
+  because the step definitions are unimplemented.
+- **Green.** The same command passes; each scenario in
+  `tests/features/string_continuation_style.feature` maps to one `#[scenario]`.
+
+Verification evidence:
+
+- `scripts/run-kani.sh string-continuation` reports both harnesses
+  `VERIFICATION:- SUCCESSFUL`, with the explored unwind bound recorded.
+- `make verus` reports `verification results:: N verified, 0 errors` for
+  `verus/string_continuation_rewrite.rs`.
+- Every `NV-*` negative control has been run and its failure transcript
+  recorded in §Artefacts and notes.
+
+Quality criteria — what "done" means:
+
+- **Tests.** `make test` passes with the whole workspace green, including the
+  new crate's unit, property, behavioural, snapshot, and UI suites in four
+  locales.
+- **Verification.** `INV-SCAN-1`, `INV-SCAN-2`, `INV-SCAN-3`, `INV-CLASS-1`,
+  `LEM-REWRITE-1`, `LEM-REWRITE-2`, and `LEM-APPLY-1` are all discharged by the
+  named artefacts, with non-vacuity controls observed.
+- **Lint and typecheck.** `make check-fmt`, `make typecheck`, and `make lint`
+  all exit zero. Whitaker lints itself clean, including `module_max_lines`.
+- **Documentation.** `make markdownlint` and `make nixie` pass.
+- **Performance.** No benchmark threshold. The scanner is linear in literal
+  length and runs once per string literal; if `make test` wall-clock grows by
+  more than 10 per cent, investigate before closing the plan.
+- **Security.** None applicable; this lint reads source and emits diagnostics.
+
+Quality method:
+
+- `scrutineer` runs the gates and reports.
+- Request a CodeRabbit review via `scrutineer` before marking the plan complete,
+  and action every finding.
+
+## Idempotence and recovery
+
+Every step is re-runnable. `cargo` builds are incremental and safe to repeat.
+UI-fixture blessing overwrites `.stderr` files in place, so review the diff
+before committing; if a blessing goes wrong, `git checkout -- crates/string_continuation_style/ui/`
+restores the committed expectations.
+
+Commit after each milestone, and after each of the numbered edits in Step 5, so
+that `git bisect` and time-travel review both work. Nothing in this plan writes
+outside the repository except log files under `/tmp`, which are disposable.
+
+If a milestone must be abandoned mid-flight, each milestone's Recovery entry
+names the single revert that returns the tree to the previous plateau.
+
+## Artefacts and notes
+
+To be filled in as work proceeds. Required entries:
+
+- `EV-M0-transcript` — the `EP-M0` spike output.
+- The observed failure of each `NV-*` negative control.
+- The `insta` snapshot of the RFC's motivating-example rewrite.
+- The `make publish-check` tail showing `string_continuation_style` in
+  `cargo dylint list`.
+
+## Interfaces and dependencies
+
+### Domain (pure; no `rustc_*` imports)
+
+In `crates/string_continuation_style/src/facts.rs`, the input port — everything
+the policy needs to know about a literal, with no compiler types:
+
+```rust
+/// What the adapter observed about one string literal.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LiteralFacts<'a> {
+    /// Raw source bytes between the quotes, exactly as written.
+    pub body: &'a str,
+    /// Which flavour of literal token this is.
+    pub token: LiteralToken,
+    /// Where the literal sits, and what the surrounding grammar permits.
+    pub context: LiteralContext,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LiteralToken {
+    CookedStr,
+    RawStr,
+    ByteStr,
+    RawByteStr,
+    CStr,
+    RawCStr,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum LiteralContext {
+    /// A general expression position in root syntax context.
+    Expression,
+    /// A source-authored format string in a proven macro contract.
+    SourceFormatString { has_implicit_capture: bool },
+    /// A format string produced by `concat!`, `include_str!`, or similar.
+    GeneratedFormatString,
+    /// The macro contract, format-string position, or span could not be proven.
+    UnprovenContract,
+    /// The editable source span could not be recovered exactly.
+    UnrecoverableSpan,
+}
+```
+
+In `crates/string_continuation_style/src/continuation/mod.rs`:
+
+```rust
+pub(crate) struct Continuation {
+    pub escape_range: core::ops::Range<usize>,
+    pub skipped_whitespace_range: core::ops::Range<usize>,
+    pub kind: ContinuationKind,
+}
+
+pub(crate) enum ContinuationKind { Join, LeadingLayoutTrim, TrailingLayoutTrim }
+
+/// Scans a cooked literal body for continuation escapes.
+///
+/// The caller must pass the body without its delimiting quotes.
+pub(crate) fn scan(body: &str) -> Vec<Continuation>;
+```
+
+In `crates/string_continuation_style/src/classification/mod.rs`:
+
+```rust
+pub(crate) enum ContinuationDisposition {
+    PreferConcat(ConcatRewrite),
+    RequireContinuation(RequiredReason),
+    Ignore,
+}
+
+pub(crate) enum RequiredReason {
+    ImplicitFormatCapture,
+    NonStringLiteralType,
+    LeadingOrTrailingLayoutTrim,
+    UnknownMacroContract,
+    GeneratedFormatString,
+    UnrecoverableSourceSpan,
+}
+
+/// The single policy entry point. Pure: same facts in, same disposition out.
+pub(crate) fn classify(facts: &LiteralFacts<'_>) -> ContinuationDisposition;
+```
+
+In `crates/string_continuation_style/src/rewrite/mod.rs`:
+
+```rust
+pub(crate) struct ConcatRewrite {
+    /// Source spellings of each fragment, in order, quotes excluded.
+    pub fragments: Vec<core::ops::Range<usize>>,
+    /// Byte offsets of each selected join's backslash, for secondary labels.
+    pub join_offsets: Vec<usize>,
+    pub applicability: RewriteApplicability,
+}
+
+pub(crate) enum RewriteApplicability { MachineApplicable, MaybeIncorrect }
+
+/// Builds the replacement text for a whole literal.
+pub(crate) fn render(body: &str, rewrite: &ConcatRewrite) -> String;
+```
+
+### Adapters (rustc-facing; `dylint-driver` feature only)
+
+`crates/string_continuation_style/src/driver.rs` holds the `EarlyLintPass`
+implementation, the `LiteralFacts` construction from `ExprKind::Lit` and
+`ExprKind::FormatArgs`, the macro-identity allowlist, and the lint declaration
+inside a private `declaration` module per the `conditional_max_n_branches`
+pattern. It must stay under 400 lines; split the allowlist into
+`src/driver/allowlist.rs` if it grows.
+
+`crates/string_continuation_style/src/diagnostics.rs` converts a
+`ContinuationDisposition` plus the recovered spans into a localized
+`cx.emit_span_lint` call, following
+`crates/bumpy_road_function/src/driver/diagnostic.rs`.
+
+### Dependencies
+
+The crate's `Cargo.toml` declares, all `optional = true` under `dylint-driver`:
+`dylint_linting`, `rustc_ast`, `rustc_lint`, `rustc_session`, `rustc_span`,
+`fluent-templates`, `log`, `serde`, `whitaker-common`, `whitaker` (with
+`features = ["dylint-driver"]`). If `DEC-002` resolves to option 3, add
+`rustc_hir` and `rustc_middle`. Do not add `clippy_utils`; no lint in this
+repository uses it.
+
+Dev-dependencies: `whitaker_test_macros`, `whitaker-common`, `whitaker`,
+`rstest`, `rstest-bdd`, `rstest-bdd-macros`, `dylint_testing`, `proptest`,
+`insta`, `googletest`, `pretty_assertions`, `serial_test`, `camino`,
+`tempfile`, and — subject to `DEC-007` — `rustc-literal-escaper`.

--- a/docs/execplans/2-2-10-string-continuation-style-post-expansion-early-lint.md
+++ b/docs/execplans/2-2-10-string-continuation-style-post-expansion-early-lint.md
@@ -242,8 +242,8 @@ prescribed approach.
 
 - **SURP-005: `LintStore::register_early_pass` exists and takes a
   `TyCtxt`-free factory.**
-  Observation:
-  `pub fn register_early_pass(&mut self, pass: impl Fn() -> EarlyLintPassObject + ...)`
+  Observation: `register_early_pass` takes
+  `impl Fn() -> EarlyLintPassObject`
   (`compiler/rustc_lint/src/context.rs:168`), alongside the public
   `early_passes` / `late_passes` fields.
   Impact: RFC 0002 §Suite integration's snippet compiles as written. The suite's
@@ -291,7 +291,8 @@ prescribed approach.
   evaluated value". See `DEC-007`.
 
 - **SURP-010: `log 0.4.33`'s facade macros capture `$($arg:tt)+`.**
-  Observation: `log::info!` matches `(logger: $logger:expr, target: $target:expr, $($arg:tt)+)`,
+  Observation: `log::info!` matches
+  `(logger: $logger:expr, target: $target:expr, $($arg:tt)+)`,
   `(target: $target:expr, $($arg:tt)+)`, `(logger: $logger:expr, $($arg:tt)+)`,
   and `($($arg:tt)+)`, forwarding to `log!` and then `__log!`; key-value fields
   are separated from the message by `;`
@@ -326,7 +327,7 @@ prescribed approach.
      `FormatArgsStorage`: an `EarlyLintPass` records `FormatArgs` nodes keyed by
      span into shared storage; a `LateLintPass` (which has `TyCtxt`) resolves
      identity, handles plain literals from HIR, and emits every diagnostic.
-     Most faithful to the RFC and to established prior art; costs a hand-written
+     Most faithful to the RFC and to established prior art; costs a handwritten
      two-pass registration in the lint crate and in the suite.
   Recommendation to the reviewer: option 3 if `EP-M0` shows that
   `log`/`tracing` invocations reach the AST as `ExprKind::FormatArgs` with
@@ -553,8 +554,9 @@ let shared_config = SharedConfig::load();
 self.localizer = get_localizer_for_lint(LINT_NAME, shared_config.locale());
 ```
 
-and resolves the primary/note/help triple with
-`safe_resolve_message_set(&localizer, MessageResolution { lint_name, key, args }, noop_reporter, fallback)`.
+and resolves the primary/note/help triple by passing a
+`MessageResolution { lint_name, key, args }` to
+`safe_resolve_message_set(&localizer, resolution, noop_reporter, fallback)`.
 Per-label strings use `localizer.attribute_with_args(LINT_NAME, "label", &args)`
 and must have Fluent's bidirectional isolation marks (`U+2068`, `U+2069`) and
 `U+FFFD` filtered out, exactly as `resolve_bump_label` does at
@@ -698,33 +700,33 @@ the check is not vacuous.
 
 ### Axioms (assumed, not verified)
 
-- **AX-1.** `rustc_ast::FormatArgs::is_source_literal == true` implies the
+- **AXIOM-1.** `rustc_ast::FormatArgs::is_source_literal == true` implies the
   format string was written as a direct literal in the source file and its
   recovered snippet matches the parsed input. Basis: `SURP-001`. This is a
   third-party interface contract; we do not verify rustc's internals. We *do*
   verify our repository-owned use of it: `EP-M3` includes UI fixtures for a
   `concat!()`-generated format string and an `include_str!()`-generated one,
   both of which must produce silence.
-- **AX-2.** `FormatArgs::span` is the format-string literal token's span, and
+- **AXIOM-2.** `FormatArgs::span` is the format-string literal token's span, and
   `Span::from_inner(InnerSpan::new(a, b))` yields the sub-span at byte offsets
   `a..b` from that token's start. Basis: `SURP-002`. Verified at the boundary by
   the byte-exact `.stderr` fixtures, whose caret positions would move if this
   were wrong.
-- **AX-3.** `FormatArgs::uncooked_fmt_str.1` is the raw source body between the
+- **AXIOM-3.** `FormatArgs::uncooked_fmt_str.1` is the raw source body between the
   quotes, unmodified by the `println!` newline append. Basis: `SURP-003`.
   Boundary-verified by `fail_println_join.rs`, whose expected suggestion would
   gain a stray `\n` fragment if this were false.
-- **AX-4.** Rust consumes, after a continuation escape's newline, every
+- **AXIOM-4.** Rust consumes, after a continuation escape's newline, every
   subsequent space, tab, and newline until the first other character. Basis:
   the Rust Reference §String literals, and rustc's `skip_ascii_whitespace`.
   This is the rule the scanner implements; `INV-SCAN-3` and its oracle test it.
-- **AX-5.** `concat!()` yields a `&'static str` and, when it supplies a format
+- **AXIOM-5.** `concat!()` yields a `&'static str` and, when it supplies a format
   string, disables implicit named capture. Basis: RFC-0002 §Source basis and
   rust-lang/rust's own UI test. Boundary-verified by
   `pass_implicit_format_capture.rs`.
-- **AX-6.** rustc normalizes CRLF to LF before lexing, so adapter-supplied
+- **AXIOM-6.** rustc normalizes CRLF to LF before lexing, so adapter-supplied
   literal bodies contain LF only. Basis: `SURP-007`.
-- **AX-7.** `LintStore::register_early_pass` causes the pass to run once per
+- **AXIOM-7.** `LintStore::register_early_pass` causes the pass to run once per
   crate, after expansion, before HIR lowering. Basis: `SURP-005` and
   `compiler/rustc_interface/src/passes.rs:400`.
 
@@ -861,7 +863,7 @@ the check is not vacuous.
   real compiled Rust.
 - Rationale: `LEM-REWRITE-1` is about source bytes; this is about *evaluated*
   bytes, and the bridge between them is the escaping rule, which is external
-  (`AX-4`). Verifying against an independent implementation of that rule, and
+  (`AXIOM-4`). Verifying against an independent implementation of that rule, and
   then grounding a few points in actual compiler output, covers both the
   general case and the "did we understand the rule at all" case.
 - Domain: generated bodies containing Unicode above the basic multilingual

--- a/docs/execplans/2-4-1-string-continuation-style-post-expansion-early-lint.md
+++ b/docs/execplans/2-4-1-string-continuation-style-post-expansion-early-lint.md
@@ -227,6 +227,10 @@ Hard invariants. Violating one requires escalation, not a workaround.
       repository owner; the feature moved from roadmap item 2.2.10 to its own
       step, §2.4 String continuation style, and the branch, this file, and the
       pull request renamed to match.
+- [x] (2026-08-21) RFC 0002 substantively revised: the two soundness defects
+      corrected, the superseded mechanics replaced, and the staging and
+      configuration decisions folded in. Status stays *Proposed* until this
+      plan is approved.
 - [ ] Plan approved as a whole.
 - [ ] EP-M0a: expansion-shape probe.
 - [ ] EP-M1: pure domain crate.
@@ -676,17 +680,27 @@ Note that this is the `rustc-src` component, not the `rust-src` component at
 
 ## Outcomes & retrospective
 
-Not started. To be completed at each milestone boundary and at plan closure.
+Implementation not started. To be completed at each milestone boundary and at
+plan closure.
 
-Before setting this plan to `COMPLETE`, reconcile every discovery against
-`docs/rfcs/0002-string-continuation-style.md`. `SURP-012` and `SURP-016` are
-defects in the RFC, not merely divergences: the first would ship a
-source-corrupting suggestion, the second specifies the wrong language rule.
-`SURP-001`, `SURP-002`, `SURP-003`, `SURP-007`, `SURP-010`, and `SURP-013`
-describe places where the RFC's prescribed mechanics differ from the pinned
-toolchain's behaviour. `DEC-001`'s rationale correction and `DEC-009`'s scope
-change also require RFC edits. The RFC must be substantively revised, not
-annotated, before it moves from *Proposed* to *Accepted*.
+One outcome is already recorded. `docs/rfcs/0002-string-continuation-style.md`
+was substantively revised on 2026-08-21, before implementation, because two of
+the discoveries below are defects in the design of record rather than
+divergences from it: `SURP-012` would have shipped a source-corrupting
+suggestion, and `SURP-016` specifies the wrong language rule. Annotating either
+would have left the RFC saying something false. The revision also folded in
+`SURP-001`, `SURP-002`, `SURP-003`, `SURP-007`, `SURP-010`, and `SURP-013`,
+`DEC-001`'s rationale correction, and the consequences of `DEC-002`, `DEC-009`,
+`DEC-010`, and `DEC-013`. It carries a §Revision history recording what changed
+and why.
+
+The RFC stays at *Proposed* until this plan is approved; the status change is
+the only RFC edit left, and it belongs at `EP-M5`.
+
+Before setting this plan to `COMPLETE`, re-check that no discovery made during
+implementation has left the RFC stale again. The verification obligations, the
+configuration table, and the fixture matrix are all now described in both
+documents, so a change to any of them has two homes.
 
 ## Context and orientation
 
@@ -1697,8 +1711,11 @@ Edit, in this order:
     decisions. Reference it from `docs/whitaker-dylint-suite-design.md`.
 17. `docs/contents.md` — index the new ADR; it lists all four existing ones.
 18. `docs/repository-layout.md` — note the new pure-domain crate.
-19. `docs/rfcs/0002-string-continuation-style.md` — the substantive revision
-    described in §Outcomes & retrospective; move status to *Accepted*.
+19. `docs/rfcs/0002-string-continuation-style.md` — move status from
+    *Proposed* to *Accepted*, and add the approval date to §Revision history.
+    The substantive revision landed on 2026-08-21, before implementation; only
+    the status transition is outstanding. Re-read it first and confirm nothing
+    discovered during implementation has made it stale.
 20. `docs/roadmap.md` — tick item 2.4.1. Items 2.4.2 and 2.4.3 already exist
     and stay open.
 

--- a/docs/execplans/2-4-1-string-continuation-style-post-expansion-early-lint.md
+++ b/docs/execplans/2-4-1-string-continuation-style-post-expansion-early-lint.md
@@ -5,9 +5,10 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision log`, `Outcomes & retrospective`, `Conformance basis`, and
 `Verification plan` must be kept up to date as work proceeds.
 
-Status: DRAFT — awaiting approval. Three decisions need the approver's
-answer before implementation starts: `DEC-009` (scope), `DEC-013` (release
-applicability default), and `DEC-014` (one lint name or two).
+Status: DRAFT — awaiting approval of the plan as a whole. The three decisions
+that were open at first review have been answered and are now settled:
+`DEC-009` (scope) is approved, `DEC-013` (manual applicability for the first
+release) is approved, and `DEC-014` resolves to a single lint name.
 
 ## Purpose / big picture
 
@@ -222,13 +223,17 @@ Hard invariants. Violating one requires escalation, not a workaround.
 - [x] (2026-08-21) First draft written.
 - [x] (2026-08-21) Six-lens design review completed; fourteen further findings
       recorded in §Surprises & discoveries and eight decisions revised.
-- [ ] Plan approved, and `DEC-009`, `DEC-013`, `DEC-014` answered.
+- [x] (2026-08-21) `DEC-009`, `DEC-013`, and `DEC-014` answered by the
+      repository owner; the feature moved from roadmap item 2.2.10 to its own
+      step, §2.4 String continuation style, and the branch, this file, and the
+      pull request renamed to match.
+- [ ] Plan approved as a whole.
 - [ ] EP-M0a: expansion-shape probe.
 - [ ] EP-M1: pure domain crate.
 - [ ] EP-M2: plain cooked string literals.
 - [ ] EP-M3: source-authored format strings from compiler built-ins.
 - [ ] EP-M5: suite, installer, tooling, and documentation integration.
-- [ ] Roadmap item 2.2.10 marked done.
+- [ ] Roadmap item 2.4.1 marked done.
 
 ## Surprises & discoveries
 
@@ -513,8 +518,8 @@ Note that this is the `rustc-src` component, not the `rust-src` component at
   Add `googletest` and `pretty_assertions` to `[workspace.dependencies]`; the
   task brief authorizes both and neither is present. Promote `serial_test`
   from four identical per-crate `4.0.1` pins to a workspace pin and migrate
-  all four crates. Add `log` and `tracing` as dev-dependency edges only if
-  `DEC-009` is declined; both are already workspace-pinned.
+  all four crates. `log` and `tracing` dev-dependency edges are not needed:
+  `DEC-009` moved the facades to roadmap item 2.4.2.
   Date/Author: 2026-08-21, planning agent.
 
 - **DEC-007: WITHDRAWN.** The first draft proposed adding
@@ -529,28 +534,29 @@ Note that this is the `rustc-src` component, not the `rust-src` component at
 - **DEC-008: SUPERSEDED by `DEC-009`.** The first draft proposed rejecting
   `log`'s `logger:` control. `DEC-009` removes the `log` allowlist entirely.
 
-- **DEC-009: Move `log` and `tracing` support out of this roadmap item.
-  REQUIRES APPROVAL.**
-  Recommendation: cut them, and cut them by construction (which `DEC-002`
-  already does), not by deferral.
-  For: `docs/roadmap.md:81` scopes 2.2.10 as "source-preserving `concat!()`
-  suggestions, format-capture and literal-context exemptions, localized
-  diagnostics, and suite integration" — it does not mention either crate. They
-  are the sole driver of the whole `TyCtxt` question. The allowlist is a policy
-  table over third-party macro grammars that change between versions, and
-  `SURP-010` shows RFC 0002's is already stale. `SURP-015` shows the fixtures
-  cannot all live in one crate anyway. They account for 14 of roughly 34
-  fixtures on a serialized test path.
-  Against: in service codebases long strings disproportionately live in log
-  messages, which is where the reviewers' hand-application that motivates this
-  work actually happens. RFC 0002 §Rollout step 3's payoff is estate-wide
-  machine fixes, and logging is where the volume is. Cutting requires amending
-  the RFC, not annotating it.
-  If approved: file roadmap item 2.2.11 for the facade allowlist, to be
-  designed against a shipped baseline. If declined: reinstate `EP-M4` from the
-  first draft, restore the `EP-M0` spike to its blocking position, and expect
-  the `Tolerances` scope and wall-clock figures to need roughly doubling.
-  Date/Author: 2026-08-21, planning agent. **Approver's call.**
+- **DEC-009: Move `log` and `tracing` support out of this item. APPROVED.**
+  The facades are cut by construction — `DEC-002`'s outermost-frame check
+  produces silence for them — rather than by deferral, so nobody ships half an
+  allowlist.
+  Rationale: the roadmap text for this work never mentioned either crate. They
+  were the sole driver of the whole `TyCtxt` question. The allowlist is a
+  policy table over third-party macro grammars that change between versions,
+  and `SURP-010` shows RFC 0002's was already stale roughly a year after it was
+  written. `SURP-015` shows their fixtures cannot all live in one crate anyway,
+  because Cargo unifies dev-dependency features. They accounted for 14 of
+  roughly 34 fixtures on a serialized test path.
+  Accepted cost: in service codebases long strings disproportionately live in
+  log messages, which is exactly where the hand-application this work replaces
+  actually happens. Coverage there is deferred, not abandoned.
+  Consequence: the approver directed that the whole feature move out of
+  §2.2 Core lint implementations into its own roadmap step rather than
+  overburdening that step. `docs/roadmap.md` now carries §2.4 String
+  continuation style with three tasks: 2.4.1 (this plan), 2.4.2 (the facade
+  allowlist, to be designed against a shipped baseline), and 2.4.3 (`DEC-013`'s
+  promotion to machine applicability). The branch, this file, and the pull
+  request were renamed to match.
+  Date/Author: 2026-08-21, planning agent; approved 2026-08-21 by the
+  repository owner.
 
 - **DEC-010: Put the pure domain in its own plain-library crate.**
   Create `crates/whitaker_string_literals/` as an ordinary `rlib` with no
@@ -601,11 +607,11 @@ Note that this is the `rustc-src` component, not the `rust-src` component at
   Date/Author: 2026-08-21, planning agent.
 
 - **DEC-013: Ship a configuration table, defaulting to manual applicability.
-  REQUIRES APPROVAL.**
+  APPROVED.**
   RFC 0002 says "No configuration section is proposed. The proof predicate is
   the configuration." For a warn-level style lint that is defensible; for a
   lint that writes to source files it is the wrong instinct for release one.
-  Proposal: a `[string_continuation_style]` table in `dylint.toml` with
+  Adopted: a `[string_continuation_style]` table in `dylint.toml` with
   `applicability = "manual" | "machine"` defaulting to `"manual"`, plus
   `excluded_crates` and `excluded_paths` mirroring `no_std_fs_operations`'s
   shape exactly. Under `"manual"` the diagnostic still prints the full
@@ -618,23 +624,31 @@ Note that this is the `rustc-src` component, not the `rust-src` component at
   motivating case is a build script writing `$OUT_DIR/protocol.rs`, included
   with `include!`: the user cannot annotate a file they do not write, and a
   fix would rewrite a file the next build deletes.
-  Date/Author: 2026-08-21, planning agent. **Approver's call.**
+  Consequence: promoting the default from `"manual"` to `"machine"` is
+  deliberately *not* in this plan's scope. It is roadmap item 2.4.3, gated on
+  field evidence from an apply-and-recompile pass over the estate. This plan
+  builds the machinery that makes that evidence collectable — the
+  `// run-rustfix` fixtures of `SURP-014` and the run-time value gate of
+  `LEM-EMIT-1` — and stops there.
+  Date/Author: 2026-08-21, planning agent; approved 2026-08-21 by the
+  repository owner.
 
-- **DEC-014: One lint name or two. REQUIRES APPROVAL.**
-  The plan of record ships one lint, `string_continuation_style`, covering
-  both branches — this is what RFC 0002 and the roadmap describe.
-  The review's alternative: two lint names,
-  `string_continuation_style` (plain literals) and
-  `format_string_continuation_style` (format strings), declared and driven by
-  the same single `EarlyLintPass` in the same crate. Users get `#[allow]`
-  granularity between a high-confidence branch and a lower-confidence one; the
-  format branch can ship at `Allow` and be promoted independently; `EP-M3`'s
-  recovery becomes a change users can make themselves. Cost: one extra Fluent
-  file per locale, one extra `SUITE_LINTS`/`SUITE_LINT_DECLS` pair, one extra
-  users-guide subsection. Two *crates* would be the wrong cut and is not
-  proposed.
-  Default if unanswered: one name.
-  Date/Author: 2026-08-21, planning agent. **Approver's call.**
+- **DEC-014: One lint name. SETTLED.**
+  Ship a single lint, `string_continuation_style`, covering both the
+  plain-literal and format-string branches, as RFC 0002 and the roadmap
+  describe.
+  Rationale, from the approver: a user does not care about the internal split
+  between the two branches unless their semantics are fundamentally different,
+  and here they are not — both say "this source-line join could be a
+  `concat!()`". The review's alternative of a second
+  `format_string_continuation_style` name would have bought `#[allow]`
+  granularity between a high-confidence and a lower-confidence branch, at the
+  cost of exposing an implementation boundary in the user-facing lint list.
+  With `DEC-013`'s configuration table providing a kill switch and `DEC-002`
+  making the format branch no riskier than the plain one, that granularity has
+  no remaining user to serve.
+  Date/Author: 2026-08-21, planning agent; settled 2026-08-21 by the
+  repository owner.
 
 - **DEC-015: Order the adapter's checks cheapest-first, normatively.**
   RFC 0002 §Ordinary string expressions puts `span_to_snippet` and a re-lex at
@@ -913,26 +927,29 @@ Upstream artefacts, at the revisions current on this branch (based on
 
 - **RFC-0002** — `docs/rfcs/0002-string-continuation-style.md`, status
   *Proposed*. The design of record, with the defects recorded above.
-- **ROADMAP-2.2.10** — `docs/roadmap.md` line 81. Depends on ROADMAP-2.1.1
-  (lint crate template, done) and ROADMAP-2.3.4 (locale selection, done).
+- **ROADMAP-2.4.1** — `docs/roadmap.md` §2.4 String continuation style, first
+  task. Depends on ROADMAP-2.1.1 (lint crate template, done) and ROADMAP-2.3.4
+  (locale selection, done). Its sibling tasks 2.4.2 (the `log` and `tracing`
+  facade allowlist) and 2.4.3 (promotion to machine applicability) are
+  explicitly out of scope here and depend on this one.
 - **SUITE-DESIGN** — `docs/whitaker-dylint-suite-design.md`.
 - **AGENTS** — `AGENTS.md`.
 - **STYLE** — `docs/documentation-style-guide.md`.
 
-There is no Terms of Reference document; ROADMAP-2.2.10 plus RFC-0002 serve
+There is no Terms of Reference document; ROADMAP-2.4.1 plus RFC-0002 serve
 that role.
 
 Trace links:
 
 ```plaintext
-ROADMAP-2.2.10 -> RFC-0002 §Continuation scanner -> EP-M1 -> INV-SCAN-1 -> crates/whitaker_string_literals/src/continuation/tests.rs
-ROADMAP-2.2.10 -> RFC-0002 §Rewrite construction -> EP-M1 -> LEM-REWRITE-1 -> verus/string_continuation_rewrite.rs
-ROADMAP-2.2.10 -> SURP-012 -> EP-M2 -> LEM-DEPTH-1 -> crates/string_continuation_style/ui/pass_literal_macro_capture.rs
-ROADMAP-2.2.10 -> RFC-0002 §Ordinary string expressions -> EP-M2 -> crates/string_continuation_style/ui/fail_plain_join.rs
-ROADMAP-2.2.10 -> Constraints §evaluated-value -> EP-M2 -> LEM-EMIT-1 -> crates/string_continuation_style/ui/fail_value_preserved.fixed
-ROADMAP-2.2.10 -> RFC-0002 §Why the motivating example passes -> EP-M3 -> crates/string_continuation_style/ui/pass_implicit_format_capture.rs
-ROADMAP-2.2.10 -> RFC-0002 §Suite integration -> EP-M5 -> suite/tests/registration.rs::then_early_pass_registered
-ROADMAP-2.2.10 -> AGENTS §Documentation maintenance -> EP-M5 -> docs/users-guide.md §string_continuation_style
+ROADMAP-2.4.1 -> RFC-0002 §Continuation scanner -> EP-M1 -> INV-SCAN-1 -> crates/whitaker_string_literals/src/continuation/tests.rs
+ROADMAP-2.4.1 -> RFC-0002 §Rewrite construction -> EP-M1 -> LEM-REWRITE-1 -> verus/string_continuation_rewrite.rs
+ROADMAP-2.4.1 -> SURP-012 -> EP-M2 -> LEM-DEPTH-1 -> crates/string_continuation_style/ui/pass_literal_macro_capture.rs
+ROADMAP-2.4.1 -> RFC-0002 §Ordinary string expressions -> EP-M2 -> crates/string_continuation_style/ui/fail_plain_join.rs
+ROADMAP-2.4.1 -> Constraints §evaluated-value -> EP-M2 -> LEM-EMIT-1 -> crates/string_continuation_style/ui/fail_value_preserved.fixed
+ROADMAP-2.4.1 -> RFC-0002 §Why the motivating example passes -> EP-M3 -> crates/string_continuation_style/ui/pass_implicit_format_capture.rs
+ROADMAP-2.4.1 -> RFC-0002 §Suite integration -> EP-M5 -> suite/tests/registration.rs::then_early_pass_registered
+ROADMAP-2.4.1 -> AGENTS §Documentation maintenance -> EP-M5 -> docs/users-guide.md §string_continuation_style
 ```
 
 ## Verification plan
@@ -1229,17 +1246,21 @@ transcript in §Artefacts and notes, and revert it.
 ### Deliberately not verified formally
 
 Nothing in this plan's scope is a policy table over third-party macro
-grammars, because `DEC-002` removed the allowlist and `DEC-009` removes the
-facades. If `DEC-009` is declined, reinstate the first draft's note explaining
-why the allowlist gets fixtures rather than a proof.
+grammars: `DEC-002` removed the allowlist and `DEC-009` moved the facades to
+roadmap item 2.4.2. When 2.4.2 is planned it will need such a table, and it
+should record there — as the first draft of this plan did — why the allowlist
+gets acceptance fixtures rather than a proof: its correctness is a claim about
+third-party crates' macro definitions, which change between their versions,
+so the safe default of "an uncertain contract produces neither a diagnostic
+nor a suggestion" carries the guarantee instead.
 
 ## Plan of work
 
 ### Stage A — understand and propose (no code changes)
 
-Read RFC-0002 in full, then §Surprises & discoveries here. Confirm `DEC-009`,
-`DEC-013`, and `DEC-014` have been answered. Do not write code until this plan
-is approved.
+Read RFC-0002 in full, then §Surprises & discoveries here. `DEC-009`,
+`DEC-013`, and `DEC-014` are settled, so no decision blocks the work. Do not
+write code until this plan is approved as a whole.
 
 ### Stage B — red tests and the behaviour specification
 
@@ -1309,8 +1330,10 @@ lemma in the same commit as the code it constrains.
   depend on. No repository change except this plan's living sections.
 - **Method.** Three compiler flags, no code. On a scratch file outside the
   workspace containing `format!`, `println!`, `write!`, `assert!`, a
-  `macro_rules!` capturing `$l:literal`, a local `macro_rules! info`, and — if
-  `DEC-009` is declined — `log::info!` and `tracing::info!` with fields:
+  `macro_rules!` capturing `$l:literal`, and a local `macro_rules! info`.
+  Add `log::info!` and `tracing::info!` too: they are out of scope here, but
+  the probe is the cheapest place to gather the evidence roadmap item 2.4.2
+  will need, and recording it now costs one extra line per flag:
   - `cargo rustc -- -Zunpretty=expanded` — does each form reach the abstract
     syntax tree as a `format_args!` node?
   - `cargo rustc -- -Zunpretty=expanded,hygiene` — what syntax context does the
@@ -1437,7 +1460,7 @@ lemma in the same commit as the code it constrains.
   in continuous integration. Documentation is complete and the roadmap item is
   ticked.
 - **Requirements discharged.** RFC-0002 §Suite integration; AGENTS
-  §Documentation maintenance; ROADMAP-2.2.10; `DEC-011`, `DEC-012`.
+  §Documentation maintenance; ROADMAP-2.4.1; `DEC-011`, `DEC-012`.
 - **Acceptance evidence.** `EV-M5`: `suite/tests/registration.rs` passes,
   including a new `then_early_pass_registered` step that asserts *which* pass
   is registered, not merely how many — a count would also pass if the wrong
@@ -1459,7 +1482,7 @@ lemma in the same commit as the code it constrains.
 ## Concrete steps
 
 All commands run from the repository root on branch
-`2-2-10-string-continuation-style-post-expansion-early-lint.md`.
+`2-4-1-string-continuation-style-post-expansion-early-lint.md`.
 
 Log every gate run so truncated output can be reviewed:
 
@@ -1676,8 +1699,8 @@ Edit, in this order:
 18. `docs/repository-layout.md` — note the new pure-domain crate.
 19. `docs/rfcs/0002-string-continuation-style.md` — the substantive revision
     described in §Outcomes & retrospective; move status to *Accepted*.
-20. `docs/roadmap.md` — tick item 2.2.10, and add 2.2.11 if `DEC-009` is
-    approved.
+20. `docs/roadmap.md` — tick item 2.4.1. Items 2.4.2 and 2.4.3 already exist
+    and stay open.
 
 Then:
 

--- a/docs/rfcs/0002-string-continuation-style.md
+++ b/docs/rfcs/0002-string-continuation-style.md
@@ -6,9 +6,40 @@
 - **Status:** Proposed
 - **Repository:** `leynos/whitaker`
 - **Created:** 2026-07-26
+- **Revised:** 2026-08-21
 - **Proposed lint:** `string_continuation_style`
 - **Default level:** `Warn`
 - **Suite status:** Proposed for the standard suite after implementation
+
+## Revision history
+
+**2026-08-21.** Substantive revision, following validation of the original
+text against the pinned `nightly-2026-05-28` compiler sources and a six-lens
+design review. Two defects were corrected rather than annotated:
+
+1. **Root syntax context does not prove a literal is unwrapped.** The original
+   §Ordinary string expressions relied on `Span::ctxt().is_root()` to reject
+   literals arriving through a macro. A literal captured by a `$l:literal`
+   matcher reaches a post-expansion pass with a root context, so the rule as
+   written would have emitted a machine-applicable rewrite that does not
+   compile. §Wrapper depth replaces it.
+2. **The continuation whitespace rule was wrong.** The original
+   §Continuation scanner specified "spaces and tabs, plus complete LF or CRLF
+   sequences" and rejected a lone carriage return. Rust skips every byte in
+   `{space, tab, LF, CR}`, in any order. §Continuation scanner now states the
+   real rule.
+
+Six further findings changed the mechanics — the compiler already supplies the
+source-literal proof and the literal's span, so the format-string
+position-proving machinery is unnecessary; rustc normalizes CRLF out of source
+before lexing; and the `log` facade grammar had already drifted. Two decisions
+changed the shape of the delivery: the `log` and `tracing` allowlist is staged
+into a follow-up, and the lint ships with a configuration table whose default
+withholds unattended fixes.
+
+Each change is attributed at the point where it applies. The delivery plan is
+[ExecPlan 2.4.1](../execplans/2-4-1-string-continuation-style-post-expansion-early-lint.md);
+the status moves to *Accepted* when that plan is approved.
 
 ## Summary
 
@@ -85,7 +116,9 @@ A naive textual rule would be wrong in several important cases:
 - `b"..."` and `c"..."` literals have different types, and stable `concat!()`
   produces only `&'static str`;
 - macros with a `$literal:literal` contract require a literal token rather than
-  a general expression;
+  a general expression, and — the trap that is easiest to miss — a literal
+  substituted from such a matcher arrives with a *root* syntax context, so
+  hygiene alone does not reveal it (see §Wrapper depth);
 - a leading continuation immediately after the opening quote commonly trims
   the source layout's initial newline and indentation rather than joining two
   semantic fragments;
@@ -100,16 +133,19 @@ compiler badge.
 - Enforce `concat!()` for interior source-line joins in ordinary cooked string
   expressions.
 - Enforce the same rule in source-authored format strings when no argument is
-  implicitly captured and the originating macro accepts an expression in the
-  format-string position.
+  implicitly captured and the format string was supplied directly to a
+  compiler built-in formatting macro.
 - Retain escaped-newline continuations when direct-literal status, literal
   type, literal-token grammar, or layout trimming requires them.
-- Provide a whole-literal, machine-applicable suggestion whenever the proof
-  succeeds.
+- Provide a whole-literal suggestion whenever the proof succeeds, and prove at
+  emission time that it preserves the evaluated value.
 - Preserve the evaluated string byte for byte.
 - Catch multiple join continuations with one diagnostic and one replacement.
 - Work in the standalone lint crate and the aggregated Whitaker suite.
-- Localize the primary message, note, and help in `en-GB`, `cy`, and `gd`.
+- Localize the primary message, note, help, and per-join labels in `en-GB`,
+  `cy`, and `gd`.
+- Give users a way to disarm the fix and to exclude paths and crates, without
+  rebuilding the lint.
 
 ## Non-goals
 
@@ -117,9 +153,32 @@ compiler badge.
 - Rewriting actual newline characters embedded in a string.
 - Rewriting raw strings, which do not interpret continuation escapes.
 - Adding explicit format arguments to replace implicit captures.
-- Inspecting arbitrary macro token trees whose grammar Whitaker cannot prove.
+- Inspecting macro token trees. The original text qualified this with "whose
+  grammar Whitaker cannot prove" and then, in §Format strings, required
+  exactly such inspection to prove a literal's argument position. That
+  contradiction is resolved in favour of the non-goal: the compiler hands the
+  lint the format string's span directly, so there is no token tree to parse
+  and no argument index to count.
+- Identifying *which* macro produced a literal. The lint proves the literal's
+  position instead; see §Wrapper depth.
 - Reversing already-valid `concat!()` expressions into continuation escapes.
 - Acting as a general-purpose formatter.
+
+## Staging
+
+This RFC describes the whole rule. Delivery is staged, because the parts carry
+very different risk:
+
+1. **Plain cooked string expressions and compiler built-in formatting macros.**
+   The proof obligations are entirely local and the macro set is fixed by the
+   language. Suggestions ship at manual applicability.
+2. **The `log` and `tracing` facades.** These need a policy table over
+   third-party macro grammars that change between crate versions — as this RFC
+   itself demonstrated by going stale (see §Deferred: facade macros).
+3. **Machine applicability.** Promoted once field evidence from an
+   apply-and-recompile pass over real repositories supports it.
+
+Roadmap items 2.4.1, 2.4.2, and 2.4.3 respectively.
 
 ## Terminology
 
@@ -155,6 +214,36 @@ let text = "\
 A continuation for which replacing the literal expression with `concat!()` is
 not proven to preserve the relevant language or macro contract.
 
+### Wrapper depth
+
+The number of enclosing abstract-syntax-tree nodes whose span came from a
+macro expansion. Zero means nothing stands between the literal and the
+compiler, so replacing the literal with a general expression cannot break an
+enclosing macro's matcher.
+
+This replaces the original text's reliance on root syntax context, which does
+not carry that meaning. When `macro_rules!` substitutes a metavariable,
+`rustc_expand`'s `maybe_use_metavar_location` returns either the original
+token or one respanned with the call-site context; either way the substituted
+token keeps the call site's syntax context. So in
+
+```rust
+macro_rules! shout { ($l:literal) => { let _x = $l; } }
+shout!("alpha \
+        beta");
+```
+
+the literal reaches a post-expansion pass with `span.ctxt().is_root() == true`
+and a snippet that lexes as exactly one cooked string token. Every gate in the
+original §Ordinary string expressions passes, and a `concat!()` rewrite would
+stop the outer matcher matching.
+
+The *container* of the substituted literal does carry the macro definition's
+marked context, because `Marker::mark_span` applies to the transcribed
+structure rather than to tokens passed in from the call site. Tracking
+enclosing expansion-derived nodes is therefore the discriminator that root
+context is not.
+
 ## Rule semantics
 
 The implementation centres on a pure classification result:
@@ -171,26 +260,32 @@ pub(crate) enum RequiredReason {
     NonStringLiteralType,
     LeadingOrTrailingLayoutTrim,
     UnknownMacroContract,
-    GeneratedFormatString,
-    UnrecoverableSourceSpan,
+    GeneratedSourceFile,
 }
 ```
 
 Only `PreferConcat` emits a lint. The `RequireContinuation` variants exist to
 make the negative policy explicit and directly testable.
 
+Two variants from the original text are gone. `GeneratedFormatString` and
+`UnrecoverableSourceSpan` named situations the decision matrix routes to
+`Ignore`, so as `RequireContinuation` reasons they were unreachable — and two
+encodings of one outcome cannot be told apart end to end, because both produce
+silence. `GeneratedSourceFile` is new; see §Configuration.
+
 ### Decision matrix
 
 | Source situation                                                                     | Decision                                  | Rationale                                                                      |
 | ------------------------------------------------------------------------------------ | ----------------------------------------- | ------------------------------------------------------------------------------ |
-| Root-context cooked `str` expression with an interior join                           | Diagnose and suggest `concat!()`          | A general expression is valid and type/value are preserved                     |
+| Cooked `str` expression at wrapper depth zero with an interior join                  | Diagnose and suggest `concat!()`          | A general expression is valid and type and value are preserved                 |
 | Source-authored format string with positional or explicitly named arguments only     | Diagnose and suggest `concat!()`          | No implicit capture is lost                                                    |
 | Source-authored format string containing any `FormatArgumentKind::Captured` argument | Require continuation                      | `concat!()` would turn the format string into macro output and disable capture |
 | Cooked byte string or C string                                                       | Require continuation                      | `concat!()` changes the type or has no stable equivalent                       |
 | Raw string, raw byte string, or raw C string                                         | Ignore                                    | Continuation escapes are not interpreted                                       |
 | Leading or trailing layout trim                                                      | Require continuation                      | It expresses source layout rather than a fragment boundary                     |
-| Literal passed through an unknown `$literal` macro contract                          | Require continuation                      | Replacement may stop the outer macro matching                                  |
-| Format string generated by `concat!`, `include_str!`, or another eager macro         | Ignore                                    | There is no direct source literal to rewrite safely                            |
+| Literal at wrapper depth greater than zero                                           | Require continuation                      | An enclosing macro may have matched `$literal` (see §Wrapper depth)            |
+| Format string generated by `concat!`, `include_str!`, or another eager macro         | Ignore                                    | `is_source_literal` is false; there is no direct source literal to rewrite     |
+| Literal in a file outside the workspace root or under the target directory           | Require continuation                      | The user cannot annotate a file they do not write (see §Configuration)         |
 | Literal whose editable source span cannot be recovered exactly                       | Ignore                                    | No trustworthy suggestion range exists                                         |
 | Several interior joins in one eligible literal                                       | One diagnostic, one whole-literal rewrite | Avoid cascaded diagnostics and conflicting fixes                               |
 
@@ -238,12 +333,20 @@ This is the narrow sweet spot:
 - `FormatArgs::is_source_literal` tells the lint whether the format string was
   written directly rather than produced by `concat!()` or `include_str!()`;
 - ordinary source string expressions still appear as AST literal expressions;
-- High-level Intermediate Representation (HIR) lowering has not yet erased the
-  source spelling that distinguishes a continuation from an ordinary evaluated
-  string.
+- lowering to the High-level Intermediate Representation (HIR) has not yet
+  discarded `FormatArgs`, which is where the argument classification lives.
 
 Use `dylint_linting::impl_early_lint!`, not a late HIR pass and not a blind
 pre-expansion token scan.
+
+The original text justified rejecting a late pass by saying HIR "no longer
+retains the exact source spelling that distinguishes an escaped newline from an
+equivalent evaluated string". That is imprecise. The HIR node holds the
+*cooked* symbol, but its span still points at the source, so the spelling is
+recoverable at any phase with `span_to_snippet`. The real disqualifier is
+narrower and firmer: format arguments are lowered away, so a late pass cannot
+see `FormatArgs` at all, and therefore cannot distinguish a captured argument
+from an explicitly named one.
 
 ### AST entry points
 
@@ -261,83 +364,146 @@ The rule analyses expression literals and source-authored format arguments
 only. It does not visit or claim classification coverage for patterns,
 attributes, or meta-item literals.
 
+The pass additionally implements `check_item`, `check_item_post`,
+`check_stmt`, `check_expr_post`, and `check_mac_def`. The first four maintain
+wrapper depth; the last participates in the shadow check of §Macro position.
+None of them classifies a literal.
+
+### Check ordering
+
+Order the checks so that the cheapest run first. This is normative, not an
+optimization note. The original §Ordinary string expressions put snippet
+recovery and a re-lex at step 2, before anything had established the literal
+was even a candidate — a source-map binary search and a string allocation for
+every cooked literal in the crate, against a candidate rate that is very close
+to zero in practice. Worse, recovering a snippet from a foreign source file
+decodes an external crate's source out of crate metadata and retains it for
+the remainder of the compilation.
+
+1. The token is `token::LitKind::Str`. Touches no source map.
+2. The uncooked symbol contains a backslash followed by a line feed. Symbol
+   resolution is an interned lookup and the scan allocates nothing.
+3. Wrapper depth is zero and the span is not from an expansion.
+4. Only now recover the snippet and re-lex it.
+
+### What the compiler already proves
+
+Two properties the original text asked the lint to establish for itself are
+supplied by `rustc_ast::FormatArgs`, and establishing them again would be
+weaker, not stronger.
+
+`is_source_literal` is computed by comparing the recovered source snippet
+against the parsed input, and is `false` when a procedural macro has respanned
+the literal. That is the fix for rust-lang/rust#114865, and it discharges both
+"verify that its snippet lexes as one cooked string token" and "reject spans
+attributable only to an external or proc-macro expansion". The lint still
+re-lexes the snippet, but as defence in depth rather than as the primary proof.
+
+`FormatArgs::span` **is** the format-string literal token's span, including its
+quotes: the builtin macro sets it from the fully-expanded format-string
+expression. `Span::from_inner` maps a byte offset within that token to a source
+span. So the literal's location is handed to the lint directly.
+
+That second fact is what removes the argument-position machinery. There is no
+token tree to parse and no argument index to count, which is just as well,
+because parsing one contradicted §Non-goals.
+
+`uncooked_fmt_str` carries the raw source body between the quotes, and the
+`println!` family's appended newline goes onto the *cooked* symbol only, so the
+scanner's input needs no adjustment for it.
+
 ### Format strings
 
 For `ExprKind::FormatArgs`:
 
 1. Require `is_source_literal`.
-2. Require a cooked `LitKind::Str` uncooked format string.
-3. Recover an exact source literal span and verify that its snippet lexes as
-   one cooked string token.
-4. Reject spans attributable only to an external or proc-macro expansion.
-5. Resolve and validate the originating macro identity, variant, argument
-   grammar, and format-string position against the allowlist below.
-6. Scan the uncooked source for join continuations.
-7. If any argument is `Captured`, return
+2. Require a cooked `token::LitKind::Str` uncooked format string.
+3. Require wrapper depth zero.
+4. Require the macro position to be provable (§Macro position).
+5. Scan `uncooked_fmt_str` for join continuations.
+6. If any argument is `Captured`, return
    `RequireContinuation(ImplicitFormatCapture)`.
-8. Otherwise, build and emit the `concat!()` rewrite.
+7. Otherwise build the `concat!()` rewrite and emit it, subject to
+   §Applicability.
 
-Macro names are not identities. Walk the expansion backtrace to the macro
-definition, then require its resolved definition identifier, defining crate,
-and canonical definition path to match an entry below. Compiler built-ins use
-their stable diagnostic identity plus canonical `core`, `alloc`, or `std` macro
-path. A re-export is acceptable only when it resolves to that same definition.
-The initial allowlist is:
+### Macro position
 
-- `core::format_args!`, `alloc::format!`, and
-  `std::{print, println, eprint, eprintln}!`: accept only
-  `(format, arguments...)`; the format string is syntactic argument 0.
-- `std::{write, writeln}!`: accept only `(destination, format, arguments...)`;
-  the format string is syntactic argument 1.
-- `core::{panic, todo, unimplemented, unreachable}!`: accept only the modern
-  formatting branch represented by `ExprKind::FormatArgs`; the format string is
-  syntactic argument 0.
-- `core::{assert, debug_assert}!`: accept only the custom-message branch
-  `(condition, format, arguments...)`; the format string is syntactic argument
-  1.
-- `core::{assert_eq, assert_ne, debug_assert_eq, debug_assert_ne}!`: accept only
-  the custom-message branch `(left, right, format, arguments...)`; the format
-  string is syntactic argument 2.
-- `log::{trace, debug, info, warn, error}!`: accept `(format, arguments...)` and
-  `(target: target_expression, format, arguments...)`. The format string is the
-  first argument, or the first argument after the validated `target:` prefix.
-  Key-value and other facade variants are not initially supported.
-- `tracing::{trace, debug, info, warn, error}!`: accept a message tail after
-  zero or more validated controls and structured fields. Controls may be
-  `target: expression`, `parent: expression`, and `name: expression`, in the
-  combinations and order accepted by the resolved macro definition, with each
-  control present at most once. A field must use one of the documented tracing
-  forms `field = expression`, `field = ?expression`, `field = %expression`,
-  `?field`, or `%field`, followed by a comma. The format string is the first
-  cooked string literal after those controls and fields; the remaining tail
-  must parse as format arguments.
+The original text required the lint to prove a macro's *identity*: its
+"resolved definition identifier, defining crate, and canonical definition
+path". That is not obtainable in a post-expansion early pass, because
+`EarlyContext` holds no `TyCtxt` and a `DefId` cannot be resolved to a crate
+name without one.
 
-For every family, parse the source-authored token tree and prove that the
-selected literal occupies the stated position. Confirm that the recovered
-literal span is the same source literal retained in
-`FormatArgs::uncooked_fmt_str`, that separators and labelled prefixes match the
-family grammar, and that replacing only that expression leaves a valid macro
-invocation. A tracing invocation without a message literal, or any unlisted
-variant, is not a candidate.
+It is also more than the rule needs. The lint does not need to know which macro
+produced a literal. It needs to know whether anything stands between that
+literal and the compiler — and that is answerable locally. Three conditions,
+all biased towards silence:
 
-Skip local macros and unrelated external macros even when they use short names
-such as `info`, `warn`, `error`, `format`, or `println`. Also skip when the
-lint cannot prove the resolved identity, canonical path, format-string
-position, or complete argument grammar. An uncertain contract produces neither
-a diagnostic nor a suggestion.
+1. **Wrapper depth is zero.** Nothing enclosing the literal came from an
+   expansion, so no enclosing matcher can be broken. This is the condition that
+   closes the `$literal` hole described in §Wrapper depth, and it subsumes the
+   original decision-matrix row for unknown literal contracts.
+2. **The outermost non-root expansion frame is a known formatting macro.** Walk
+   the literal span's expansion chain to its outermost frame — the invocation
+   the user actually typed — and require it to be a bang macro whose name is in
+   this fixed set: `format_args`, `format`, `print`, `println`, `eprint`,
+   `eprintln`, `write`, `writeln`, `panic`, `todo`, `unimplemented`,
+   `unreachable`, `assert`, `debug_assert`, `assert_eq`, `assert_ne`,
+   `debug_assert_eq`, `debug_assert_ne`. These are language built-ins with no
+   macro-by-example matcher to break: `format_args!` parses an expression, and
+   `write!`/`writeln!` forward through `$($arg:tt)*`.
+3. **The crate does not shadow any of those names.** A bare name check is sound
+   only if the name cannot be shadowed. If the crate under compilation defines
+   a `macro_rules!` or `macro` with a name in the set, or contains a `use`
+   whose terminal segment is one, or a `#[macro_use] extern crate`, the lint
+   disables itself for that crate entirely.
+
+Condition 3 is blunt. It will occasionally silence the lint across a whole
+crate that had no real conflict, and its residual hole — a crate reaching a
+same-named macro by a path none of the three checks observes — fails silently
+rather than loudly. Both are the correct direction under a near-zero
+false-positive budget, but they mean the lint's real-world hit rate cannot be
+measured from inside the lint.
+
+### Deferred: facade macros
+
+The original allowlist also covered `log::{trace, debug, info, warn, error}!`
+and `tracing::{trace, debug, info, warn, error}!`. Under §Macro position those
+now produce silence by construction, because their invocation is not in the
+built-in set.
+
+That is deliberate, and staged rather than abandoned. Three reasons:
+
+- An allowlist over third-party macro grammars is a policy table that decays.
+  This RFC is the evidence: by `log` 0.4.33 the facade macros had grown a
+  `logger:` control that the text above does not mention, and their key-value
+  form is separated from the message by `;`, so the original grammar was
+  already incomplete roughly a year after it was written.
+- The two crates are the only reason the lint would need macro identity at all,
+  and therefore the only reason to reach for a `TyCtxt`.
+- Their acceptance fixtures cannot all live in one lint crate. `tracing`'s
+  behaviour differs with its `log` feature, and Cargo unifies dev-dependency
+  features across a crate's fixtures, so a fixture needing the feature on and
+  one needing it off cannot coexist.
+
+Facade support is roadmap item 2.4.2, to be designed against a shipped
+baseline. When it is, it will need the identity proof this section declines,
+and the design should say why an allowlist gets acceptance fixtures rather than
+a proof: its correctness is a claim about other people's macro definitions,
+which change between their versions, so the guarantee has to come from the safe
+default — an uncertain contract produces neither a diagnostic nor a suggestion.
 
 ### Ordinary string expressions
 
 For a direct cooked `str` expression:
 
-1. Require a user-editable source span in root syntax context.
+1. Require wrapper depth zero and a span that is not from an expansion.
+   The original text required "a user-editable source span in root syntax
+   context"; §Wrapper depth explains why that is not sufficient.
 2. Require that the source snippet lexes as exactly one cooked string literal.
 3. Scan for interior join continuations.
 4. Ignore literals containing only leading or trailing layout trims.
 5. Build a whole-literal `concat!()` rewrite.
-
-Source literals that originated inside an unknown macro expansion are skipped
-because the source macro may have matched `$literal:literal`.
 
 ## Continuation scanner
 
@@ -348,24 +514,46 @@ body range that excludes the opening and closing quotes. An unescaped closing
 (`\"`) and an escaped backslash (`\\`) remain body source content. Raw, byte,
 and C literals never reach this scanner.
 
-A continuation begins at an unescaped backslash immediately followed by either
-`\n` or `\r\n`. Count the run of consecutive backslashes to distinguish a
-continuation from a literal escaped backslash. An odd run leaves one
-continuation backslash; an even run does not.
+A continuation begins at an unescaped backslash immediately followed by a line
+feed. Count the run of consecutive backslashes to distinguish a continuation
+from a literal escaped backslash. An odd run leaves one continuation backslash;
+an even run does not.
 
 For each continuation, find the start of its physical line by scanning
-backwards to the preceding LF byte or the start of the literal body. The
+backwards to the preceding line feed or the start of the literal body. The
 pre-continuation side has content when that slice contains a byte other than
 horizontal space or tab. Escaped quotes and escaped backslashes count as
 content because their complete escape spelling lies in that slice.
 
-After the newline, consume exactly the source whitespace rustc removes: spaces
-and tabs, plus complete LF or CRLF sequences. Continue across whitespace-only
-and blank physical lines until reaching the first non-whitespace body byte or
-the closing quote that bounds the body. A lone CR is not a supported source
-newline; if exact recovery encounters one, classify the span as unrecoverable
-and do not emit a lint. Escaped quotes and escaped backslashes encountered
-after the consumed whitespace count as post-continuation content.
+### The whitespace rule
+
+After the newline, Rust discards **every byte in
+`{space, tab, line feed, carriage return}`, in any order, until the first byte
+outside that set** — with the single exception of the formfeed character, which
+is not skipped (rust-lang/rust#136600). Consume exactly that.
+
+This corrects the original text, which said "spaces and tabs, plus complete LF
+or CRLF sequences" and directed the lint to treat a lone carriage return as
+making the span unrecoverable. Neither `rustc-literal-escaper` nor
+`rustc_lexer` gives carriage returns or CRLF pairs any special status; both
+implement the rule as a single "skip while the byte is in this set" scan. A
+scanner verified against the original wording would have been verified against
+the wrong language rule.
+
+Two consequences follow.
+
+Scanning continues across whitespace-only and blank physical lines until it
+reaches the first non-whitespace body byte or the closing quote that bounds the
+body. Escaped quotes and escaped backslashes encountered after the consumed
+whitespace count as post-continuation content.
+
+And carriage returns cannot in fact reach the scanner from the compiler, so the
+handling above is a completeness property of the scanner rather than a
+reachable path. rustc normalizes newlines when it loads a source file, so every
+literal symbol and every recovered snippet contains line feeds only. Keep the
+scanner's contract complete anyway — it is a pure, reusable component and the
+cost is negligible — but do not claim compiler-level coverage for it, and do
+not write a user-interface fixture that pretends to exercise it.
 
 The scanner records:
 
@@ -391,10 +579,10 @@ the closing quote without content, classify it as `TrailingLayoutTrim`. When
 both sides lack content, `LeadingLayoutTrim` takes precedence.
 
 Here, post-continuation "content" means any byte in the bounded cooked-literal
-body other than horizontal space, LF, or a complete CRLF sequence. The closing
-quote is outside the body and terminates the search. Scanning does not stop at
-a blank line: blank lines are part of `skipped_whitespace_range`, and a later
-escaped or ordinary byte can still make the continuation a `Join`.
+body outside `{space, tab, line feed, carriage return}`. The closing quote is
+outside the body and terminates the search. Scanning does not stop at a blank
+line: blank lines are part of `skipped_whitespace_range`, and a later escaped
+or ordinary byte can still make the continuation a `Join`.
 
 | Source shape after a line containing content           | Classification       | Reason                                    |
 | ------------------------------------------------------ | -------------------- | ----------------------------------------- |
@@ -454,20 +642,57 @@ Since a continuation contributes no evaluated character and split points never
 bisect another escape, separately decoding the copied fragments produces the
 same value as decoding the original literal.
 
+That is an argument, and arguments about byte offsets are exactly the kind that
+survive review and fail in the field. §Emission gate turns it into a check.
+
+### Layout of the replacement
+
+The replacement is inserted verbatim into the user's file, so its own layout
+matters.
+
+Prefer a single line — `concat!("alpha ", "beta")` — when it fits within the
+formatter's width. Otherwise emit the indented multi-line form, indented to the
+original literal's column. A replacement that ignores the column will fail
+`cargo fmt --check` after every fix run, which for an estate-wide rollout means
+every fixed repository needs a follow-up formatting commit.
+
+Emit the source file's dominant line ending, not an unconditional line feed.
+Writing line feeds into a checkout with carriage-return line endings produces
+mixed endings inside the hunk, which shows up as a whole-region diff and fights
+any `.gitattributes` policy.
+
 ### Applicability
 
-Use `Applicability::MachineApplicable` only when all of the following hold:
+Emit a suggestion only when all of the following hold:
 
 - the source span is exact and user-editable;
 - the snippet is exactly one cooked string literal;
 - every selected split is an interior join;
 - the context accepts a general expression;
 - a format string has no implicit captures;
-- the root macro contract is known safe;
-- the generated replacement re-lexes as one `concat!()` expression.
+- the macro position is provable (§Macro position);
+- the generated replacement re-lexes as one `concat!()` expression;
+- the emission gate below passes.
 
 Otherwise, suppress the lint rather than emit an unfixable style complaint.
 This rule should have near-zero false-positive tolerance.
+
+Whether a passing suggestion is labelled `MachineApplicable` or
+`MaybeIncorrect` is a configuration decision, not a property of the rewrite;
+see §Configuration.
+
+### Emission gate
+
+Before attaching any applicability above `MaybeIncorrect`, unescape the
+recovered original snippet and the generated replacement's fragments, and
+compare the resulting byte sequences. On mismatch, emit nothing.
+
+This is cheap — the check ordering in §Check ordering has already eliminated
+almost every literal before this point — and it is the difference between a
+span-arithmetic bug corrupting a user's source and the same bug producing
+silence. It catches failures no test anticipated, including ones in the
+offset-to-span conversion that the pure rewriter's own verification cannot
+reach.
 
 ## Diagnostic
 
@@ -506,67 +731,94 @@ labels on each continuation.
 
 ## Crate layout
 
-Add:
+Two crates, not one. The original text put everything in a single `cdylib`
+lint crate; splitting the pure logic out buys five things at once.
 
 ```plaintext
-crates/string_continuation_style/
+crates/whitaker_string_literals/     # plain rlib, no rustc dependency
 ├── Cargo.toml
 ├── src/
 │   ├── lib.rs
-│   ├── classification.rs
-│   ├── continuation.rs
+│   ├── facts.rs
+│   ├── continuation/                # scanner, plus its Kani harness
+│   ├── classification/              # the policy
+│   └── rewrite/                     # fragments and the applicability gate
+└── tests/features/string_continuation.feature
+
+crates/string_continuation_style/    # thin cdylib adapter
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
 │   ├── diagnostics.rs
-│   ├── driver.rs
-│   └── rewrite.rs
-├── tests/
-│   └── features/
-│       └── string_continuation_style.feature
-├── ui/
-│   ├── fail_plain_join.rs
-│   ├── fail_plain_join.stderr
-│   ├── fail_explicit_format_arguments.rs
-│   ├── fail_explicit_format_arguments.stderr
-│   ├── fail_multiple_joins.rs
-│   ├── fail_multiple_joins.stderr
-│   ├── fail_log_message.rs
-│   ├── fail_log_target.rs
-│   ├── fail_tracing_fields.rs
-│   ├── fail_tracing_controls.rs
-│   ├── pass_implicit_format_capture.rs
-│   ├── pass_implicit_width_capture.rs
-│   ├── pass_leading_layout_trim.rs
-│   ├── pass_byte_and_c_strings.rs
-│   ├── pass_unknown_literal_macro.rs
-│   ├── pass_local_macro_lookalikes.rs
-│   ├── pass_external_macro_lookalikes.rs
-│   ├── pass_log_implicit_capture.rs
-│   ├── pass_log_target_implicit_capture.rs
-│   ├── pass_tracing_implicit_capture.rs
-│   ├── pass_tracing_controls_implicit_capture.rs
-│   └── pass_generated_format_string.rs
-├── ui-cy/
-│   └── locale_smoke.rs
-└── ui-gd/
-    └── locale_smoke.rs
+│   └── driver/                      # pass, wrapper depth, facts, spans
+├── ui/    ui-cy/    ui-gd/    ui-fallback/
 ```
+
+The reasons, in order of weight:
+
+- **Bounded model checking works.** No Kani harness in this repository has ever
+  run inside a `cdylib` lint crate; `whitaker_clones_core` demonstrates that it
+  works in a plain one.
+- **Deductive proofs can bridge to production source.** The existing Verus
+  proofs include production modules by path, which requires a crate Verus can
+  read without `rustc_private` plumbing.
+- **The module-size ceiling becomes enforceable.** `make lint-whitaker` runs
+  the suite over ordinary library crates only, because `cargo dylint`'s check
+  build cannot supply `rustc_private` plumbing for a lint crate. A plain crate
+  can be added to that list, so the 400-line limit is gate-enforced for the
+  domain rather than merely asserted.
+- **Doctests run.** Lint crates are excluded from the doctest pass for the same
+  linking reason, so a runnable example on a pure function is only actually run
+  if it lives outside the `cdylib`.
+- **Domain purity is structural.** A crate with no rustc dependency cannot
+  acquire one by accident, which no `--all-features` gate would otherwise
+  notice.
 
 Keep each source module below Whitaker's 400-line limit.
 
 ### Dependencies
 
-The lint crate needs only:
+The domain crate needs only `rustc_lexer` — the crates.io mirror, already a
+workspace dependency, pure, and carrying the unescaper the emission gate needs
+and the lexer the applicability gate needs.
+
+The lint crate needs:
 
 - `dylint_linting`;
-- `rustc_ast`;
-- `rustc_lint`;
-- `rustc_session`;
-- `rustc_span`;
+- `rustc_ast`, `rustc_lint`, `rustc_session`, `rustc_span`;
 - `whitaker-common`;
 - `whitaker` for shared driver wiring;
-- `proptest`, `rstest`, `rstest-bdd`, `rstest-bdd-macros`, and
-  `dylint_testing` as development dependencies.
+- `whitaker_string_literals`.
 
-No configuration section is proposed. The proof predicate is the configuration.
+Development dependencies for the two crates between them: `proptest`, `rstest`,
+`rstest-bdd`, `rstest-bdd-macros`, `insta`, `googletest`, `pretty_assertions`,
+`serial_test`, and `dylint_testing`.
+
+## Configuration
+
+The original text said: "No configuration section is proposed. The proof
+predicate is the configuration." For a warn-level style lint that is a
+defensible position. For a lint that writes to source files it is the wrong
+instinct for a first release, and every lint in this suite that shipped without
+configuration has later grown it under pressure — which is the worst time to
+design it.
+
+A `[string_continuation_style]` table in `dylint.toml`:
+
+- `applicability = "manual" | "machine"`, defaulting to `"manual"`. Under
+  `"manual"` the diagnostic still prints the whole replacement; only the
+  unattended write is disarmed. Flipping one line arms the fixer estate-wide,
+  with no rebuild, once the apply-and-recompile evidence supports it.
+- `excluded_crates` and `excluded_paths`, mirroring `no_std_fs_operations`'s
+  shape exactly so the estate does not have to learn a second idiom.
+
+Independently of any setting, skip a literal whose source file lies outside the
+workspace root or beneath the target directory, returning
+`RequireContinuation(GeneratedSourceFile)`. The motivating case is a build
+script writing into `OUT_DIR` and a source file pulling it in with `include!`:
+the finding is correct by the lint's own rules, but the user cannot annotate a
+file they do not write, the warning recurs on every build, and a fix would
+rewrite a file the next build deletes.
 
 ## Suite integration
 
@@ -589,15 +841,26 @@ pub fn register_suite_lints(store: &mut LintStore) {
 Do not force an early lint into the combined late-pass macro merely for visual
 uniformity.
 
+Assert *which* pass was registered, not how many. A late pass omitted from the
+combined macro is a compile error; a missing `register_early_pass` line is not.
+Delete it and the suite still declares the lint, still passes the descriptor
+alignment tests, and still lists the lint — while never firing.
+
 Update:
 
 - `suite/Cargo.toml` feature and dependency lists;
 - `suite/src/lints.rs` descriptors and declarations;
-- suite count and name tests;
-- installer lint enumeration, if it is not derived from suite metadata;
-- `README.md` and `docs/users-guide.md`;
-- `docs/roadmap.md`, adding this as the next core lint item;
-- Fluent resources under `common/locales/{en-GB,cy,gd}`.
+- suite count and name tests, plus a new early-pass registration assertion;
+- installer lint enumeration, if it is not derived from suite metadata. It is
+  not: two separate lists must be kept in step, one in the installer and one in
+  the Makefile;
+- `README.md` and `docs/users-guide.md`, the latter documenting the
+  configuration table of §Configuration;
+- `docs/roadmap.md` §2.4 String continuation style;
+- Fluent resources under `common/locales/{en-GB,cy,gd}`, and the locale
+  completeness test, which today checks only the `help` attribute. A missing
+  label translation would otherwise render English, be captured into a
+  non-English expectation file, and be enforced from then on.
 
 ## Test plan
 
@@ -633,16 +896,43 @@ Update:
 
 4. **Multiple joins** produce one diagnostic and one replacement.
 5. **Join consuming blank source lines** preserves the exact evaluated value.
-6. **Known standard formatting facade** such as `println!` receives a valid
-   suggestion.
-7. **Supported `log` facade forms** cover both `info!(format, arguments...)`
-   and `warn!(target: target_expression, format, arguments...)`.
-8. **Supported `tracing` facade forms** cover message-only calls, structured
-   fields, and valid combinations of `target`, `parent`, and `name` controls.
-   Each fixture proves the format-string position before expecting a
-   machine-applicable suggestion.
+6. **Known standard formatting facades** such as `println!`, `write!`, and the
+   custom-message branch of `assert!` receive a valid suggestion.
+7. **A literal with both a leading layout trim and an interior join**, and
+   **a literal with two adjacent continuations**, both rewrite correctly and
+   converge.
+
+The `log` and `tracing` fixtures from the original text move to roadmap item
+2.4.2 along with the facade support itself.
+
+### Applying the fix is part of the test, not a separate exercise
+
+Every failing fixture carries a `// run-rustfix` header and a checked-in
+`.fixed` file. The harness then applies the suggestion, diffs the result
+against the `.fixed` file, **recompiles it**, and fails if it either does not
+compile or still produces diagnostics.
+
+Three obligations fall out of that at no extra cost. The suggestion is proved
+to apply. The result is proved to compile. And the rewrite is proved to be a
+fixed point, which matters because `cargo fix` re-runs the lint up to four
+rounds and reports an error blaming the user's code if it does not converge.
+
+Better still, because the fixed code is compiled, a compile-time assertion
+inside the `.fixed` file makes **the compiler itself** adjudicate value
+preservation:
+
+```rust
+const _: () = assert!(matches!(ORIGINAL.as_bytes(), REWRITTEN_BYTES));
+```
+
+That is a stronger oracle than any reference unescaper the implementation could
+carry, because it shares no lineage with the scanner under test.
 
 ### UI passes
+
+Each of these asserts silence, so each needs a paired control that inverts the
+one gate it exercises and confirms the fixture then fires. A silence fixture
+without a control passes against an unimplemented lint and proves nothing.
 
 1. **The exact PR #296 example with implicit `status_line` capture.**
 2. Captured width and precision parameters.
@@ -651,41 +941,66 @@ Update:
 5. Byte strings and C strings.
 6. Raw strings.
 7. A local macro declared with `$message:literal` and forwarding to
-   `format_args!`.
-8. Local short-name lookalikes for `format`, `println`, `info`, `warn`, and
-   `error`.
-9. Same-name macros from external crates other than the approved `log` and
-   `tracing` definitions.
-10. Supported `log` forms, with and without `target`, whose format strings use
-    implicit capture and must remain direct literals.
-11. Supported `tracing` forms whose format strings use implicit capture,
-    including structured fields and applicable `target`, `parent`, and `name`
-    controls.
-12. Unlisted `log` or `tracing` variants and any invocation whose macro
-    identity, format-string position, or complete argument grammar is uncertain.
-    Assert both that no diagnostic is emitted and that no suggestion is
-    produced.
-13. A format string generated by `concat!()` or `include_str!()`.
-14. Proc-macro-generated or unrecoverable spans.
-15. An ordinary literal containing a real newline rather than a continuation.
+   `format_args!`. This is the §Wrapper depth fixture, and its control —
+   disabling the depth counter — is the one that proves the whole silence class
+   is not vacuous.
+8. A literal inside an expanded item, an expanded statement, a derive-generated
+   implementation, and a two-level nested expansion.
+9. A crate that defines its own `println!`, which must disable the lint
+   entirely (§Macro position, condition 3).
+10. A format string generated by `concat!()` or `include_str!()`.
+11. Procedural-macro-generated or unrecoverable spans.
+12. An ordinary literal containing a real newline rather than a continuation.
+13. A literal in a generated file beneath the target directory.
+14. A literal in a pattern position, which the pass must not visit at all.
 
 ### Pure unit and property tests
 
-- Classify odd and even runs of backslashes before line feed (LF) and carriage
-  return plus line feed (CRLF).
+- Classify odd and even runs of backslashes before a line feed.
 - Classify leading, interior, and trailing continuations.
+- Exercise the full whitespace set — space, tab, line feed, carriage return, in
+  mixed order — against the rule in §The whitespace rule. Carriage returns
+  cannot arrive from the compiler, so this is the only place that path is
+  covered, and the test plan should say so rather than implying otherwise.
 - Assert that splitting and re-concatenating copied fragment source equals
   deleting the union of `escape_range` and `skipped_whitespace_range` for every
-  selected join.
+  selected join. This is also the subject of a deductive proof over sequences,
+  inducting on the *last* range rather than the first, so that no index-rebasing
+  lemma is needed.
 - Generate arbitrary safe fragment text and one to several continuation joins
   with `proptest`. Generate non-empty indentation after each newline and assert
   the union semantics explicitly, so retaining only that indentation while
   deleting `escape_range` fails the property.
-- Verify Unicode before and after split points.
+- Verify Unicode before and after split points, including scalars above the
+  basic multilingual plane, and classify generated cases so that a generator
+  which stopped producing them fails loudly.
 - Verify escaped quotes, escaped braces, and ordinary Rust escapes remain
   unchanged.
 - Verify one diagnostic is produced for any positive number of joins in one
   literal.
+- Exhaustively explore the scanner over short symbolic inputs with a bounded
+  model checker, using a fixed-capacity sink rather than a growable vector and
+  deriving the unwind bound from that capacity. State the alphabet the bound
+  excludes; "exhaustive over short inputs" is only true of the alphabet
+  actually explored.
+
+### Adapter tests
+
+The pure half is where the proofs live, and the adapter is where the byte
+offsets live. Do not let the first fact aim the testing effort away from the
+second.
+
+- In-process tests for the body-offset to source-span conversion, driven
+  directly rather than only through rendered diagnostics. A blessed expectation
+  cannot falsify the code that produced it.
+- In-process tests for wrapper-depth accounting across every enclosing node
+  kind the pass visits.
+- In-process tests feeding the emission gate a deliberately corrupted rewrite
+  and asserting silence.
+
+These also keep the adapter out of the zero-coverage trap: it compiles into the
+instrumented test binary but only ever executes inside a separate compiler
+subprocess, so without in-process tests it reports as entirely uncovered.
 
 ### Behaviour scenarios
 
@@ -712,21 +1027,26 @@ Feature: Context-sensitive string continuation style
 
 ## Acceptance fixtures
 
-### Macro identity and grammar fixtures
+### Macro position fixtures
 
-| Fixture                                     | Expected result                                                                            |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `fail_log_message.rs`                       | `log::info!` message join receives one machine-applicable suggestion                       |
-| `fail_log_target.rs`                        | `log::warn!(target: ..., ...)` message join receives one machine-applicable suggestion     |
-| `pass_log_implicit_capture.rs`              | Supported `log` message with capture receives no diagnostic or suggestion                  |
-| `pass_log_target_implicit_capture.rs`       | Supported targeted `log` message with capture receives no diagnostic or suggestion         |
-| `fail_tracing_fields.rs`                    | `tracing::info!` fields plus message receive one machine-applicable suggestion             |
-| `fail_tracing_controls.rs`                  | Valid controls preserve the message position and receive one machine-applicable suggestion |
-| `pass_tracing_implicit_capture.rs`          | Supported tracing message with capture receives no diagnostic or suggestion                |
-| `pass_tracing_controls_implicit_capture.rs` | Supported controlled tracing message with capture receives no diagnostic or suggestion     |
-| `pass_local_macro_lookalikes.rs`            | Local short-name macros receive no diagnostic or suggestion                                |
-| `pass_external_macro_lookalikes.rs`         | Unapproved same-name external macros receive no diagnostic or suggestion                   |
-| `pass_unknown_literal_macro.rs`             | Uncertain identity or grammar receives no diagnostic or suggestion                         |
+The original text listed eleven fixtures over `log` and `tracing` grammars.
+Those move to roadmap item 2.4.2 with the facade support. What replaces them
+is one fixture per way the position proof of §Macro position can fail —
+a shorter list, and one that does not decay when a third-party crate ships a
+new macro arm.
+
+| Fixture                           | Expected result                                                                        |
+| --------------------------------- | -------------------------------------------------------------------------------------- |
+| `pass_literal_macro_capture.rs`   | A `$l:literal` matcher substituting a joined literal receives no diagnostic            |
+| `pass_expanded_item.rs`           | A joined literal inside an expanded item receives no diagnostic                        |
+| `pass_expanded_stmt.rs`           | A joined literal inside an expanded statement receives no diagnostic                   |
+| `pass_derive_generated.rs`        | A joined literal in derive output receives no diagnostic                               |
+| `pass_nested_expansion.rs`        | A joined literal two expansions deep receives no diagnostic                            |
+| `pass_local_macro_lookalikes.rs`  | A crate defining its own `println!` disables the lint for that crate                   |
+| `pass_facade_macros.rs`           | `log::info!` and `tracing::info!` joins receive no diagnostic until roadmap item 2.4.2 |
+| `pass_generated_format_string.rs` | `concat!()` and `include_str!()` format strings receive no diagnostic                  |
+
+Each has a paired control that inverts its gate, per §UI passes.
 
 ### Must pass unchanged
 
@@ -740,7 +1060,7 @@ fn header(status_line: &str, length: usize) -> String {
 }
 ```
 
-### Must fail with a machine-applicable rewrite
+### Must fail with a rewrite
 
 ```rust
 fn header(status_line: &str, length: usize) -> String {
@@ -770,20 +1090,31 @@ fn header(status_line: &str, length: usize) -> String {
 
 ## Rollout
 
-1. Land the lint with its classifier, UI matrix, localization, suite
-   registration, and user documentation.
+1. Land the lint with its classifier, fixture matrix, localization, suite
+   registration, configuration table, and user documentation, with
+   `applicability` defaulting to `"manual"`.
 2. Dogfood it against Whitaker. The PR #296 fixture must remain clean because
    of its capture.
-3. Run it across df12 Rust repositories and apply machine fixes.
-4. Replace CodeRabbit's unconditional prose guidance with the context-sensitive
+3. Run it across df12 Rust repositories in reporting mode and read the
+   findings. This is the evidence-gathering step, not the fixing step.
+4. Build a dry-run harness before any estate-wide fix: per repository, record
+   the current commit, apply the fixes, build, run that repository's tests, and
+   **revert automatically** if either fails. Report a per-repository verdict.
+   Without this, an estate-wide fix run is dozens of unreviewed automated
+   commits and the first bad one is found by whoever's continuous integration
+   goes red first.
+5. Only then flip `applicability` to `"machine"`. This is roadmap item 2.4.3
+   and it is a separate decision with its own evidence, not a formality.
+6. Replace CodeRabbit's unconditional prose guidance with the context-sensitive
    rule:
 
    > Use `concat!()` for interior joins in cooked string expressions unless
    > direct-literal status is required, including implicit format capture or a
    > literal-only macro contract.
 
-5. Promote no later than the next normal Whitaker release. The rule is
-   deterministic and should not need an experimental incubation period.
+7. Promote the lint itself no later than the next normal Whitaker release. The
+   rule is deterministic and should not need an experimental incubation period;
+   it is the *fixer*, not the diagnostic, that earns its promotion by evidence.
 
 ## Alternatives considered
 
@@ -800,8 +1131,35 @@ rustc already performs.
 
 ### Late HIR lint
 
-Rejected. HIR no longer retains the exact source spelling that distinguishes an
-escaped newline from an equivalent evaluated string.
+Rejected, but not for the reason first given. The original text said HIR "no
+longer retains the exact source spelling"; in fact the HIR literal's span still
+points at the source, so the spelling is recoverable with a snippet lookup at
+any phase. The real disqualifier is that format arguments are lowered away, so
+a late pass cannot see `FormatArgs` and therefore cannot tell a captured
+argument from an explicitly named one.
+
+### Prove the macro's identity rather than the literal's position
+
+Rejected, after being the original design. Resolving a macro's defining crate
+and canonical path requires a `TyCtxt`, which a post-expansion early pass does
+not have. Three ways round that were considered:
+
+- Reach the `TyCtxt` through thread-local compiler state. It is present,
+  because early lints run inside a query, but it is a hidden global that
+  defeats the boundary the crate split exists to enforce.
+- Split into an early collector that records format arguments and a late
+  emitter that resolves identity, mirroring Clippy's format-argument storage.
+  Clippy needs that structure because its format lints reason about *types*;
+  this lint reasons about *bytes*. Adopting the structure without the
+  motivation buys one thing — a crate name — and costs a second literal-handling
+  path, shared mutable storage across two pass objects, two more compiler
+  dependencies, and a two-pass suite registration.
+- Restrict the allowlist to what `ExpnData` alone can distinguish, which cannot
+  satisfy the identity clause as written.
+
+All three answer "which macro is this?". §Macro position asks "is anything
+wrapping this literal?" instead, which is answerable locally, and which the
+identity check would not have answered — a `$l:literal` capture defeats it too.
 
 ### Always add explicit captured arguments and use `concat!()`
 
@@ -847,3 +1205,38 @@ A technically accurate response to the open review thread is:
 - Rust's own UI test verifies that `format!(concat!("{a}"))` fails with the
   diagnostic that `format_args!` cannot capture variables when its format
   string is expanded from a macro.
+
+Added in the 2026-08-21 revision, verified against the pinned
+`nightly-2026-05-28` compiler sources:
+
+- `FormatArgs::is_source_literal` is set from `rustc_parse_format`'s own
+  snippet-versus-input comparison, which is `false` when a procedural macro has
+  respanned the literal (rust-lang/rust#114865).
+- `FormatArgs::span` is assigned the fully-expanded format-string expression's
+  span, and `Span::from_inner` maps byte offsets within a token to source
+  spans.
+- The `println!` family appends its newline to the cooked symbol only, leaving
+  `uncooked_symbol` — the raw source body — untouched.
+- `rustc_expand`'s `maybe_use_metavar_location` preserves the call-site syntax
+  context for tokens substituted from a matcher, while `Marker::mark_span`
+  marks the transcribed structure around them. This is the basis of
+  §Wrapper depth.
+- `rustc-literal-escaper` and `rustc_lexer` both implement the continuation
+  whitespace rule as a single skip over `{space, tab, line feed, carriage
+  return}`, excluding formfeed (rust-lang/rust#136600). This is the basis of
+  §The whitespace rule.
+- `SourceFile` construction normalizes newlines, so literal symbols and
+  recovered snippets never contain carriage returns.
+- `LintStore::register_early_pass` takes a factory, and the only site that
+  instantiates it runs once per crate, inside the early-lint query — which also
+  means a `TyCtxt` exists on the thread even though `EarlyContext` does not
+  expose one.
+- `compiletest_rs`, which `dylint_testing` layers on, honours a `run-rustfix`
+  header: it applies the suggestion, diffs against a `.fixed` file, recompiles
+  the result, and fails on residual diagnostics. Note that `dylint_testing`
+  constructs its configuration with blessing disabled and exposes no override,
+  so expectation files are updated by copying the actual-output path the
+  report prints, not by an environment variable.
+- `log` 0.4.33's facade macros accept a `logger:` control absent from the
+  original allowlist, and separate key-value fields from the message with a
+  semicolon.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -78,11 +78,6 @@
   suppressions narrowly scoped to the item they justify. See
   [ADR 002](adr-002-dylint-expect-attribute-macro.md) §Migration plan. Requires
   1.3.3.
-- [ ] 2.2.10. Implement `string_continuation_style` as a post-expansion early
-  lint, including source-preserving `concat!()` suggestions, format-capture and
-  literal-context exemptions, localized diagnostics, and suite integration. See
-  [RFC 0002](rfcs/0002-string-continuation-style.md).
-  Requires 2.1.1 and 2.3.4.
 
 ### 2.3. Localization enablement
 
@@ -95,6 +90,26 @@
 - [x] 2.3.4. Allow locale selection via `DYLINT_LOCALE` and `dylint.toml`, and
   add UI smoke tests that run under at least one non-English locale. Requires
   2.3.3.
+
+### 2.4. String continuation style
+
+- [ ] 2.4.1. Implement `string_continuation_style` as a post-expansion early
+  lint covering plain cooked string expressions and source-authored format
+  strings from compiler built-in macros, including source-preserving
+  `concat!()` suggestions, format-capture and literal-context exemptions,
+  localized diagnostics, and suite integration. Suggestions ship at manual
+  applicability. See [RFC 0002](rfcs/0002-string-continuation-style.md).
+  Requires 2.1.1 and 2.3.4.
+- [ ] 2.4.2. Extend `string_continuation_style` to the `log` and `tracing`
+  facade macros, proving macro identity, format-string position, and complete
+  argument grammar before suggesting a rewrite, with acceptance fixtures for
+  every supported variant and for same-named local and external lookalikes.
+  See [RFC 0002](rfcs/0002-string-continuation-style.md) §Detection
+  architecture. Requires 2.4.1.
+- [ ] 2.4.3. Promote the `string_continuation_style` suggestion from manual to
+  machine applicability once field evidence shows the rewrite is safe to apply
+  unattended, including an apply-and-recompile harness across the estate and a
+  documented rollback path. Requires 2.4.1.
 
 ## 3. Aggregated packaging, installer, and unified CLI
 


### PR DESCRIPTION
## Summary

This pull request adds the execution plan for roadmap item 2.4.1, implementing `string_continuation_style` as a post-expansion early lint per [RFC 0002](https://github.com/leynos/whitaker/blob/main/docs/rfcs/0002-string-continuation-style.md). No implementation is included; the plan must be approved first.

- [docs/execplans/2-4-1-string-continuation-style-post-expansion-early-lint.md](https://github.com/leynos/whitaker/blob/2-4-1-string-continuation-style-post-expansion-early-lint.md/docs/execplans/2-4-1-string-continuation-style-post-expansion-early-lint.md)

The plan was drafted against the pinned `nightly-2026-05-28` compiler sources, then stress-tested by a six-lens design-review panel covering structure, alternatives, scaling, contracts, failure modes, and long-term viability. Sixteen findings changed the design.

## Roadmap restructure

The feature has moved out of §2.2 Core lint implementations, where it was task 2.2.10, into its own step §2.4 String continuation style:

- **2.4.1** — the base lint: plain cooked string expressions and source-authored format strings from compiler built-in macros, shipping at manual applicability. This plan.
- **2.4.2** — the `log` and `tracing` facade allowlist, to be designed against a shipped baseline.
- **2.4.3** — promotion to machine applicability, gated on field evidence from an apply-and-recompile pass over the estate.

The roadmap edit was applied directly rather than through `mapsplice`: no renumbering was needed (2.2.10 was the last task in its step, and 2.4 is new), and `mapsplice` would have reindented 588 unrelated continuation lines for a 3-line change — the churn its own guidance says to stop on.

## Two soundness defects found in RFC 0002

Both would have shipped. Both need RFC amendments, not annotations.

**Root syntax context does not prove what the RFC says it proves.** A literal captured by a `$l:literal` macro matcher reaches an early pass with `span.ctxt().is_root() == true`, because `maybe_use_metavar_location` preserves the call-site context. Every gate in RFC 0002 §Ordinary string expressions passes, and the lint would offer a machine-applicable rewrite that does not compile — the exact failure the design forbids. The plan proves the literal's *position* with a wrapper-depth counter over enclosing expansion-derived nodes instead.

**The continuation-whitespace rule is wrong.** RFC 0002 specifies "spaces and tabs, plus complete LF or CRLF sequences", and treats a lone carriage return as unrecoverable. Both `rustc-literal-escaper` and `rustc_lexer` skip every byte in `{space, tab, LF, CR}`, in any order, until the first byte outside that set. Verifying the scanner against the RFC as written would have verified it against the wrong language rule.

## Key design decisions

**Prove the position, not the macro identity.** `EarlyContext` carries no `TyCtxt`, so the RFC's requirement to match a "resolved definition identifier, defining crate, and canonical definition path" is not satisfiable from a pure early pass. The plan sidesteps the question: the lint does not need to know *which* macro produced a literal, only whether anything stands between it and the compiler. That removes the two-pass architecture, the `rustc_middle` dependency, the thread-local reach-through, and the allowlist table — and makes `log` and `tracing` silent by construction rather than by policy, which is what the 2.4.2 split wants.

**Split the pure domain into a plain library crate.** Kani has never run inside a `cdylib` lint crate in this repository; `whitaker_clones_core` proves it works in a plain one. The same split makes doctests run, lets Verus bridge to production source, and puts the 400-line ceiling under an actual gate — `make lint-whitaker` cannot reach `cdylib` lint crates today, so that constraint was asserted rather than enforced.

**Adopt `// run-rustfix` fixtures.** `dylint_testing` layers on `compiletest_rs`, not `trybuild`, and `compiletest_rs` honours a `run-rustfix` header: it applies the suggestion, diffs it against a checked-in `.fixed` file, recompiles the result, and fails on residual diagnostics. Apply-correctness and fixed-point idempotence come free, and a `const` assertion inside the `.fixed` file makes rustc itself the value-preservation oracle. This withdrew a proposed new dependency.

**Check the value at run time before emitting.** Before attaching any applicability above `MaybeIncorrect`, the lint unescapes the original and the replacement and compares the bytes. That converts an entire class of span-arithmetic bug from silent source corruption into a silent no-op.

**Ship a configuration table, defaulting to manual applicability.** RFC 0002 declines configuration entirely. For a lint that writes to source files that is the wrong instinct for release one, so the first release prints the full replacement but does not write it unattended. `excluded_crates` and `excluded_paths` mirror `no_std_fs_operations`, and generated files outside the workspace root are skipped unconditionally.

**Verify the adapter, not just the domain.** The first draft verified the pure half thoroughly and the byte offsets not at all — and the byte offsets are the whole risk. The plan now names three adapter obligations for span mapping, depth accounting, and the emission gate.

## Validation

`make check-fmt`, `make typecheck`, `make lint`, `make markdownlint`, and `make nixie` all pass. This is a documentation-only change.

## References

- [Lody session](https://lody.ai/leynos/sessions/79835686-da6f-44b3-8bc2-5c7544bdeec4)
- [RFC 0002: `string_continuation_style`](https://github.com/leynos/whitaker/blob/main/docs/rfcs/0002-string-continuation-style.md)
- Roadmap §2.4 in [docs/roadmap.md](https://github.com/leynos/whitaker/blob/main/docs/roadmap.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Establish and document the approved execution plan for a conservative string-continuation lint, correcting RFC assumptions and separating its staged roadmap work.

Bug Fixes:
- Correct the RFC’s macro-expansion safety rule and continuation-whitespace specification based on the pinned compiler sources.
- Clarify the early-lint design so implicit format captures and generated or macro-wrapped literals are handled conservatively.

Enhancements:
- Add a detailed execution plan for implementing string_continuation_style as a post-expansion early lint, including pure-domain separation, adapter validation, configuration, diagnostics, and verification strategy.
- Restructure the roadmap into a dedicated string-continuation-style workstream covering the base lint, facade support, and later machine-applicability promotion.

Documentation:
- Revise RFC 0002 with the corrected design, staging model, configuration policy, compiler findings, and expanded validation guidance.